### PR TITLE
Add relation auto-extraction to reindex

### DIFF
--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1176,11 +1176,15 @@ router.post('/admin/notes/reindex', requirePerm('notes', 'write'), adminRoute('n
                     // Enrichment module not available — skip silently
                 }
             }
+            const { autoExtractRelations } = require('../services/relations');
 
             for (const doc of docs.rows) {
                 try {
                     const result = await ingestContent(doc.namespace, doc.slug, doc.content);
                     reindexState.chunks_created += result.chunks_created;
+
+                    // Auto-extract slug references as relations
+                    autoExtractRelations(doc.namespace, doc.slug, doc.content).catch(() => {});
 
                     // Fire-and-forget enrichment for each note (skips conversations/dreams internally)
                     if (enrichModule) {


### PR DESCRIPTION
## Summary
- `autoExtractRelations` (slug reference detection) only ran on `saveNote`, not during reindex
- Reindex calls `ingestContent` for vectors and `enrichNote` for enrichment, but neither extracts slug references
- Note graph was empty after reindex because no relations were created
- Now runs `autoExtractRelations` for each document during reindex

## Test plan
- [ ] Run reindex, verify `note_relations` table has rows afterward
- [ ] Graph view shows connections between notes

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)