### PR TITLE
Open note dialog on graph node click, fix dropdown widths

### DIFF
--- a/node/api/public/admin/graph.js
+++ b/node/api/public/admin/graph.js
@@ -39,6 +39,7 @@ export function useGraph({ api, showToast }) {
     const graphTypeFilter = ref('');
     const graphShowAuto = ref(true);
     const graphSelectedNode = ref(null);
+    let onNodeClick = null;
 
     let simulation = null;
     let svgElement = null;
@@ -230,7 +231,11 @@ export function useGraph({ api, showToast }) {
             .style('cursor', 'pointer')
             .on('click', (event, d) => {
                 event.stopPropagation();
-                graphSelectedNode.value = d;
+                if (onNodeClick) {
+                    onNodeClick(d);
+                } else {
+                    graphSelectedNode.value = d;
+                }
             });
 
         // Node circles — sized by connection count
@@ -330,5 +335,6 @@ export function useGraph({ api, showToast }) {
         renderGraph,
         destroyGraph,
         nsColor,
+        setOnNodeClick(fn) { onNodeClick = fn; },
     };
 }

--- a/node/api/public/admin/main.js
+++ b/node/api/public/admin/main.js
@@ -394,6 +394,9 @@ createApp({
             nextTick(function() { notesModule.openNote(note.namespace, note.slug); });
         }
 
+        // Wire graph node clicks to open the note dialog directly
+        graphModule.setOnNodeClick(openNoteFromGraph);
+
         // Flatten everything into the template namespace
         const appState = {
             currentView,

--- a/node/api/public/admin/views/memory.html
+++ b/node/api/public/admin/views/memory.html
@@ -12,13 +12,13 @@
         <div style="display: flex; gap: 12px; align-items: center; padding: 8px 12px; border-bottom: 1px solid var(--border);">
             <label style="font-size: 12px; display: flex; align-items: center; gap: 4px;">
                 Namespace
-                <custom-select v-model="graphNamespaceFilter" @update:model-value="onGraphFilterChange"
+                <custom-select v-model="graphNamespaceFilter" @update:model-value="onGraphFilterChange" style="min-width: 120px;"
                     :options="[{ value: '', label: 'All' }].concat(notesNamespaces.map(ns => ({ value: ns.namespace, label: ns.namespace })))"
                     placeholder="All" />
             </label>
             <label style="font-size: 12px; display: flex; align-items: center; gap: 4px;">
                 Type
-                <custom-select v-model="graphTypeFilter" @update:model-value="onGraphFilterChange"
+                <custom-select v-model="graphTypeFilter" @update:model-value="onGraphFilterChange" style="min-width: 120px;"
                     :options="[{ value: '', label: 'All' }, { value: 'depends-on', label: 'depends-on' }, { value: 'references', label: 'references' }, { value: 'supersedes', label: 'supersedes' }, { value: 'led-to', label: 'led-to' }, { value: 'related', label: 'related' }, { value: 'subtask-of', label: 'subtask-of' }]"
                     placeholder="All" />
             </label>
@@ -30,24 +30,6 @@
         </div>
         <div style="display: flex; flex: 1; min-height: 0;">
             <div id="graph-container" style="flex: 1;"></div>
-            <!-- Node detail panel -->
-            <div v-if="graphSelectedNode" style="width: 280px; border-left: 1px solid var(--border); padding: 12px; overflow-y: auto; font-size: 13px;">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-                    <strong>Note Details</strong>
-                    <button class="btn btn-ghost btn-compact" @click="graphSelectedNode = null"><i class="icon-x"></i></button>
-                </div>
-                <div style="margin-bottom: 6px;">
-                    <span class="ts">Namespace</span><br>
-                    <span :style="{ color: nsColor(graphSelectedNode.namespace) }">{{ graphSelectedNode.namespace }}</span>
-                </div>
-                <div style="margin-bottom: 6px;">
-                    <span class="ts">Slug</span><br>
-                    <span style="word-break: break-all;">{{ graphSelectedNode.slug }}</span>
-                </div>
-                <button class="btn btn-primary btn-compact" style="margin-top: 8px;" @click="openNoteFromGraph(graphSelectedNode)">
-                    <i class="icon-file-text"></i> Open Note
-                </button>
-            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Remove the sidebar detail panel from graph view — clicking a node now opens the note preview dialog directly instead of showing a narrow sidebar that pushed the graph off-screen
- Add min-width: 120px to namespace and type filter dropdowns so they don't collapse to the width of "All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Home <noreply@anthropic.com>