### PR TITLE
Fix Go module path from bill1st to jeffdafoe

### DIFF
--- a/go/client/cmd/memory-sync/main.go
+++ b/go/client/cmd/memory-sync/main.go
@@ -21,9 +21,9 @@ import (
     "path/filepath"
     "syscall"
 
-    "github.com/bill1st/llm-memory-api/go/client/internal/api"
-    "github.com/bill1st/llm-memory-api/go/client/internal/config"
-    "github.com/bill1st/llm-memory-api/go/client/internal/memsync"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/api"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/config"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/memsync"
 )
 
 func main() {

--- a/go/client/go.mod
+++ b/go/client/go.mod
@@ -1,3 +1,3 @@
-module github.com/bill1st/llm-memory-api/go/client
+module github.com/jeffdafoe/llm-memory-api/go/client
 
 go 1.22

--- a/go/client/internal/api/client.go
+++ b/go/client/internal/api/client.go
@@ -13,7 +13,7 @@ import (
     "net/http"
     "time"
 
-    "github.com/bill1st/llm-memory-api/go/client/internal/config"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/config"
 )
 
 // HTTPError represents a non-2xx response from the API.

--- a/go/client/internal/memsync/conversations.go
+++ b/go/client/internal/memsync/conversations.go
@@ -12,7 +12,7 @@ import (
     "strings"
     "time"
 
-    "github.com/bill1st/llm-memory-api/go/client/internal/api"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/api"
 )
 
 var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)

--- a/go/client/internal/memsync/memory.go
+++ b/go/client/internal/memsync/memory.go
@@ -11,7 +11,7 @@ import (
     "strings"
     "time"
 
-    "github.com/bill1st/llm-memory-api/go/client/internal/api"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/api"
 )
 
 // MemorySync runs Phase 1: bidirectional sync of memory/*.md files.

--- a/go/client/internal/memsync/notes.go
+++ b/go/client/internal/memsync/notes.go
@@ -8,7 +8,7 @@ import (
     "strings"
     "time"
 
-    "github.com/bill1st/llm-memory-api/go/client/internal/api"
+    "github.com/jeffdafoe/llm-memory-api/go/client/internal/api"
 )
 
 // NoteSync runs Phase 3: sync configured note slug/prefix mappings to


### PR DESCRIPTION
## Summary
- Module path in `go.mod` and all internal imports referenced `github.com/bill1st/llm-memory-api` instead of `github.com/jeffdafoe/llm-memory-api`
- Updated `go.mod` and 5 source files

## Test plan
- [ ] CI Go vet + build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)