### PR TITLE
Remove stale /admin/dream/run endpoint

### DIFF
--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -2701,17 +2701,4 @@ router.post('/admin/virtual-agent-access/revoke', requirePerm('actors', 'write')
     res.json({ revoked: true });
 }));
 
-// ---- Dream Processing ----
-
-// POST /admin/dream/run — trigger nightly dream consolidation job
-// Designed to be called by cron. Requires admin auth with agents:write permission.
-router.post('/admin/dream/run', requirePerm('agents', 'write'), adminRoute('dream-run', async (req, res) => {
-    const { runDream } = require('../services/dream');
-
-    logAdmin('dream_run', { user_id: req.authenticatedUser.id });
-
-    const result = await runDream();
-    res.json(result);
-}));
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- Remove `/admin/dream/run` POST endpoint from admin routes
- Dream processing now runs internally via node-cron scheduler (`0 4 * * *`), so the manual trigger is dead code

## Test plan
- [ ] Verify admin dashboard still loads
- [ ] Confirm dream scheduler continues running on its cron schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)