### PR TITLE
Clear name error on input

### DIFF
--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -627,6 +627,7 @@ function checkName() {
     const statusEl = document.getElementById('nameStatus');
     nameAvailable = false;
     updateRegisterBtn();
+    hideError('name');
 
     if (!name) { statusEl.textContent = ''; return; }
     if (!/^[a-z][a-z0-9_-]{1,30}$/.test(name)) {


### PR DESCRIPTION
## Summary
Clear the name moderation error message when the user starts typing a new name, so it doesn't linger after navigating back from the dream step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)