### PR TITLE
Default agents to private, fix deleted name reuse

### DIFF
--- a/migrations/MEM-099-visible-to-others-default-false_up.sql
+++ b/migrations/MEM-099-visible-to-others-default-false_up.sql
@@ -1,0 +1,4 @@
+-- MEM-099: Change visible_to_others default to false
+-- New agents should be private by default
+
+ALTER TABLE actors ALTER COLUMN visible_to_others SET DEFAULT false;

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -13,7 +13,7 @@ const auth = require('../middleware/auth');
 const { mailSend } = require('../services/mail');
 const { formatPricing } = require('../services/provider');
 const { resolveEffectiveLimits } = require('../services/virtual-agent');
-const { requireByName, resolveByName, resolveById, checkNameAvailability, moderateActorName } = require('../services/actors');
+const { requireByName, resolveByName, resolveById, checkNameAvailability, moderateActorName, clearCache: clearActorCache } = require('../services/actors');
 const { hasAccess, requireAccess, getReadableNamespaces, validateNamespace, clearCache: clearPermissionsCache } = require('../services/namespace-permissions');
 const { SESSION_KIND } = require('../constants');
 const { getVisibleActorIds, canSee, clearCache: clearVisibilityCache } = require('../services/actor-visibility');
@@ -2442,9 +2442,11 @@ router.post('/admin/actors/delete', requirePerm('agents', 'write'), adminRoute('
 
         await client.query('COMMIT');
 
-        // Clear permission caches
+        // Clear caches so deleted actors don't linger
+        clearActorCache();
         for (const id of allActorIds) {
             clearAdminPermissionsCache(id);
+            clearVisibilityCache(id);
         }
 
         logAdmin('actor_delete', {


### PR DESCRIPTION
## Summary
- **MEM-099**: Change `visible_to_others` default from `true` to `false`. New agents are private by default — users opt in to sharing visibility via the toggle.
- **Clear actor cache on delete** — the actor name resolver caches for 5 minutes. After deleting an agent, the stale cache made the name appear taken on re-registration. Now clears actor, visibility, and admin permission caches on delete.

## Test plan
- [ ] Create a new agent — verify "Visible to others" defaults to off
- [ ] Delete an agent, then register with the same name — should succeed immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>