### PR TITLE
Fix dream cron: expertise query and error logging

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -5,7 +5,7 @@
 
 const pool = require('../db');
 const config = require('./config');
-const { log } = require('./logger');
+const { log, logError } = require('./logger');
 const { saveNote, readNote } = require('./documents');
 const { invokeAgent } = require('./virtual-agent');
 
@@ -118,7 +118,7 @@ async function findDreamAgent(expertiseTag) {
         `SELECT ac.id, ac.name, ac.created_by, agc.provider, agc.model, agc.api_key
          FROM actors ac
          JOIN agent_configuration agc ON agc.actor_id = ac.id
-         WHERE $1 = ANY(ac.expertise)`,
+         WHERE ac.expertise::jsonb ? $1`,
         [expertiseTag]
     );
 
@@ -373,6 +373,7 @@ function startDreamScheduler() {
             logDream('cron-complete', { result });
         } catch (err) {
             logDream('cron-error', { error: err.message });
+            logError('dream', 'cron-error', { message: err.message, detail: err.stack });
         }
     });
 


### PR DESCRIPTION
## Summary
- Fix `ANY(ac.expertise)` crash — expertise is stored as JSON text, not a PG array. Use `jsonb ?` operator instead.
- Write dream cron errors to `error_log` table so they surface in the admin UI (was only logging to stdout).

## Context
Dream cron fired at 4 AM UTC on Apr 3 and crashed with `op ANY/ALL (array) requires array on right side`. The error only appeared in journalctl, not in the admin error log.

## Test plan
- [ ] Deploy and verify dream cron runs at next 4 AM UTC without the array error
- [ ] Verify errors from dream cron appear in admin UI error log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>