### PR TITLE
Fix GoReleaser config for monorepo layout

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ project_name: llm-memory-client
 
 before:
   hooks:
-    - go vet ./...
+    - cd go/client && go vet ./...
 
 builds:
   - id: memory-sync
@@ -23,12 +23,14 @@ builds:
 
 archives:
   - id: memory-sync
-    builds:
+    ids:
       - memory-sync
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: "memory-sync_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary
- `before.hooks` ran `go vet ./...` from repo root, but `go.mod` lives in `go/client/` — fixed with `cd go/client &&` prefix
- Updated deprecated `archives` fields to GoReleaser v2 syntax (`builds` → `ids`, `format` → `formats`)
- Deleted failed `v0.1.0` tag — will re-tag after merge

## Test plan
- [ ] Re-tag v0.1.0 after merge and verify Release workflow produces all 6 binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)