### PR TITLE
Configurable conversation chunking with smaller windows

### DIFF
--- a/migrations/MEM-094-conversation-chunk-config_down.sql
+++ b/migrations/MEM-094-conversation-chunk-config_down.sql
@@ -1,0 +1,3 @@
+-- MEM-094 rollback: Remove conversation chunk config keys.
+
+DELETE FROM config WHERE key IN ('conversation_chunk_window', 'conversation_chunk_overlap', 'conversation_chunk_max_chars');

--- a/migrations/MEM-094-conversation-chunk-config_up.sql
+++ b/migrations/MEM-094-conversation-chunk-config_up.sql
@@ -1,0 +1,8 @@
+-- MEM-094: Configurable conversation chunking parameters.
+-- Smaller windows produce more focused embeddings for better search relevance.
+
+INSERT INTO config (key, value, description) VALUES
+    ('conversation_chunk_window', '5', 'Max messages per conversation chunk for vector search. Smaller = more focused embeddings.'),
+    ('conversation_chunk_overlap', '2', 'Messages carried over between conversation chunks for context continuity.'),
+    ('conversation_chunk_max_chars', '2000', 'Max characters per conversation chunk. Window closes early if exceeded.')
+ON CONFLICT (key) DO NOTHING;

--- a/node/api/src/services/chunker.js
+++ b/node/api/src/services/chunker.js
@@ -39,10 +39,12 @@ function chunkByHeading(content) {
 // Conversation format: lines like "[HH:MM speaker] text"
 // Splits into windows of `windowSize` messages with `overlap` messages carried
 // over between chunks for context continuity. The header block (everything
-// before the first message line) is prepended to each chunk.
-function chunkConversation(content, windowSize, overlap) {
-    windowSize = windowSize || 20;
-    overlap = overlap || 4;
+// before the first message line) is prepended to each chunk. If `maxChars`
+// is set, the window closes early when accumulated text exceeds that limit.
+function chunkConversation(content, windowSize, overlap, maxChars) {
+    windowSize = windowSize || 5;
+    overlap = overlap || 2;
+    maxChars = maxChars || 0; // 0 = no char limit
 
     const lines = content.split('\n');
     const messagePattern = /^\[\d{2}:\d{2}\s/;
@@ -91,7 +93,19 @@ function chunkConversation(content, windowSize, overlap) {
     let start = 0;
 
     while (start < messages.length) {
-        const end = Math.min(start + windowSize, messages.length);
+        // Build window: take up to windowSize messages, but stop early if
+        // accumulated text exceeds maxChars (produces more focused embeddings).
+        let end = Math.min(start + windowSize, messages.length);
+        if (maxChars > 0) {
+            let charCount = 0;
+            for (let i = start; i < end; i++) {
+                charCount += messages[i].length;
+                if (charCount > maxChars && i > start) {
+                    end = i;
+                    break;
+                }
+            }
+        }
         const windowMessages = messages.slice(start, end);
 
         // Build chunk text with header for context
@@ -115,8 +129,11 @@ function chunkConversation(content, windowSize, overlap) {
             });
         }
 
-        // Advance by windowSize minus overlap, but always advance at least 1
-        const step = Math.max(1, windowSize - overlap);
+        // Advance by actual window size minus overlap, but always advance at least 1.
+        // Uses (end - start) instead of windowSize because the char limit may have
+        // closed the window early.
+        const actualWindow = end - start;
+        const step = Math.max(1, actualWindow - overlap);
         start += step;
     }
 

--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -62,9 +62,19 @@ async function ingestContent(namespace, sourceFile, content) {
         return { chunks_created: 0 };
     }
 
-    // Use conversation-aware chunking for conversation logs, heading-based for everything else
+    // Use conversation-aware chunking for conversation logs, heading-based for everything else.
+    // Conversation chunk params are configurable — smaller windows produce more focused embeddings.
     const isConversation = sourceFile.startsWith('conversations/');
-    const chunks = isConversation ? chunkConversation(content) : chunkByHeading(content);
+    let chunks;
+    if (isConversation) {
+        const config = require('./config');
+        const windowSize = parseInt(config.get('conversation_chunk_window')) || 5;
+        const overlap = parseInt(config.get('conversation_chunk_overlap')) || 2;
+        const maxChars = parseInt(config.get('conversation_chunk_max_chars')) || 0;
+        chunks = chunkConversation(content, windowSize, overlap, maxChars);
+    } else {
+        chunks = chunkByHeading(content);
+    }
 
     if (chunks.length === 0) {
         throw Object.assign(new Error('No chunks extracted from content'), { statusCode: 400 });


### PR DESCRIPTION
## Summary
- Reduce conversation chunk window from 20 messages to 5 (configurable via `conversation_chunk_window`)
- Add character limit per chunk — window closes early at 2000 chars (configurable via `conversation_chunk_max_chars`)
- Overlap reduced from 4 to 2 (configurable via `conversation_chunk_overlap`)
- MEM-094 migration adds the three config keys

Old chunking produced 5-7K char chunks that embedded poorly — too many topics diluted into one vector. New defaults produce ~1-2K char chunks focused on a single exchange.

**Existing conversations need a reindex** after deploy to benefit from the new chunking parameters.

## Test plan
- [ ] Deploy and run MEM-094 migration
- [ ] Reindex conversations from admin UI
- [ ] Search for conversation-specific topics and verify they surface

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)