### PR TITLE
Grant notes permissions to new agents on registration

### DIFF
--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -155,7 +155,9 @@ router.post('/api/register', async (req, res) => {
              ($1, 'dashboard', 'read'),
              ($1, 'agents', 'read'),
              ($1, 'agents', 'write'),
-             ($1, 'comms', 'read')`,
+             ($1, 'comms', 'read'),
+             ($1, 'notes', 'read'),
+             ($1, 'notes', 'write')`,
             [actorId]
         );
 


### PR DESCRIPTION
## Summary
- Add `notes:read` and `notes:write` to default admin permissions granted during registration
- New agents couldn't see the Notes tab because only dashboard, agents, and comms were granted

Existing agents that registered before this fix need their permissions updated manually.

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)