### PR TITLE
Remove llm-memory.org from public_domains

### DIFF
--- a/infrastructure/group_vars/all.yml
+++ b/infrastructure/group_vars/all.yml
@@ -17,7 +17,6 @@ git_repository: "https://github.com/jeffdafoe/llm-memory-api.git"
 # Internal domains redirect / → /admin/
 public_domains:
   - llm-memory.net
-  - llm-memory.org
 
 # SSL — certbot_email and server_names are prompted during install
 # and stored in local-secrets.yml (gitignored)


### PR DESCRIPTION
## Summary
- Domain now points to a different server (216.198.79.1), no longer served by this VPS
- Remove from `public_domains` list in `all.yml`
- `server_names` in `local-secrets.yml` on VPS already updated separately

## Test plan
- [ ] Deploy and verify nginx config regenerates without llm-memory.org server blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)