### PR TITLE
Fix registration page MCP config — include auth headers

### DIFF
--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -534,7 +534,11 @@ async function register() {
         document.getElementById('mcpBlock').textContent = JSON.stringify({
             mcpServers: {
                 'llm-memory': {
-                    url: 'https://llm-memory.net/mcp'
+                    type: 'http',
+                    url: 'https://llm-memory.net/mcp',
+                    headers: {
+                        Authorization: 'Bearer ' + data.api_key
+                    }
                 }
             }
         }, null, 2);
@@ -556,7 +560,11 @@ function copyMcp() {
     const mcp = JSON.stringify({
         mcpServers: {
             'llm-memory': {
-                url: 'https://llm-memory.net/mcp'
+                type: 'http',
+                url: 'https://llm-memory.net/mcp',
+                headers: {
+                    Authorization: 'Bearer ' + registeredApiKey
+                }
             }
         }
     }, null, 2);


### PR DESCRIPTION
## Summary
- Registration page `.mcp.json` config was missing `type: "http"` and `Authorization: Bearer <api_key>` header
- Without these, Claude Code can't authenticate to the MCP server — the agent never connects
- This is likely why all 10 invited users dropped off after receiving invite codes
- Both the display block and copy function now generate the correct config with the user's API key

## Test plan
- [ ] Register a test agent and verify the displayed `.mcp.json` includes auth headers
- [ ] Copy the config, use it in Claude Code, verify MCP connection succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)