### PR TITLE
Fix agent creation: visibility, MCP permissions, and UI gates

### DIFF
--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div style="display:flex; gap:4px;">
-                <button v-if="actorDialogMode === 'edit' && canDo('actors', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteActor" :disabled="actorDeleting" title="Delete Actor"><i class="icon-trash-2"></i></button>
+                <button v-if="actorDialogMode === 'edit' && canDo('agents', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteActor" :disabled="actorDeleting" title="Delete Actor"><i class="icon-trash-2"></i></button>
                 <button aria-label="Close" rel="prev" @click="closeActorConfig()"></button>
             </div>
         </header>

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -4,8 +4,8 @@
         <header>
             <div></div>
             <div style="display:flex; gap:4px;">
-                <button v-if="canDo('actors', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteAgent" :disabled="agentDeleting" title="Delete Agent"><i class="icon-trash-2"></i></button>
-                <button v-if="canDo('actors', 'read')" class="btn btn-ghost btn-compact" @click="openActorConfig(selectedAgent.agent)" title="Permissions"><i class="icon-shield"></i></button>
+                <button v-if="canDo('agents', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteAgent" :disabled="agentDeleting" title="Delete Agent"><i class="icon-trash-2"></i></button>
+                <button v-if="canDo('agents', 'read')" class="btn btn-ghost btn-compact" @click="openActorConfig(selectedAgent.agent)" title="Permissions"><i class="icon-shield"></i></button>
                 <button v-if="!agentPassphraseConfirming && !agentNewPassphrase && canDo('agents', 'write')" class="btn btn-ghost btn-compact" @click="agentPassphraseConfirming = true" title="Reset Passphrase"><i class="icon-key"></i></button>
                 <button aria-label="Close" rel="prev" @click="selectedAgent = null"></button>
             </div>

--- a/node/api/public/admin/views/config.html
+++ b/node/api/public/admin/views/config.html
@@ -3,7 +3,7 @@
         <h2>Configuration</h2>
     </div>
     <div class="sub-tabs" style="padding: 0 24px;">
-        <a v-if="canDo('actors', 'read')" href="#" :class="{ active: configSubTab === 'actors' }" @click.prevent="configSubTab = 'actors'">Actors</a>
+        <a v-if="canDo('agents', 'read')" href="#" :class="{ active: configSubTab === 'actors' }" @click.prevent="configSubTab = 'actors'">Actors</a>
         <a v-if="canDo('config', 'read')" href="#" :class="{ active: configSubTab === 'system' }" @click.prevent="configSubTab = 'system'">System</a>
         <a v-if="canDo('logs', 'read')" href="#" :class="{ active: configSubTab === 'apilog' }" @click.prevent="configSubTab = 'apilog'">API Log</a>
         <a v-if="canDo('logs', 'read')" href="#" :class="{ active: configSubTab === 'errorlog' }" @click.prevent="configSubTab = 'errorlog'">Error Log</a>
@@ -15,7 +15,7 @@
     <!-- Actors sub-tab -->
     <div v-if="configSubTab === 'actors'">
         <div style="margin-bottom: 0.75rem;">
-            <button v-if="canDo('actors', 'write')" class="inline-button" @click="startCreateActor"><i class="icon-plus"></i> Add Actor</button>
+            <button v-if="canDo('agents', 'write')" class="inline-button" @click="startCreateActor"><i class="icon-plus"></i> Add Actor</button>
         </div>
         <div class="table-wrap">
             <table class="fixed-table">

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1687,6 +1687,15 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
              ['none', 'companion', 'technical'].includes(dream_mode) ? dream_mode : 'none']
         );
 
+        // Grant all MCP permissions (full tool access) — non-virtual agents only
+        if (!isVirtual) {
+            await client.query(
+                `INSERT INTO agent_permissions (actor_id, permission_id)
+                 SELECT $1, id FROM permissions`,
+                [actorId]
+            );
+        }
+
         // Grant the creator visibility to the new agent (so they can see it in the UI).
         // Skip if the creator already has wildcard visibility (sees everything).
         const creatorVis = await client.query(

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1687,7 +1687,23 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
              ['none', 'companion', 'technical'].includes(dream_mode) ? dream_mode : 'none']
         );
 
+        // Grant the creator visibility to the new agent (so they can see it in the UI).
+        // Skip if the creator already has wildcard visibility (sees everything).
+        const creatorVis = await client.query(
+            'SELECT target_actor_id FROM actor_visibility_configuration WHERE actor_id = $1 AND target_actor_id IS NULL',
+            [req.actorId]
+        );
+        if (creatorVis.rows.length === 0) {
+            await client.query(
+                'INSERT INTO actor_visibility_configuration (actor_id, target_actor_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+                [req.actorId, actorId]
+            );
+        }
+
         await client.query('COMMIT');
+        // Clear visibility cache so the new grant takes effect immediately
+        const { clearCache: clearVisCache } = require('../services/actor-visibility');
+        clearVisCache(req.actorId);
     } catch (txErr) {
         await client.query('ROLLBACK');
         throw txErr;


### PR DESCRIPTION
## Summary
- **Auto-grant creator visibility** — when a user creates an agent through the admin UI, add a visibility row so the creator can see it. Without this, users without wildcard visibility couldn't see agents they just created.
- **Grant MCP permissions on admin create** — admin actor create was missing the `INSERT INTO agent_permissions` that registration does. Non-virtual agents only.
- **Frontend permission checks** — five `canDo('actors', ...)` checks in the UI used a resource name that doesn't exist in the DB. Changed to `canDo('agents', ...)` to match. Fixes missing shield button, delete button, actors tab, and add actor button for new users.

## Test plan
- [ ] Log in as test3, verify test4 is visible in Agents
- [ ] Create a new agent as test3, verify it appears immediately
- [ ] Verify shield/permissions button shows on agent detail dialog
- [ ] Verify delete button shows on agent detail dialog
- [ ] Verify Config > Actors tab is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>