### PR TITLE
Add delete button to agent detail dialog

### DIFF
--- a/node/api/public/admin/agents.js
+++ b/node/api/public/admin/agents.js
@@ -618,6 +618,33 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         });
     }
 
+    // ─── Delete Agent ───
+
+    const agentDeleting = ref(false);
+
+    async function deleteAgent() {
+        if (!selectedAgent.value) return;
+        const name = selectedAgent.value.agent;
+        const confirmed = await showConfirm('Permanently delete "' + name + '" and ALL associated data (notes, mail, chat, discussions)? This cannot be undone.');
+        if (!confirmed) return;
+        agentDeleting.value = true;
+        try {
+            const data = await api('/admin/actors/delete', { actor_id: selectedAgent.value.actor_id });
+            let msg = 'Deleted "' + name + '"';
+            if (data.deleted && data.deleted.virtual_agents && data.deleted.virtual_agents.length > 0) {
+                msg += ' and virtual agents: ' + data.deleted.virtual_agents.join(', ');
+            }
+            showToast(msg, 'success');
+            selectedAgent.value = null;
+            loadAgents();
+        } catch (err) {
+            console.error('Failed to delete agent:', err);
+            showToast('Failed: ' + err.message, 'error');
+        } finally {
+            agentDeleting.value = false;
+        }
+    }
+
     function closeDialogs() {
         selectedAgent.value = null;
     }
@@ -644,6 +671,7 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         startEditInstructions, cancelEditInstructions, saveInstructions,
         startEditExpertise, cancelEditExpertise, saveExpertise,
         resetAgentPassphrase,
+        agentDeleting, deleteAgent,
         // Templates
         welcomeTemplates, templateEditing, templateEditId,
         templateEditName, templateEditKind, templateEditDescription, templateEditContent, templateSaving,

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -4,6 +4,7 @@
         <header>
             <div></div>
             <div style="display:flex; gap:4px;">
+                <button v-if="canDo('actors', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteAgent" :disabled="agentDeleting" title="Delete Agent"><i class="icon-trash-2"></i></button>
                 <button v-if="canDo('actors', 'read')" class="btn btn-ghost btn-compact" @click="openActorConfig(selectedAgent.agent)" title="Permissions"><i class="icon-shield"></i></button>
                 <button v-if="!agentPassphraseConfirming && !agentNewPassphrase && canDo('agents', 'write')" class="btn btn-ghost btn-compact" @click="agentPassphraseConfirming = true" title="Reset Passphrase"><i class="icon-key"></i></button>
                 <button aria-label="Close" rel="prev" @click="selectedAgent = null"></button>


### PR DESCRIPTION
## Summary
- Add trash icon button to agent detail dialog header (same pattern as actor config dialog)
- Agents opened from Config > Actors were routed to the agent detail view which had no delete option
- Uses the existing `/admin/actors/delete` endpoint with confirmation dialog

## Test plan
- [ ] Click an agent in Config > Actors, verify trash icon appears in dialog header
- [ ] Click trash icon, confirm deletion, verify agent is removed

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)