### PR TITLE
Remove config pre-fetch from agents view

### DIFF
--- a/node/api/public/admin/main.js
+++ b/node/api/public/admin/main.js
@@ -206,7 +206,6 @@ createApp({
                 errorLogModule.startErrorLogPolling();
             } else if (currentView.value === 'agents') {
                 agentsModule.loadAgents();
-                if (configModule.configEntries.value.length === 0) configModule.loadConfig();
             } else if (currentView.value === 'comms') {
                 if (commSubTab.value === 'discussions') discussionsModule.loadDiscussions();
                 else if (commSubTab.value === 'chat') chatModule.loadChat();


### PR DESCRIPTION
## Summary
- Users without config permission get a 403 when navigating to the Agents tab because `main.js` eagerly pre-fetches config data
- The config data isn't used by the agents view — it was just a cache warm-up for the Config tab
- Remove the pre-fetch so config only loads when the Config tab is actually opened

## Test plan
- [ ] Log in as a user without config permission, navigate to Agents tab — no 403 in console
- [ ] Navigate to Config tab — config data loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)