### PR TITLE
Remove GoReleaser before hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,11 +2,6 @@ version: 2
 
 project_name: llm-memory-client
 
-before:
-  hooks:
-    - dir: go/client
-      cmd: go vet ./...
-
 builds:
   - id: memory-sync
     main: ./cmd/memory-sync/


### PR DESCRIPTION
## Summary
- GoReleaser v2.15 can't unmarshal the `dir`/`cmd` map syntax on global before hooks
- `go vet` already runs in the CI workflow, so the hook is redundant — just remove it

## Test plan
- [ ] Re-tag v0.1.0 after merge, verify Release workflow produces all 6 binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)