### PR TITLE
Revert live name moderation, fix error display step

### DIFF
--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -716,7 +716,7 @@ async function register() {
         });
         const data = await res.json();
         if (!res.ok) {
-            showError(2, data.error || 'Registration failed');
+            showError(3, data.error || 'Registration failed');
             return;
         }
         registeredAgent = data.agent;

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -42,14 +42,6 @@ router.post('/api/check-name', async (req, res) => {
         return res.json({ available: false, reason: 'Name must start with a letter, 2-31 chars, only lowercase letters, numbers, hyphens, underscores.' });
     }
     const result = await checkNameAvailability(agentName);
-    if (!result.available) {
-        return res.json(result);
-    }
-    // Run VA moderation if available (skips gracefully if VA not configured)
-    const moderation = await moderateActorName(agentName);
-    if (!moderation.approved) {
-        return res.json({ available: false, reason: moderation.reason });
-    }
     res.json(result);
 });
 


### PR DESCRIPTION
## Summary
- Reverts PR #50 (live name moderation during check-name) — too costly per keystroke
- Fixes registration error display: errors were showing on hidden step 2, now correctly show on step 3 (dream step) where the Create Account button lives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>