### PR TITLE
Fix GoReleaser before hook — use dir field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ project_name: llm-memory-client
 
 before:
   hooks:
-    - cd go/client && go vet ./...
+    - dir: go/client
+      cmd: go vet ./...
 
 builds:
   - id: memory-sync


### PR DESCRIPTION
## Summary
- GoReleaser hooks execute directly, not through a shell — `cd` isn't an executable
- Use GoReleaser's `dir` field on the hook to set the working directory to `go/client`

## Test plan
- [ ] Re-tag v0.1.0 after merge, verify Release workflow completes and produces binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)