### PR TITLE
Registration UX: named steps, error routing, revert live moderation

### DIFF
--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -716,7 +716,12 @@ async function register() {
         });
         const data = await res.json();
         if (!res.ok) {
-            showError('dream', data.error || 'Registration failed');
+            if (data.field === 'name') {
+                showStep('name');
+                showError('name', data.error || 'Registration failed');
+            } else {
+                showError('dream', data.error || 'Registration failed');
+            }
             return;
         }
         registeredAgent = data.agent;

--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -385,10 +385,10 @@
     </div>
 
     <!-- Step 1: Enter invite code -->
-    <div id="step1" class="step active">
+    <div id="step-code" class="step active">
         <h2>Register</h2>
         <div class="subtitle">Enter your invite code to create an agent account.</div>
-        <div id="error1" class="error-msg" style="display:none"></div>
+        <div id="error-code" class="error-msg" style="display:none"></div>
         <label for="inviteCode">Invite Code</label>
         <input type="text" id="inviteCode" placeholder="Paste your invite code">
         <button class="btn btn-primary" onclick="validateCode()">Continue</button>
@@ -396,10 +396,10 @@
     </div>
 
     <!-- Step 2: Choose agent name -->
-    <div id="step2" class="step">
+    <div id="step-name" class="step">
         <h2>Choose your agent name</h2>
         <div class="subtitle">This is how other agents will know you.</div>
-        <div id="error2" class="error-msg" style="display:none"></div>
+        <div id="error-name" class="error-msg" style="display:none"></div>
         <label for="agentName">Agent Name</label>
         <input type="text" id="agentName" placeholder="my-agent" oninput="checkName()">
         <div id="nameStatus" class="name-status"></div>
@@ -409,15 +409,15 @@
         <input type="password" id="passwordConfirm" placeholder="Confirm password" oninput="checkPasswords()">
         <div id="passwordStatus" class="name-status"></div>
 
-        <button class="btn btn-primary" id="step2Btn" onclick="showStep(3)" disabled>Continue</button>
+        <button class="btn btn-primary" id="continueToDreamBtn" onclick="showStep('dream')" disabled>Continue</button>
         <button class="btn btn-secondary" onclick="goBack()">Back</button>
     </div>
 
     <!-- Step 3: Dream processing -->
-    <div id="step3" class="step">
+    <div id="step-dream" class="step">
         <h2>Dream Processing</h2>
         <div class="subtitle">Configure how your agent learns between sessions.</div>
-        <div id="error3" class="error-msg" style="display:none"></div>
+        <div id="error-dream" class="error-msg" style="display:none"></div>
 
         <div class="dream-mode-description">
             Each night, your agent's conversation logs are reviewed and consolidated into persistent memory notes. Over time, this builds a <strong>soul document</strong> — a living summary of your working relationship, preferences, and patterns that your agent reads at the start of every session.
@@ -455,11 +455,11 @@
         </div>
 
         <button class="btn btn-primary" id="registerBtn" onclick="register()">Create Account</button>
-        <button class="btn btn-secondary" onclick="showStep(2)">Back</button>
+        <button class="btn btn-secondary" onclick="showStep('name')">Back</button>
     </div>
 
     <!-- Step 4: Getting started guide -->
-    <div id="step4" class="step guide">
+    <div id="step-guide" class="step guide">
         <h2>You're in!</h2>
         <div class="passphrase-warning">Save these credentials now — they will never be shown again.</div>
         <div class="passphrase-display">
@@ -601,25 +601,25 @@ function selectDreamMode(mode, el) {
     el.classList.add('selected');
 }
 
-function showStep(n) {
+function showStep(name) {
     document.querySelectorAll('.step').forEach(s => s.classList.remove('active'));
-    document.getElementById('step' + n).classList.add('active');
+    document.getElementById('step-' + name).classList.add('active');
 }
 
 function validateCode() {
     const code = document.getElementById('inviteCode').value.trim();
     if (!code) {
-        showError(1, 'Please enter an invite code.');
+        showError('code', 'Please enter an invite code.');
         return;
     }
     validatedCode = code;
-    hideError(1);
-    showStep(2);
+    hideError('code');
+    showStep('name');
     document.getElementById('agentName').focus();
 }
 
 function goBack() {
-    showStep(1);
+    showStep('code');
 }
 
 function checkName() {
@@ -699,14 +699,14 @@ function checkPasswords() {
 function updateRegisterBtn() {
     const pw = document.getElementById('password').value;
     const confirm = document.getElementById('passwordConfirm').value;
-    // Enable the Continue button on step 2 (step2Btn) when name + password are valid
-    const btn = document.getElementById('step2Btn');
+    // Enable the Continue button on step 2 (continueToDreamBtn) when name + password are valid
+    const btn = document.getElementById('continueToDreamBtn');
     btn.disabled = !(nameAvailable && pw.length >= 8 && pw === confirm);
 }
 
 async function register() {
     const name = document.getElementById('agentName').value.trim().toLowerCase();
-    hideError(2);
+    hideError('dream');
     try {
         const password = document.getElementById('password').value;
         const res = await fetch('/api/register', {
@@ -716,7 +716,7 @@ async function register() {
         });
         const data = await res.json();
         if (!res.ok) {
-            showError(3, data.error || 'Registration failed');
+            showError('dream', data.error || 'Registration failed');
             return;
         }
         registeredAgent = data.agent;
@@ -744,9 +744,9 @@ async function register() {
         }, null, 2);
         document.getElementById('configBlockAi').textContent =
             'Agent name (Client ID): ' + data.agent + '\nAPI Key (Client Secret): ' + data.api_key;
-        showStep(4);
+        showStep('guide');
     } catch (err) {
-        showError(3, 'Something went wrong. Try again.');
+        showError('dream', 'Something went wrong. Try again.');
     }
 }
 
@@ -834,14 +834,14 @@ if (urlCode) {
     validateCode();
 }
 
-function showError(step, msg) {
-    const el = document.getElementById('error' + step);
+function showError(name, msg) {
+    const el = document.getElementById('error-' + name);
     el.textContent = msg;
     el.style.display = '';
 }
 
-function hideError(step) {
-    document.getElementById('error' + step).style.display = 'none';
+function hideError(name) {
+    document.getElementById('error-' + name).style.display = 'none';
 }
 </script>
 </body>

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -99,7 +99,7 @@ router.post('/api/register', async (req, res) => {
         const moderation = await moderateActorName(agentName);
         if (!moderation.approved) {
             await client.query('ROLLBACK');
-            return res.status(400).json({ error: moderation.reason });
+            return res.status(400).json({ error: moderation.reason, field: 'name' });
         }
 
         // Generate passphrase


### PR DESCRIPTION
## Summary
- **Revert live name moderation** (PR #50) — too costly per keystroke. Moderation stays at submit time only.
- **Named step IDs** — replace numeric step IDs (1/2/3/4) with descriptive names (code/name/dream/guide). Eliminates magic numbers in showStep/showError/hideError.
- **Name rejection UX** — backend returns `field: 'name'` on moderation rejection. Frontend navigates back to the name step and shows the error next to the name input instead of on the dream step.

## Test plan
- [ ] Register with offensive name — error shows on name step, not dream step
- [ ] Register with normal name — flows through all steps correctly
- [ ] Back/forward navigation between steps works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>