### PR TITLE
Fix templates unique constraint: (name, kind) not just (name)

### DIFF
--- a/migrations/MEM-100-templates-unique-name-kind_up.sql
+++ b/migrations/MEM-100-templates-unique-name-kind_up.sql
@@ -1,0 +1,8 @@
+-- MEM-100: Change templates unique constraint from (name) to (name, kind)
+-- Allows the same name (e.g. "default") across different template kinds.
+
+ALTER TABLE templates DROP CONSTRAINT welcome_templates_name_key;
+ALTER TABLE templates ADD CONSTRAINT templates_name_kind_key UNIQUE (name, kind);
+
+-- Fix the seed template that had to use a different name due to the old constraint
+UPDATE templates SET name = 'default' WHERE name = 'default-getting-started' AND kind = 'welcome-note';


### PR DESCRIPTION
## Summary
- MEM-097 seed template failed silently because "default" name was already taken by the welcome template
- MEM-100: changes unique constraint from `(name)` to `(name, kind)` so each kind can have its own "default"
- Renames the manually inserted `default-getting-started` back to `default`

## Test plan
- [ ] Register a new agent — verify getting-started note appears in their namespace
- [ ] Check Config > Templates — both "default" templates show (welcome and welcome-note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>