### PR TITLE
Run name moderation during live check-name

### DIFF
--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -42,6 +42,14 @@ router.post('/api/check-name', async (req, res) => {
         return res.json({ available: false, reason: 'Name must start with a letter, 2-31 chars, only lowercase letters, numbers, hyphens, underscores.' });
     }
     const result = await checkNameAvailability(agentName);
+    if (!result.available) {
+        return res.json(result);
+    }
+    // Run VA moderation if available (skips gracefully if VA not configured)
+    const moderation = await moderateActorName(agentName);
+    if (!moderation.approved) {
+        return res.json({ available: false, reason: moderation.reason });
+    }
     res.json(result);
 });
 


### PR DESCRIPTION
## Summary
The `/api/check-name` endpoint only checked availability — offensive names showed as "Available" while typing. The VA moderation only rejected at final registration submit. Now runs `moderateActorName` during the live check so users get immediate feedback.

## Test plan
- [ ] Type an offensive name on the registration page — should show rejection reason instead of "Available"
- [ ] Type a normal name — should still show "Available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>