### PR TITLE
Hide delete button for own agent

### DIFF
--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div style="display:flex; gap:4px;">
-                <button v-if="actorDialogMode === 'edit' && canDo('agents', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteActor" :disabled="actorDeleting" title="Delete Actor"><i class="icon-trash-2"></i></button>
+                <button v-if="actorDialogMode === 'edit' && canDo('agents', 'write') && selectedActorConfig.name !== user.username" class="btn btn-ghost btn-compact btn-danger" @click="deleteActor" :disabled="actorDeleting" title="Delete Actor"><i class="icon-trash-2"></i></button>
                 <button aria-label="Close" rel="prev" @click="closeActorConfig()"></button>
             </div>
         </header>

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -4,7 +4,7 @@
         <header>
             <div></div>
             <div style="display:flex; gap:4px;">
-                <button v-if="canDo('agents', 'write')" class="btn btn-ghost btn-compact btn-danger" @click="deleteAgent" :disabled="agentDeleting" title="Delete Agent"><i class="icon-trash-2"></i></button>
+                <button v-if="canDo('agents', 'write') && selectedAgent.agent !== user.username" class="btn btn-ghost btn-compact btn-danger" @click="deleteAgent" :disabled="agentDeleting" title="Delete Agent"><i class="icon-trash-2"></i></button>
                 <button v-if="canDo('agents', 'read')" class="btn btn-ghost btn-compact" @click="openActorConfig(selectedAgent.agent)" title="Permissions"><i class="icon-shield"></i></button>
                 <button v-if="!agentPassphraseConfirming && !agentNewPassphrase && canDo('agents', 'write')" class="btn btn-ghost btn-compact" @click="agentPassphraseConfirming = true" title="Reset Passphrase"><i class="icon-key"></i></button>
                 <button aria-label="Close" rel="prev" @click="selectedAgent = null"></button>


### PR DESCRIPTION
## Summary
Hide the trash/delete icon in both agent detail and actor config dialogs when viewing your own agent. Backend already rejects self-deletion, but the button shouldn't show at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)