### PR TITLE
Fix manualChunks for Vite 8 (Rolldown)

### DIFF
--- a/node/api/vite.config.js
+++ b/node/api/vite.config.js
@@ -71,10 +71,10 @@ export default defineConfig({
         rollupOptions: {
             input: 'public/admin/index.html',
             output: {
-                manualChunks: {
-                    vue: ['vue'],
-                    mermaid: ['mermaid'],
-                    markdown: ['marked', 'dompurify']
+                manualChunks(id) {
+                    if (id.includes('node_modules/vue/')) return 'vue';
+                    if (id.includes('node_modules/mermaid/')) return 'mermaid';
+                    if (id.includes('node_modules/marked/') || id.includes('node_modules/dompurify/')) return 'markdown';
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Vite 8 uses Rolldown instead of Rollup, which requires `manualChunks` as a function, not an object
- Deploy script fails at the admin dashboard build step due to this incompatibility
- Converts object-style `manualChunks` to equivalent function form

## Test plan
- [ ] Deploy to VPS and confirm admin dashboard builds successfully
- [ ] Verify admin dashboard loads and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)