### PR TITLE
Show default storage quota value in admin dashboard

### DIFF
--- a/migrations/MEM-095-agent-status-storage-quota_down.sql
+++ b/migrations/MEM-095-agent-status-storage-quota_down.sql
@@ -1,0 +1,33 @@
+-- MEM-095 rollback: Remove storage_quota from agent_status view.
+
+CREATE OR REPLACE VIEW agent_status AS
+SELECT ac.id AS actor_id,
+    ac.name AS agent,
+    CASE
+        WHEN agc.virtual = TRUE AND ac.status IN ('available', 'degraded', 'error') THEN ac.status
+        WHEN agc.virtual = TRUE THEN 'available'
+        WHEN ac.last_seen > (now() - INTERVAL '15 minutes') THEN 'online'
+        WHEN ac.last_seen IS NOT NULL THEN 'offline'
+        ELSE 'unknown'
+    END AS status,
+    ac.last_seen,
+    ac.passphrase_rotated_at,
+    ac.created_at AS registered_at,
+    ac.expertise,
+    agc.provider,
+    agc.model,
+    agc.virtual,
+    agc.personality,
+    agc.cost_budget_daily,
+    agc.cost_budget_monthly,
+    CASE
+        WHEN ac.active_since IS NOT NULL AND ac.active_since > (now() - INTERVAL '30 minutes') THEN ac.active_since
+        ELSE NULL
+    END AS active_since,
+    agc.cache_prompts,
+    agc.learning_enabled,
+    agc.max_tokens,
+    agc.temperature,
+    agc.dream_mode
+FROM actors ac
+JOIN agent_configuration agc ON agc.actor_id = ac.id;

--- a/migrations/MEM-095-agent-status-storage-quota_up.sql
+++ b/migrations/MEM-095-agent-status-storage-quota_up.sql
@@ -1,0 +1,35 @@
+-- MEM-095: Add storage_quota to agent_status view so the admin dashboard
+-- can display per-agent quota alongside the global default.
+
+CREATE OR REPLACE VIEW agent_status AS
+SELECT ac.id AS actor_id,
+    ac.name AS agent,
+    CASE
+        WHEN agc.virtual = TRUE AND ac.status IN ('available', 'degraded', 'error') THEN ac.status
+        WHEN agc.virtual = TRUE THEN 'available'
+        WHEN ac.last_seen > (now() - INTERVAL '15 minutes') THEN 'online'
+        WHEN ac.last_seen IS NOT NULL THEN 'offline'
+        ELSE 'unknown'
+    END AS status,
+    ac.last_seen,
+    ac.passphrase_rotated_at,
+    ac.created_at AS registered_at,
+    ac.expertise,
+    agc.provider,
+    agc.model,
+    agc.virtual,
+    agc.personality,
+    agc.cost_budget_daily,
+    agc.cost_budget_monthly,
+    CASE
+        WHEN ac.active_since IS NOT NULL AND ac.active_since > (now() - INTERVAL '30 minutes') THEN ac.active_since
+        ELSE NULL
+    END AS active_since,
+    agc.cache_prompts,
+    agc.learning_enabled,
+    agc.max_tokens,
+    agc.temperature,
+    agc.dream_mode,
+    agc.storage_quota
+FROM actors ac
+JOIN agent_configuration agc ON agc.actor_id = ac.id;

--- a/node/api/public/admin/agents.js
+++ b/node/api/public/admin/agents.js
@@ -5,6 +5,7 @@ import { useSortable } from './core.js';
 function useAgents({ api, showToast, showConfirm, onEvent }) {
     const agents = ref([]);
     const selectedAgent = ref(null);
+    const defaultStorageQuota = ref(52428800); // updated from backend on load
 
     // Sortable table — default sort by agent name
     const agentSort = useSortable(agents, 'agent', 'asc');
@@ -242,6 +243,9 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         try {
             const data = await api('/admin/agents');
             agents.value = data.agents;
+            if (data.default_storage_quota) {
+                defaultStorageQuota.value = data.default_storage_quota;
+            }
             if (selectedAgent.value) {
                 const updated = data.agents.find(a => a.agent === selectedAgent.value.agent);
                 // Merge list data onto existing selectedAgent so detail-only fields (configuration, expertise, etc.) survive
@@ -634,6 +638,7 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         startEditProfile, onProfileProviderChange, saveProfile,
         costBudgetEditing, costBudgetDailyValue, costBudgetMonthlyValue, startEditCostBudget, saveCostBudget,
         agentUsageHistory, agentUsageLoading, loadUsageHistory,
+        defaultStorageQuota,
         agentSettingsEditing, agentSettingsLearningEnabled, agentSettingsStorageQuota, agentSettingsConfig, agentSettingsSaving,
         startEditSettings, saveSettings,
         startEditInstructions, cancelEditInstructions, saveInstructions,

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -172,7 +172,7 @@
                 </div>
                 <div v-if="!agentSettingsEditing" style="font-size: 13px; line-height: 1.8;">
                     <span>Learning: <strong>{{ selectedAgent.learning_enabled !== false ? 'on' : 'off' }}</strong></span>
-                    <br><span>Storage quota: <strong>{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default' }}</strong></span>
+                    <br><span>Storage quota: <strong>{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</strong></span>
                     <template v-for="(cap, key) in capabilitiesFor(selectedAgent.provider, selectedAgent.model)" :key="key">
                         <br><span>{{ cap.label }}: <strong>{{ formatConfigValue(key, parseAgentConfig(selectedAgent)[key], cap) }}</strong></span>
                     </template>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -373,7 +373,7 @@ router.post('/admin/agents', requirePerm('agents', 'read'), adminRoute('agents-l
     const visibleIds = await getVisibleActorIds(req.actorId);
     // Subqueries for visibility and VA access summaries shown in the agent list
     let sql = `SELECT s.agent, s.actor_id, s.status, s.last_seen, s.passphrase_rotated_at, s.registered_at, s.provider, s.model, s.virtual, s.personality, s.active_since,
-                s.cost_budget_daily, s.cost_budget_monthly, s.cache_prompts, s.learning_enabled, s.max_tokens, s.temperature, s.dream_mode, ac.configuration,
+                s.cost_budget_daily, s.cost_budget_monthly, s.cache_prompts, s.learning_enabled, s.max_tokens, s.temperature, s.dream_mode, s.storage_quota, ac.configuration,
                 COALESCE(vis.summary, 'self only') AS visibility_summary,
                 va.summary AS va_access_summary
          FROM agent_status s
@@ -430,7 +430,11 @@ router.post('/admin/agents', requirePerm('agents', 'read'), adminRoute('agents-l
         delete row.configuration;
     }
 
-    res.json({ agents: result.rows });
+    // Include global default storage quota so the frontend can display it
+    const config = require('../services/config');
+    const defaultStorageQuota = parseInt(config.get('default_storage_quota')) || 52428800;
+
+    res.json({ agents: result.rows, default_storage_quota: defaultStorageQuota });
 }));
 
 // POST /admin/agents/instructions/read — read an agent's startup instructions


### PR DESCRIPTION
## Summary
- MEM-095: Add `storage_quota` to `agent_status` view
- Include `default_storage_quota` from config table in `/admin/agents` response
- Frontend shows "default (50 MB)" instead of just "default"
- Matches the pattern used by provider-specific config defaults (temperature, max tokens, etc.)

## Test plan
- [ ] Agent config panel shows "Storage quota: default (50 MB)" for agents without a per-agent override
- [ ] Agents with a custom quota still show the specific value (e.g. "100 MB")

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)