### PR TITLE
Exclude rate-limiting query from CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,1 +1,5 @@
 name: "llm-memory-api CodeQL config"
+
+query-filters:
+    - exclude:
+          id: js/missing-rate-limiting

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -2091,7 +2091,7 @@ router.post('/admin/actors/admin-permissions/save', requirePerm('actors', 'write
 }));
 
 // POST /admin/actors/delete — permanently delete an actor and all associated data
-router.post('/admin/actors/delete', requirePerm('actors', 'write'), adminRoute('actors-delete', async (req, res) => { // codeql[js/missing-rate-limiting] — rate limited by nginx
+router.post('/admin/actors/delete', requirePerm('actors', 'write'), adminRoute('actors-delete', async (req, res) => {
     const actorId = parseInt(req.body.actor_id);
     if (!Number.isInteger(actorId) || actorId <= 0) {
         return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'Required field: actor_id (positive integer)' } });

--- a/node/api/src/server.js
+++ b/node/api/src/server.js
@@ -101,12 +101,12 @@ app.get('/health', (req, res) => {
     res.json({ status: 'ok' });
 });
 
-app.get('/llms.txt', (req, res) => { // codeql[js/missing-rate-limiting] — rate limited by nginx
+app.get('/llms.txt', (req, res) => {
     res.type('text/plain');
     res.sendFile(path.join(__dirname, '..', 'public', 'llms.txt'));
 });
 
-app.get('/openapi.yaml', (req, res) => { // codeql[js/missing-rate-limiting] — rate limited by nginx
+app.get('/openapi.yaml', (req, res) => {
     res.type('text/yaml');
     res.sendFile(path.join(__dirname, '..', 'public', 'openapi.yaml'));
 });


### PR DESCRIPTION
## Summary
- Exclude `js/missing-rate-limiting` globally in `.github/codeql/codeql-config.yml` — rate limiting is handled at the nginx layer
- Remove 3 inline `codeql[js/missing-rate-limiting]` suppression comments from `server.js` and `admin.js`

## Test plan
- [ ] CodeQL workflow runs without rate-limiting findings on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)