### PR TITLE
Fix numeric config values sent as strings to provider APIs

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -375,10 +375,10 @@ function buildProviderConf(agent) {
         conf.cache_prompts = agent.cache_prompts || false;
     }
     if (conf.max_tokens === undefined && agent.max_tokens != null) {
-        conf.max_tokens = agent.max_tokens;
+        conf.max_tokens = Number(agent.max_tokens);
     }
     if (conf.temperature === undefined && agent.temperature != null) {
-        conf.temperature = agent.temperature;
+        conf.temperature = Number(agent.temperature);
     }
     return conf;
 }


### PR DESCRIPTION
## Summary
- PostgreSQL `numeric` columns are returned as strings by the `pg` driver
- `temperature` and `max_tokens` were passed through to provider APIs without conversion
- OpenRouter rejected with "expected number, received string"
- Fix: `Number()` coercion in `virtual-agent.js` where agent config is built

Affects all providers (Anthropic, OpenAI, Google, OpenRouter, Perplexity, xAI) — some may have been silently coercing, others (like OpenRouter) reject outright.

## Test plan
- [ ] memory-enrichment VA processes a note without temperature error
- [ ] Dream VAs can be invoked without errors

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)