### PR TITLE
Add default values to config descriptions

### DIFF
--- a/migrations/MEM-094-conversation-chunk-config_up.sql
+++ b/migrations/MEM-094-conversation-chunk-config_up.sql
@@ -2,7 +2,7 @@
 -- Smaller windows produce more focused embeddings for better search relevance.
 
 INSERT INTO config (key, value, description) VALUES
-    ('conversation_chunk_window', '5', 'Max messages per conversation chunk for vector search. Smaller = more focused embeddings.'),
-    ('conversation_chunk_overlap', '2', 'Messages carried over between conversation chunks for context continuity.'),
-    ('conversation_chunk_max_chars', '2000', 'Max characters per conversation chunk. Window closes early if exceeded.')
+    ('conversation_chunk_window', '5', 'Max messages per conversation chunk for vector search (default: 5). Smaller = more focused embeddings.'),
+    ('conversation_chunk_overlap', '2', 'Messages carried over between conversation chunks for context continuity (default: 2).'),
+    ('conversation_chunk_max_chars', '2000', 'Max characters per conversation chunk (default: 2000). Window closes early if exceeded.')
 ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- Add default values in parentheses to conversation chunk config key descriptions
- Matches the pattern used by `default_storage_quota` and other config keys
- DB already updated directly; this syncs the migration file

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)