### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and auto-merge patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved (dependabot ${{ steps.metadata.outputs.update-type }})"
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary
- Auto-approves and auto-merges (squash) Dependabot PRs for patch/minor version bumps after CI passes
- Major version bumps are left open for manual review
- Uses `dependabot/fetch-metadata` to classify update type

## Test plan
- [ ] Verify workflow triggers on next Dependabot PR
- [ ] Confirm major bumps are not auto-approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)