### PR TITLE
Onboarding, visibility, and UI fixes

### DIFF
--- a/migrations/MEM-096-welcome-note-template-kind_up.sql
+++ b/migrations/MEM-096-welcome-note-template-kind_up.sql
@@ -1,0 +1,6 @@
+-- MEM-096: Add 'welcome-note' to templates kind check constraint
+-- Allows templates that produce a getting-started note saved to the new agent's namespace
+
+ALTER TABLE templates DROP CONSTRAINT templates_kind_check;
+ALTER TABLE templates ADD CONSTRAINT templates_kind_check
+    CHECK (kind IN ('welcome', 'welcome-note'));

--- a/migrations/MEM-097-seed-welcome-note-template_up.sql
+++ b/migrations/MEM-097-seed-welcome-note-template_up.sql
@@ -17,9 +17,8 @@ Welcome, {agent}. This note lives in your namespace and is always available via 
 ## Session lifecycle
 
 **Start each session:**
-- `read_instructions` — reload your behavioral rules
+- `read_instructions` — reload your behavioral rules (if dream processing is enabled, your soul document is automatically included)
 - `activity_start` — show you''re online
-- Read `context/soul` if it exists — this is your living summary of who your user is and how you work together, built automatically by dream processing overnight. It may not exist yet if dreams haven''t run.
 - `mail_check` + `chat_receive` — check for messages
 - `discussion_pending` — check for discussion invitations
 - Read `notes/active-work` — pick up where you left off
@@ -54,7 +53,6 @@ Your conversation has a finite context window. When it fills up, earlier message
 
 - `notes/active-work` — current state, updated every session
 - `notes/user-profile` — who your user is and how they work
-- `context/soul` — built automatically by dream processing; a living summary of your relationship with your user, their patterns, and how you work together. Read it at session start, but don''t edit it directly — dreams maintain it.
 - `instructions/getting-started` — this note (you can update it as you learn)
 
 Once you''re comfortable, update your startup instructions (`save_instructions`) with behavioral rules specific to your user. Those instructions are the first thing you read each session — make them count.'

--- a/migrations/MEM-097-seed-welcome-note-template_up.sql
+++ b/migrations/MEM-097-seed-welcome-note-template_up.sql
@@ -19,6 +19,7 @@ Welcome, {agent}. This note lives in your namespace and is always available via 
 **Start each session:**
 - `read_instructions` — reload your behavioral rules
 - `activity_start` — show you''re online
+- Read `context/soul` if it exists — this is your living summary of who your user is and how you work together, built automatically by dream processing overnight. It may not exist yet if dreams haven''t run.
 - `mail_check` + `chat_receive` — check for messages
 - `discussion_pending` — check for discussion invitations
 - Read `notes/active-work` — pick up where you left off
@@ -53,6 +54,7 @@ Your conversation has a finite context window. When it fills up, earlier message
 
 - `notes/active-work` — current state, updated every session
 - `notes/user-profile` — who your user is and how they work
+- `context/soul` — built automatically by dream processing; a living summary of your relationship with your user, their patterns, and how you work together. Read it at session start, but don''t edit it directly — dreams maintain it.
 - `instructions/getting-started` — this note (you can update it as you learn)
 
 Once you''re comfortable, update your startup instructions (`save_instructions`) with behavioral rules specific to your user. Those instructions are the first thing you read each session — make them count.'

--- a/migrations/MEM-097-seed-welcome-note-template_up.sql
+++ b/migrations/MEM-097-seed-welcome-note-template_up.sql
@@ -1,0 +1,59 @@
+-- MEM-097: Seed a default welcome-note template
+-- Creates a getting-started note saved to new agents' namespaces
+
+INSERT INTO templates (name, kind, description, content) VALUES (
+    'default',
+    'welcome-note',
+    'Getting started guide saved as a note in the agent''s namespace',
+    '---
+title: Getting Started
+slug: instructions/getting-started
+---
+
+# Getting Started
+
+Welcome, {agent}. This note lives in your namespace and is always available via `read_note`. Use it as a reference until you''ve built your own habits.
+
+## Session lifecycle
+
+**Start each session:**
+- `read_instructions` — reload your behavioral rules
+- `activity_start` — show you''re online
+- `mail_check` + `chat_receive` — check for messages
+- `discussion_pending` — check for discussion invitations
+- Read `notes/active-work` — pick up where you left off
+
+**During sessions:**
+- When something noteworthy comes up — a decision, a preference, a useful fact — save it to your notes right away. Don''t wait until the end. Notes are your long-term memory; conversation context is temporary.
+- Use `save_note` to create or replace notes, `edit_note` for targeted changes within a note.
+- Use `search` (semantic) and `grep` (exact text) to find things across your notes.
+
+**End each session:**
+- Update `notes/active-work` with your current state — what you worked on, what''s pending, anything the next session needs to know
+- `activity_stop` — signal you''re done
+
+## What to save
+
+- **Who your user is** — name, communication style, preferences, boundaries
+- **What matters to them** — interests, goals, ongoing projects, important dates
+- **Decisions and context** — why something was done a certain way, not just what was done
+- **Project details** — architecture, key files, environment setup, patterns
+- **Anything you''d need if you lost all conversation history** — because you will
+
+## Surviving context loss
+
+Your conversation has a finite context window. When it fills up, earlier messages get compressed or lost.
+
+- **Save early, save often** — if you''ll need it later, it belongs in a note
+- **Keep `notes/active-work` current** — this is your resume point after compression or a new session
+- **Trust your notes over your memory** — after compression, your summarized recall may be wrong; the notes have ground truth
+- **Re-read your instructions** after compression — they''re your behavioral anchor
+
+## Key notes to maintain
+
+- `notes/active-work` — current state, updated every session
+- `notes/user-profile` — who your user is and how they work
+- `instructions/getting-started` — this note (you can update it as you learn)
+
+Once you''re comfortable, update your startup instructions (`save_instructions`) with behavioral rules specific to your user. Those instructions are the first thing you read each session — make them count.'
+);

--- a/node/api/public/admin/actors-config.js
+++ b/node/api/public/admin/actors-config.js
@@ -77,6 +77,7 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
     const newActorUiAccess = ref(false);
     const newActorPassword = ref('');
     const newActorTemplateId = ref(null);
+    const newActorNoteTemplateId = ref(null);
     const newActorCreating = ref(false);
     const newActorPassphrase = ref(null);
     const createSource = ref('config'); // 'config' (full) or 'agents' (streamlined virtual agent)
@@ -554,6 +555,7 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
         newActorUiAccess.value = false;
         newActorPassword.value = '';
         newActorTemplateId.value = null;
+        newActorNoteTemplateId.value = null;
         newActorCreating.value = false;
         newActorPassphrase.value = null;
     }
@@ -588,6 +590,9 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
             if (newActorTemplateId.value && !newActorVirtual.value) {
                 body.welcome_template_id = newActorTemplateId.value;
             }
+            if (newActorNoteTemplateId.value && !newActorVirtual.value) {
+                body.welcome_note_template_id = newActorNoteTemplateId.value;
+            }
             const data = await api('/admin/actors/create', body);
             newActorPassphrase.value = data.passphrase;
 
@@ -599,9 +604,12 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
                 });
             }
 
+            var extras = [];
+            if (data.welcome_mail_sent) extras.push('welcome mail');
+            if (data.welcome_note_saved) extras.push('getting-started note');
             const msg = data.virtual
                 ? 'Virtual agent "' + data.name + '" created'
-                : 'Actor "' + data.name + '" created' + (data.welcome_mail_sent ? ' with welcome mail' : '');
+                : 'Actor "' + data.name + '" created' + (extras.length ? ' with ' + extras.join(' + ') : '');
             showToast(msg, 'success');
             loadActorsConfig();
             await agentsModule.loadAgents();
@@ -758,7 +766,7 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
         // Create actor
         createSource, newActorName, newActorVirtual,
         newActorUiAccess, newActorPassword,
-        newActorTemplateId, newActorCreating, newActorPassphrase,
+        newActorTemplateId, newActorNoteTemplateId, newActorCreating, newActorPassphrase,
         nameCheckStatus, nameCheckMessage,
         startCreateActor, createActor,
         closeDialogs

--- a/node/api/public/admin/main.js
+++ b/node/api/public/admin/main.js
@@ -11,6 +11,8 @@ import { useChat } from './chat.js';
 import { useMail } from './mail.js';
 import { useNotes } from './notes.js';
 import { useGraph } from './graph.js';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { useApiLog } from './apilog.js';
 import { useErrorLog } from './errorlog.js';
 import { useConfig } from './config.js';
@@ -356,6 +358,42 @@ createApp({
             });
         }
 
+        // Graph note preview dialog — opens note content over the graph
+        const graphNoteDialog = ref(null);
+        const graphNoteData = ref(null);
+        const graphNoteRendered = ref('');
+        const graphNoteLoading = ref(false);
+
+        async function openNoteFromGraph(node) {
+            graphNoteLoading.value = true;
+            graphNoteData.value = { namespace: node.namespace, slug: node.slug, title: node.slug };
+            graphNoteRendered.value = '';
+            graphNoteDialog.value.showModal();
+            try {
+                var data = await core.api('/admin/notes/read', { namespace: node.namespace, slug: node.slug });
+                graphNoteData.value = { ...data.note, namespace: node.namespace };
+                graphNoteRendered.value = DOMPurify.sanitize(marked.parse(data.note.content || ''));
+            } catch (err) {
+                graphNoteRendered.value = '<p class="muted">Failed to load note: ' + DOMPurify.sanitize(err.message) + '</p>';
+            } finally {
+                graphNoteLoading.value = false;
+            }
+        }
+
+        function closeGraphNoteDialog(event) {
+            // Close on backdrop click (click on dialog element itself, not article)
+            if (event && event.target !== graphNoteDialog.value) return;
+            graphNoteDialog.value.close();
+        }
+
+        function goToNoteFromGraph() {
+            var note = graphNoteData.value;
+            graphNoteDialog.value.close();
+            graphModule.graphMode.value = false;
+            graphModule.destroyGraph();
+            nextTick(function() { notesModule.openNote(note.namespace, note.slug); });
+        }
+
         // Flatten everything into the template namespace
         const appState = {
             currentView,
@@ -395,11 +433,9 @@ createApp({
             onGraphFilterChange() {
                 graphModule.renderGraph('graph-container');
             },
-            openNoteFromGraph(node) {
-                graphModule.graphMode.value = false;
-                graphModule.destroyGraph();
-                nextTick(() => notesModule.openNote(node.namespace, node.slug));
-            },
+            // Graph note preview dialog
+            graphNoteDialog, graphNoteData, graphNoteRendered, graphNoteLoading,
+            openNoteFromGraph, closeGraphNoteDialog, goToNoteFromGraph,
             // API Log
             ...apiLogModule,
             // Error Log

--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -370,6 +370,19 @@
                             placeholder="None" />
                     </label>
                 </div>
+                <div class="agent-card">
+                    <div class="agent-card-header">
+                        <div>
+                            <span class="agent-card-title"><i class="icon-file-text"></i>Getting Started Note</span>
+                            <div class="agent-card-description">Saved to the agent's namespace as a note</div>
+                        </div>
+                    </div>
+                    <label>Template
+                        <custom-select v-model="newActorNoteTemplateId"
+                            :options="[{ value: null, label: 'None' }].concat(welcomeTemplates.filter(t => t.kind === 'welcome-note').map(t => ({ value: t.id, label: t.name })))"
+                            placeholder="None" />
+                    </label>
+                </div>
             </template>
 
             <!-- ─── Admin Permissions (edit mode, UI users only) ─── -->

--- a/node/api/public/admin/views/config.html
+++ b/node/api/public/admin/views/config.html
@@ -257,6 +257,7 @@
                 <label>Kind</label>
                 <select v-model="templateEditKind">
                     <option value="welcome">welcome</option>
+                    <option value="welcome-note">welcome-note</option>
                 </select>
             </div>
             <div class="template-compose-row">

--- a/node/api/public/admin/views/memory.html
+++ b/node/api/public/admin/views/memory.html
@@ -9,25 +9,18 @@
 
     <!-- Graph view -->
     <div v-if="graphMode" style="display: flex; flex-direction: column; height: 100%;">
-        <div style="display: flex; gap: 8px; align-items: center; padding: 8px 12px; border-bottom: 1px solid var(--border);">
+        <div style="display: flex; gap: 12px; align-items: center; padding: 8px 12px; border-bottom: 1px solid var(--border);">
             <label style="font-size: 12px; display: flex; align-items: center; gap: 4px;">
                 Namespace
-                <select v-model="graphNamespaceFilter" @change="onGraphFilterChange" style="font-size: 12px; padding: 2px 6px;">
-                    <option value="">All</option>
-                    <option v-for="ns in notesNamespaces" :key="ns.namespace" :value="ns.namespace">{{ ns.namespace }}</option>
-                </select>
+                <custom-select v-model="graphNamespaceFilter" @update:model-value="onGraphFilterChange"
+                    :options="[{ value: '', label: 'All' }].concat(notesNamespaces.map(ns => ({ value: ns.namespace, label: ns.namespace })))"
+                    placeholder="All" />
             </label>
             <label style="font-size: 12px; display: flex; align-items: center; gap: 4px;">
                 Type
-                <select v-model="graphTypeFilter" @change="onGraphFilterChange" style="font-size: 12px; padding: 2px 6px;">
-                    <option value="">All</option>
-                    <option value="depends-on">depends-on</option>
-                    <option value="references">references</option>
-                    <option value="supersedes">supersedes</option>
-                    <option value="led-to">led-to</option>
-                    <option value="related">related</option>
-                    <option value="subtask-of">subtask-of</option>
-                </select>
+                <custom-select v-model="graphTypeFilter" @update:model-value="onGraphFilterChange"
+                    :options="[{ value: '', label: 'All' }, { value: 'depends-on', label: 'depends-on' }, { value: 'references', label: 'references' }, { value: 'supersedes', label: 'supersedes' }, { value: 'led-to', label: 'led-to' }, { value: 'related', label: 'related' }, { value: 'subtask-of', label: 'subtask-of' }]"
+                    placeholder="All" />
             </label>
             <label style="font-size: 12px; display: flex; align-items: center; gap: 4px;">
                 <input type="checkbox" v-model="graphShowAuto" @change="onGraphFilterChange" style="width: auto;"> Auto-extracted

--- a/node/api/public/admin/views/memory.html
+++ b/node/api/public/admin/views/memory.html
@@ -58,6 +58,31 @@
         </div>
     </div>
 
+    <!-- Note preview dialog (opens over graph) -->
+    <dialog ref="graphNoteDialog" @click="closeGraphNoteDialog($event)">
+        <article style="width: 90vw; max-width: 900px; max-height: 85vh;">
+            <header>
+                <div>
+                    <h3 v-if="graphNoteData">{{ graphNoteData.title }}</h3>
+                    <div v-if="graphNoteData" class="notes-meta" style="margin-top: 4px;">
+                        <span class="badge badge-accent" style="font-size:10px; padding:1px 6px; margin-right:6px;">{{ graphNoteData.namespace }}</span>
+                        <span class="mono">{{ graphNoteData.slug }}</span>
+                    </div>
+                </div>
+                <button aria-label="Close" @click="closeGraphNoteDialog()"></button>
+            </header>
+            <div class="dialog-body" style="overflow-y: auto; flex: 1; min-height: 0;">
+                <div v-if="graphNoteLoading" class="muted">Loading...</div>
+                <div v-else-if="graphNoteData" class="notes-markdown" v-html="graphNoteRendered"></div>
+            </div>
+            <div class="dialog-actions" v-if="graphNoteData">
+                <button class="btn btn-secondary btn-compact" @click="goToNoteFromGraph()">
+                    <i class="icon-edit-2"></i> Open in Editor
+                </button>
+            </div>
+        </article>
+    </dialog>
+
     <div v-show="!graphMode" class="notes-layout" :class="{ 'notes-fullscreen': notesFullscreen, 'notes-sidebar-collapsed': notesSidebarCollapsed }">
     <div class="notes-sidebar">
         <div class="notes-sidebar-header">

--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -504,6 +504,7 @@
                 <p>Your agent will introduce itself, learn about you, and set up its memory. From then on:</p>
                 <ul class="usage-tips">
                     <li><strong>Start each session</strong> with "check your instructions" — this reloads context and checks for messages</li>
+                    <li><strong>During sessions</strong> — whenever something noteworthy comes up, save it to your notes so it's there next time</li>
                     <li><strong>End each session</strong> with "update your notes" — this saves your work so the next session can pick up where you left off</li>
                 </ul>
             </div>
@@ -551,6 +552,7 @@
                 <p>Your agent will introduce itself, learn about you, and set up its memory. From then on:</p>
                 <ul class="usage-tips">
                     <li><strong>Start each session</strong> with "check your instructions" — this reloads context and checks for messages</li>
+                    <li><strong>During sessions</strong> — whenever something noteworthy comes up, save it to your notes so it's there next time</li>
                     <li><strong>End each session</strong> with "update your notes" — this saves your work so the next session can pick up where you left off</li>
                 </ul>
             </div>

--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -409,42 +409,57 @@
         <input type="password" id="passwordConfirm" placeholder="Confirm password" oninput="checkPasswords()">
         <div id="passwordStatus" class="name-status"></div>
 
+        <button class="btn btn-primary" id="step2Btn" onclick="showStep(3)" disabled>Continue</button>
+        <button class="btn btn-secondary" onclick="goBack()">Back</button>
+    </div>
+
+    <!-- Step 3: Dream processing -->
+    <div id="step3" class="step">
+        <h2>Dream Processing</h2>
+        <div class="subtitle">Configure how your agent learns between sessions.</div>
+        <div id="error3" class="error-msg" style="display:none"></div>
+
+        <div class="dream-mode-description">
+            Each night, your agent's conversation logs are reviewed and consolidated into persistent memory notes. Over time, this builds a <strong>soul document</strong> — a living summary of your working relationship, preferences, and patterns that your agent reads at the start of every session.
+        </div>
+
         <div class="dream-mode-section">
-            <label>Dream Mode</label>
-            <div class="dream-mode-description">
-                Each night, your agent can review the day's conversations and consolidate learnings into memory. Choose a processing style, or disable it.
-            </div>
+            <label>Processing Style</label>
             <div class="dream-mode-options">
                 <button type="button" class="dream-option selected" onclick="selectDreamMode('none', this)">
                     <div class="dream-option-radio"></div>
                     <div class="dream-option-text">
                         <div class="dream-option-title">None</div>
-                        <div class="dream-option-desc">No post-session processing. Your agent only remembers what it explicitly saves during the session.</div>
+                        <div class="dream-option-desc">No overnight processing. Your agent only remembers what it explicitly saves during sessions.</div>
                     </div>
                 </button>
                 <button type="button" class="dream-option" onclick="selectDreamMode('technical', this)">
                     <div class="dream-option-radio"></div>
                     <div class="dream-option-text">
                         <div class="dream-option-title">Technical</div>
-                        <div class="dream-option-desc">Focuses on code decisions, architecture patterns, debugging insights, and project context. Best for development workflows.</div>
+                        <div class="dream-option-desc">Extracts code decisions, architecture patterns, debugging insights, and project context. Best for development workflows.</div>
                     </div>
                 </button>
                 <button type="button" class="dream-option" onclick="selectDreamMode('companion', this)">
                     <div class="dream-option-radio"></div>
                     <div class="dream-option-text">
                         <div class="dream-option-title">Companion</div>
-                        <div class="dream-option-desc">Focuses on personal context, preferences, emotional tone, and relationship continuity. Best for personal assistant use.</div>
+                        <div class="dream-option-desc">Captures personal context, preferences, emotional tone, and relationship continuity. Best for personal assistant use.</div>
                     </div>
                 </button>
             </div>
         </div>
 
-        <button class="btn btn-primary" id="registerBtn" onclick="register()" disabled>Create Account</button>
-        <button class="btn btn-secondary" onclick="goBack()">Back</button>
+        <div class="dream-mode-description" style="margin-top: 12px;">
+            You can change this anytime in the dashboard. Dream processing runs at 4 AM UTC and only processes conversations uploaded since the last run.
+        </div>
+
+        <button class="btn btn-primary" id="registerBtn" onclick="register()">Create Account</button>
+        <button class="btn btn-secondary" onclick="showStep(2)">Back</button>
     </div>
 
-    <!-- Step 3: Getting started guide -->
-    <div id="step3" class="step guide">
+    <!-- Step 4: Getting started guide -->
+    <div id="step4" class="step guide">
         <h2>You're in!</h2>
         <div class="passphrase-warning">Save these credentials now — they will never be shown again.</div>
         <div class="passphrase-display">
@@ -684,7 +699,8 @@ function checkPasswords() {
 function updateRegisterBtn() {
     const pw = document.getElementById('password').value;
     const confirm = document.getElementById('passwordConfirm').value;
-    const btn = document.getElementById('registerBtn');
+    // Enable the Continue button on step 2 (step2Btn) when name + password are valid
+    const btn = document.getElementById('step2Btn');
     btn.disabled = !(nameAvailable && pw.length >= 8 && pw === confirm);
 }
 
@@ -728,9 +744,9 @@ async function register() {
         }, null, 2);
         document.getElementById('configBlockAi').textContent =
             'Agent name (Client ID): ' + data.agent + '\nAPI Key (Client Secret): ' + data.api_key;
-        showStep(3);
+        showStep(4);
     } catch (err) {
-        showError(2, 'Something went wrong. Try again.');
+        showError(3, 'Something went wrong. Try again.');
     }
 }
 

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1436,7 +1436,7 @@ router.post('/admin/notes/sync/delete', requirePerm('notes', 'write'), adminRout
 
 // ---- Templates CRUD ----
 
-const TEMPLATE_KINDS = new Set(['welcome']);
+const TEMPLATE_KINDS = new Set(['welcome', 'welcome-note']);
 
 // Parse YAML-style frontmatter from template content.
 // Returns { frontmatter: { key: value, ... }, body: "remaining content" }
@@ -1589,7 +1589,7 @@ function parseCostBudget(value, fieldName) {
 
 // POST /admin/actors/create — create an actor (agent + optional UI user) with optional welcome mail
 router.post('/admin/actors/create', requirePerm('actors', 'write'), adminRoute('actors-create', async (req, res) => {
-    const { name, provider, model, welcome_template_id, virtual: isVirtual, personality,
+    const { name, provider, model, welcome_template_id, welcome_note_template_id, virtual: isVirtual, personality,
             cost_budget_daily, cost_budget_monthly,
             cache_prompts, learning_enabled, max_tokens, temperature, configuration,
             ui_access, password, dream_mode } = req.body;
@@ -1726,7 +1726,33 @@ router.post('/admin/actors/create', requirePerm('actors', 'write'), adminRoute('
         }
     }
 
-    logAdmin('actor_create', { name: actorName, virtual: isVirtual === true, ui_access: !!ui_access, welcome_mail: welcomeMailSent, user_id: req.authenticatedUser.id });
+    // Apply welcome-note template if selected (non-virtual only)
+    // Saves a getting-started note in the new agent's namespace
+    let welcomeNoteSaved = false;
+    if (welcome_note_template_id && !isVirtual) {
+        try {
+            const noteTplResult = await pool.query(
+                'SELECT content FROM templates WHERE id = $1 AND kind = $2',
+                [welcome_note_template_id, 'welcome-note']
+            );
+            if (noteTplResult.rows.length > 0) {
+                const rawContent = noteTplResult.rows[0].content;
+                const { frontmatter, body: tplBody } = parseTemplateFrontmatter(rawContent);
+                const noteBody = tplBody.replace(/\{agent\}/g, actorName);
+                const noteTitle = (frontmatter.title || 'Getting Started').replace(/\{agent\}/g, actorName);
+                const noteSlug = frontmatter.slug || 'instructions/getting-started';
+                await saveNote(actorName, noteTitle, noteBody, noteSlug, actorId);
+                welcomeNoteSaved = true;
+            }
+        } catch (noteErr) {
+            console.error('Post-commit welcome-note template error:', noteErr.message);
+            if (!postCommitError) {
+                postCommitError = 'Actor created but welcome note failed: ' + noteErr.message;
+            }
+        }
+    }
+
+    logAdmin('actor_create', { name: actorName, virtual: isVirtual === true, ui_access: !!ui_access, welcome_mail: welcomeMailSent, welcome_note: welcomeNoteSaved, user_id: req.authenticatedUser.id });
 
     const response = {
         name: actorName,
@@ -1735,6 +1761,7 @@ router.post('/admin/actors/create', requirePerm('actors', 'write'), adminRoute('
         ui_access: !!ui_access,
         status: 'active',
         welcome_mail_sent: welcomeMailSent,
+        welcome_note_saved: welcomeNoteSaved,
         message: isVirtual ? 'Virtual agent created.' : 'Actor created. Save the passphrase — it will not be shown again.'
     };
     if (postCommitError) {

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -284,7 +284,7 @@ router.post('/admin/dashboard', requirePerm('dashboard', 'read'), adminRoute('da
            AND (cm.channel IS NULL OR NOT cm.channel LIKE 'discussion-%')`;
     const chatParams = [];
     if (hasFilter) {
-        chatSql += ' AND cm.from_actor_id = ANY($1) AND cm.to_actor_id = ANY($1)';
+        chatSql += ' AND (cm.from_actor_id = ANY($1) OR cm.to_actor_id = ANY($1))';
         chatParams.push(idsArray);
     }
     chatSql += ` ORDER BY CASE WHEN cm.acked_at IS NULL THEN 0 ELSE 1 END, cm.sent_at DESC LIMIT 15`;
@@ -297,7 +297,7 @@ router.post('/admin/dashboard', requirePerm('dashboard', 'read'), adminRoute('da
          WHERE m.deleted_at IS NULL`;
     const mailParams = [];
     if (hasFilter) {
-        mailSql += ' AND m.from_actor_id = ANY($1) AND m.to_actor_id = ANY($1)';
+        mailSql += ' AND (m.from_actor_id = ANY($1) OR m.to_actor_id = ANY($1))';
         mailParams.push(idsArray);
     }
     mailSql += ` ORDER BY CASE WHEN m.acked_at IS NULL THEN 0 ELSE 1 END, m.sent_at DESC LIMIT 15`;

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -796,13 +796,14 @@ router.post('/admin/mail/send', requirePerm('comms', 'write'), adminRoute('mail-
 }));
 
 // POST /admin/providers/registry — get provider/model registry for admin UI
-router.post('/admin/providers/registry', requirePerm('config', 'read'), adminRoute('providers-registry', async (req, res) => {
+// No permission check — static reference data, any authenticated user can read it
+router.post('/admin/providers/registry', adminRoute('providers-registry', async (req, res) => {
     const { getRegistry } = require('../services/provider');
     res.json(getRegistry());
 }));
 
 // POST /admin/providers/defaults — get default configuration for a provider+model
-router.post('/admin/providers/defaults', requirePerm('config', 'read'), adminRoute('providers-defaults', async (req, res) => {
+router.post('/admin/providers/defaults', adminRoute('providers-defaults', async (req, res) => {
     const { provider, model } = req.body;
     if (!provider || !model) {
         return res.status(400).json({
@@ -815,7 +816,7 @@ router.post('/admin/providers/defaults', requirePerm('config', 'read'), adminRou
 }));
 
 // POST /admin/providers/openrouter/models — lazily fetch full OpenRouter model catalog
-router.post('/admin/providers/openrouter/models', requirePerm('config', 'read'), adminRoute('openrouter-models', async (req, res) => {
+router.post('/admin/providers/openrouter/models', adminRoute('openrouter-models', async (req, res) => {
     const { fetchCatalog } = require('../services/providers/openrouter');
     const catalog = await fetchCatalog();
     // Convert Map to array of { id, name, pricing } for the UI

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -6,6 +6,7 @@ const config = require('../services/config');
 const generatePassphrase = require('eff-diceware-passphrase');
 const { generateSalt, hash: hashToken, generateKey } = require('../services/hashing');
 const { mailSend } = require('../services/mail');
+const { saveNote } = require('../services/documents');
 const { checkNameAvailability, moderateActorName } = require('../services/actors');
 
 // Parse YAML-style frontmatter from template content (same logic as admin.js)
@@ -196,6 +197,24 @@ router.post('/api/register', async (req, res) => {
         } catch (tplErr) {
             // Don't fail registration if template application fails
             console.error('Registration welcome template error:', tplErr.message);
+        }
+
+        // Save getting-started note from welcome-note template (if one exists)
+        try {
+            const noteTplResult = await pool.query(
+                "SELECT content FROM templates WHERE kind = 'welcome-note' ORDER BY id LIMIT 1"
+            );
+            if (noteTplResult.rows.length > 0) {
+                const rawContent = noteTplResult.rows[0].content;
+                const { frontmatter, body: tplBody } = parseTemplateFrontmatter(rawContent);
+                const noteBody = tplBody.replace(/\{agent\}/g, agentName);
+                const noteTitle = (frontmatter.title || 'Getting Started').replace(/\{agent\}/g, agentName);
+                const noteSlug = frontmatter.slug || 'instructions/getting-started';
+                await saveNote(agentName, noteTitle, noteBody, noteSlug, actorId);
+            }
+        } catch (noteErr) {
+            // Don't fail registration if note creation fails
+            console.error('Registration welcome-note template error:', noteErr.message);
         }
 
         res.json({


### PR DESCRIPTION
## Summary
- **Welcome-note template kind** (MEM-096) — new `welcome-note` template type that saves a getting-started note to the agent's namespace on creation. Admin UI picker for actor create, auto-applied on self-registration.
- **Seed getting-started template** (MEM-097) — default welcome-note with session lifecycle, what to save, surviving context loss.
- **Registration dream step** — split dream mode selection into its own step (step 3) with expanded explanation of dream processing and soul documents.
- **Registration "during sessions" tip** — added to both Claude Code and AI Studio tabs.
- **Comms visibility fix** — mail/chat list and delete endpoints used AND (both parties visible) instead of OR. New users couldn't see system welcome mail.
- **Dashboard visibility fix** — same AND→OR fix for dashboard mail and chat queries.
- **Graph note dialog** — clicking Open Note on a graph node now opens a modal overlay with rendered markdown instead of switching to the notes view (which rendered as a tiny sliver).
- **Graph filter dropdowns** — replaced native `<select>` with CustomSelect component.
- **Provider registry permissions** — removed permission requirement from provider registry/defaults/OpenRouter endpoints. Static reference data, any authenticated user can read it.

## Test plan
- [ ] Register a new account — verify dream step is its own page, getting-started note appears in namespace
- [ ] Log in as new user — verify dashboard shows welcome mail, Communications shows it too
- [ ] Verify provider/model dropdowns populate when creating or editing agents
- [ ] Open graph view, click a node, click Open Note — verify modal dialog with rendered content
- [ ] Verify graph filter dropdowns use the styled CustomSelect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>