### PR TITLE
Add Go discuss binary and /agent/config endpoint

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,20 @@ builds:
       - amd64
       - arm64
 
+  - id: discuss
+    main: ./cmd/discuss/
+    dir: go/client
+    binary: discuss
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: memory-sync
     ids:
@@ -30,6 +44,17 @@ archives:
         formats:
           - zip
     name_template: "memory-sync_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  - id: discuss
+    ids:
+      - discuss
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "discuss_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: checksums.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ When a session starts from a continuation summary, treat operational details in 
 - **Scripts**: `node/api/scripts/` — operational scripts deployed with the app (e.g., `db-cleanup.sh` for cron)
 - **Migrations**: `migrations/` — raw SQL, sequential MEM-XXX numbering
 - **Infrastructure**: `infrastructure/` — Ansible playbooks, roles, and templates for deployment
-- **Discussion transport**: `node/client/discuss.js` — Node CLI for multi-agent discussions
+- **Discussion transport**: `go/client/cmd/discuss/` — Go binary for multi-agent discussions (replaces legacy `node/client/discuss.js`)
 
 ## Deployment
 

--- a/go/client/cmd/discuss/discussion-prompt.tpl
+++ b/go/client/cmd/discuss/discussion-prompt.tpl
@@ -1,0 +1,128 @@
+You are [MY_AGENT], participating in a real-time discussion with [OTHER_AGENTS].
+
+## Discussion Topic
+
+**[TOPIC]**
+
+[CONTEXT]
+
+[FIRST_CONTACT]
+
+## Style
+
+- Keep responses concise — working discussion, not essays
+- Challenge ideas you disagree with. Say why. Don't just agree to be agreeable.
+- If you see a flaw, edge case, or missing consideration — raise it, even if it slows consensus
+- Produce a shared plan or recommendation. Do NOT divide work ("I'll do X, you do Y") — the user decides who implements what
+- Propose votes to formalize concrete decisions
+
+## Convergence
+
+The transport monitors this discussion for convergence. If the discussion goes too long without
+resolution, you will receive `[SYSTEM]` messages with warnings.
+
+When you receive a convergence warning, you must respond with exactly one of:
+1. Propose a vote to resolve the specific disagreement
+2. Concede a point you've been defending to unblock progress
+3. Identify the exact factual or architectural question where you disagree and propose how to resolve it (e.g., "we need to test X to know which approach is right")
+
+Do not restate your existing position after a convergence warning. If you believe the warning is
+premature, say so briefly and take one of the three actions above anyway.
+
+## Impasse Handling
+
+When a vote splits (no unanimous agreement), the transport injects an impasse notification.
+When you receive this notification, write a **balanced decision brief** for the user:
+
+1. **Each position's pros and cons** — fair representation, not advocacy
+2. **What was agreed** — common ground between participants
+3. **The specific disagreement** — the exact decision point where you differ
+4. **Your recommendation** (optional) — if you have one, state it with reasoning
+
+The user will see this summary and make the final call. After writing the brief, propose
+a conclude vote to end the discussion.
+
+## Communication Standards
+
+**IMPORTANT: Be comprehensive in your messages.** Include exact file paths, line numbers, code snippets. Every message should be self-contained — the other agent can't see your screen.
+
+[GUIDELINES]
+
+---
+
+## Protocol Reference
+
+You ONLY have access to the Bash tool. Do NOT use MCP tools — they block execution.
+
+Working directory: [WORK_DIR]
+Proxy URL: [API_URL]
+
+### Setup
+
+Define this helper at the start of your session:
+```bash
+agentlog() { echo "[$(date +%H:%M:%S)] $*" >> [WORK_DIR]/subagent.log; }
+```
+
+Use `agentlog` to log your activity — the transport monitors this file for diagnostics.
+
+### Messaging
+
+A transport process relays messages via files. No auth needed — the proxy handles it.
+
+- **Read:** Incoming messages appear as .txt files in `inbox/` (e.g., `inbox/37.txt`). Each starts with `From: agent-name`. Delete after reading.
+- **Write:** Put replies in `outbox/` as sequential .txt files (`outbox/001.txt`, `outbox/002.txt`). The transport sends and deletes them.
+
+Read and delete inbox in one call:
+```bash
+for f in [WORK_DIR]/inbox/*.txt; do [ -f "$f" ] && echo "=== $f ===" && cat "$f"; done
+rm [WORK_DIR]/inbox/*.txt 2>/dev/null
+```
+
+### Your Loop
+
+**Important:** Always read inbox before checking timeouts to avoid missing a message that arrived just before the deadline.
+
+1. `agentlog "Reading inbox"`
+   Read inbox (see above), think, write reply to outbox/
+   `agentlog "Wrote outbox reply"`
+2. `agentlog "Checking votes"`
+   Check for pending votes: `curl -s -X POST [API_URL]/pending -H "Content-Type: application/json" -d '{}'`
+3. If `done` file exists → go to Exit
+4. `agentlog "Polling"`
+   Poll for new messages (run the poll script — handles idle timeout automatically):
+   ```bash
+   bash [WORK_DIR]/poll.sh
+   ```
+   - `NEW_MESSAGES` → go to step 1
+   - `DONE` → go to Exit
+   - `IDLE_TIMEOUT` → `echo "idle" > [WORK_DIR]/idle-timeout` → go to Exit
+5. Go to step 1
+
+### Proxy Endpoints
+
+All POST, JSON body, no auth. Example: `curl -s -X POST [API_URL]/ENDPOINT -H "Content-Type: application/json" -d 'JSON'`
+
+| Endpoint | Body | Purpose |
+|----------|------|---------|
+| /vote/propose | `{"question": "Description. 1=yes 2=no", "type": "general", "threshold": "unanimous"}` | Propose a vote |
+| /vote/cast | `{"vote_id": N, "choice": N, "reason": "..."}` | Cast ballot |
+| /vote/status | `{"vote_id": N}` | Check result |
+| /pending | `{}` | Pending votes needing your ballot |
+| /conclude | `{}` | Conclude the discussion |
+
+Mention votes in chat so others know. Check `/pending` after each inbox read.
+
+### Concluding
+
+When discussion reaches a natural conclusion:
+1. Write final summary message to outbox (conclusions, action items, open items)
+2. Propose conclude vote: `type: "conclude"`
+3. Cast your own yes vote, wait for others
+4. When passed: call `/conclude`, then `echo "concluded" > [WORK_DIR]/done` → Exit
+
+If another participant proposes conclude: cast yes if you agree, no if not.
+
+### Exit
+
+When `done` file exists: write `result.md` in the working directory summarizing what was discussed, agreed, votes and outcomes, any open items. Do NOT silently exit — result.md is how the parent agent reports to the user.

--- a/go/client/cmd/discuss/main.go
+++ b/go/client/cmd/discuss/main.go
@@ -1,0 +1,574 @@
+// discuss — Discussion transport binary for the memory API.
+//
+// Combines the functionality of discuss.js (transport) and
+// discuss-launch.js (launcher) into a single binary. In normal mode
+// (the default), it spawns itself as a background transport process,
+// polls for the prompt file, and outputs its contents to stdout.
+// In --transport mode, it runs the transport directly (used when
+// the binary re-spawns itself).
+//
+// Usage:
+//
+//	discuss create --config .agent.json --topic "..." --other <agent> [--optional <agent>]
+//	discuss join --config .agent.json [discussion-id]
+//	discuss create --transport --config .agent.json --topic "..." --other <agent>
+//
+// The --config flag points to .agent.json which provides agent name,
+// passphrase, api_url, and work_dir.
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jeffdafoe/llm-memory-api/go/client/internal/discuss"
+)
+
+// Embed the discussion prompt template into the binary so it doesn't
+// need to exist on disk at runtime. The source file lives at
+// templates/discussion-prompt.tpl in the repo root — this copy in
+// cmd/discuss/ must be kept in sync.
+//
+//go:embed discussion-prompt.tpl
+var embeddedTemplate string
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+	if command != "create" && command != "join" {
+		printUsage()
+		os.Exit(1)
+	}
+
+	// Parse flags from os.Args[2:]
+	args := os.Args[2:]
+	opts := parseArgs(args, command)
+
+	// Load config from .agent.json
+	cfg := discuss.DefaultConfig()
+	cfg.Initiator = (command == "create")
+
+	// Apply CLI overrides before loading config file
+	if opts.agent != "" {
+		cfg.Agent = opts.agent
+	}
+	if opts.passphrase != "" {
+		cfg.Passphrase = opts.passphrase
+	}
+	if opts.apiURL != "" {
+		cfg.APIURL = opts.apiURL
+	}
+	if opts.workDir != "" {
+		cfg.WorkDirBase = opts.workDir
+	}
+
+	if opts.configPath != "" {
+		if err := cfg.LoadAgentConfig(opts.configPath); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Apply remaining options
+	cfg.Topic = opts.topic
+	cfg.Others = opts.others
+	cfg.OptionalParticipants = opts.optional
+	cfg.Context = opts.context
+	cfg.ContextFile = opts.contextFile
+	if opts.mode != "" {
+		cfg.Mode = opts.mode
+	}
+	if opts.maxMessages > 0 {
+		cfg.MaxMessages = opts.maxMessages
+	}
+	if opts.timeoutMinutes > 0 {
+		cfg.TimeoutMinutes = opts.timeoutMinutes
+	}
+	if opts.joinTimeout > 0 {
+		cfg.JoinTimeout = opts.joinTimeout
+	}
+	if err := cfg.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
+	if opts.transportMode {
+		// Direct transport mode — run the full discussion lifecycle
+		runTransport(cfg, command, opts.discussionID)
+	} else {
+		// Launcher mode — spawn transport as background process, poll for prompt
+		runLauncher(cfg, command, opts)
+	}
+}
+
+// runTransport is the main entry point when running in --transport mode.
+// It handles the full discussion lifecycle: login, create/join, wait,
+// proxy, transport loop, cleanup.
+func runTransport(cfg *discuss.Config, command string, discussionID int) {
+	logger := discuss.NewLogger("") // will be set after workDir is known
+
+	// Health check
+	healthURL := strings.TrimSuffix(cfg.APIURL, "/v1") + "/health"
+	healthURL = strings.TrimSuffix(healthURL, "/") + "/health"
+	// Normalize: if APIURL ends with /v1, strip it and add /health
+	if strings.HasSuffix(cfg.APIURL, "/v1") {
+		healthURL = cfg.APIURL[:len(cfg.APIURL)-3] + "/health"
+	} else if strings.HasSuffix(cfg.APIURL, "/v1/") {
+		healthURL = cfg.APIURL[:len(cfg.APIURL)-4] + "/health"
+	} else {
+		healthURL = cfg.APIURL + "/health"
+	}
+
+	client := discuss.NewAPIClient(cfg.APIURL, cfg.Agent, cfg.Passphrase, logger)
+	if err := client.Get(healthURL); err != nil {
+		fmt.Fprintf(os.Stderr, "API at %s is unreachable: %s\n", cfg.APIURL, err)
+		os.Exit(1)
+	}
+
+	if err := client.Login(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
+	// Fetch server config for discussion defaults
+	discuss.ApplyServerConfig(client, cfg, logger)
+
+	// Setup based on command
+	if command == "create" {
+		if len(cfg.Others) == 0 {
+			fmt.Fprintf(os.Stderr, "create requires at least one --other participant\n")
+			os.Exit(1)
+		}
+		if cfg.Topic == "" {
+			fmt.Fprintf(os.Stderr, "create requires --topic\n")
+			os.Exit(1)
+		}
+		var err error
+		discussionID, err = discuss.SetupCreate(client, cfg, logger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Create failed: %s\n", err)
+			client.Logout()
+			os.Exit(1)
+		}
+	} else {
+		// Join mode
+		if discussionID == 0 {
+			var err error
+			discussionID, err = discuss.AutoDiscoverDiscussion(client, cfg, logger)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", err)
+				client.Logout()
+				os.Exit(1)
+			}
+		}
+		var err error
+		discussionID, err = discuss.SetupJoin(client, cfg, logger, discussionID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Join failed: %s\n", err)
+			client.Logout()
+			os.Exit(1)
+		}
+	}
+
+	// Set workDir now that we have the discussion ID
+	cfg.SetWorkDir(discussionID)
+	paths := discuss.InitPaths(cfg.WorkDir)
+	logger.SetLogFile(paths.LogFile)
+
+	if err := os.MkdirAll(cfg.WorkDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Create work dir: %s\n", err)
+		client.Logout()
+		os.Exit(1)
+	}
+	if err := paths.EnsureDirectories(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		client.Logout()
+		os.Exit(1)
+	}
+
+	paths.CleanWorkDir()
+	paths.KillStalePID()
+	if err := paths.AcquireLock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		client.Logout()
+		os.Exit(1)
+	}
+	paths.WritePollScript(cfg.WorkDir)
+
+	// Wait for all participants
+	if err := discuss.WaitForReady(client, discussionID, cfg, logger); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		paths.ReleaseLock()
+		client.Logout()
+		os.Exit(1)
+	}
+
+	// Signal activity
+	client.Post("/agent/activity/start", map[string]interface{}{"agent": cfg.Agent}, nil)
+
+	paths.InitTranscript(cfg.Agent, cfg.OtherAgents())
+
+	// Start proxy server
+	startTime := time.Now()
+	others := cfg.OtherAgents()
+	convergence := discuss.NewConvergence(
+		append([]string{cfg.Agent}, others...),
+		cfg.MaxRounds, logger, paths,
+	)
+	proxy, err := discuss.NewProxyServer(client, discussionID, cfg.Agent,
+		convergence, paths, logger, startTime)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Start proxy: %s\n", err)
+		paths.ReleaseLock()
+		client.Logout()
+		os.Exit(1)
+	}
+	proxy.Start()
+
+	// Generate prompt
+	discuss.GeneratePrompt(cfg, paths, discussionID, proxy.Port(), logger, embeddedTemplate)
+
+	// Log summary
+	logger.Log("Discussion #%d ready", discussionID)
+	logger.Log("Mode: %s, Agent: %s, Others: %s",
+		command, cfg.Agent, strings.Join(others, ", "))
+	logger.Log("Proxy: 127.0.0.1:%d", proxy.Port())
+	logger.Log("Prompt: %s", paths.PromptFile)
+
+	// Handle clean shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		logger.Log("Shutting down...")
+		paths.ReleaseLock()
+		client.Logout()
+		proxy.Close()
+		os.Exit(0)
+	}()
+
+	// Create and run transport
+	transport := discuss.NewTransport(client, cfg, paths, logger,
+		convergence, proxy, discussionID)
+	transport.RestoreState()
+	transport.Run()
+
+	// Save transcript and result
+	transport.SaveTranscript()
+	transport.SaveResult()
+
+	// Clean exit
+	paths.ReleaseLock()
+	client.Logout()
+	proxy.Close()
+
+	if transport.IsTerminated() {
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+// runLauncher spawns the transport as a background process, polls for
+// the prompt file, and outputs its contents to stdout.
+func runLauncher(cfg *discuss.Config, command string, opts *options) {
+	workDir := cfg.WorkDirBase
+	if workDir == "" {
+		workDir = filepath.Join(os.TempDir(), "llm")
+	}
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Create work dir: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Clean up stale context temp files
+	entries, _ := os.ReadDir(workDir)
+	for _, e := range entries {
+		matched, _ := regexp.MatchString(`^discuss-context-\d+\.md$`, e.Name())
+		if matched {
+			os.Remove(filepath.Join(workDir, e.Name()))
+		}
+	}
+
+	// If --context-file is provided, copy to a unique temp file
+	childArgs := buildChildArgs(command, opts)
+	if opts.contextFile != "" {
+		uniquePath := filepath.Join(workDir, fmt.Sprintf("discuss-context-%d.md", time.Now().UnixMilli()))
+		data, err := os.ReadFile(opts.contextFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: Could not copy context file: %s\n", err)
+		} else {
+			os.WriteFile(uniquePath, data, 0644)
+			// Replace context-file in child args
+			for i, a := range childArgs {
+				if a == "--context-file" && i+1 < len(childArgs) {
+					childArgs[i+1] = uniquePath
+					break
+				}
+			}
+			fmt.Fprintf(os.Stderr, "Context copied to %s\n", uniquePath)
+		}
+	}
+
+	logFile := filepath.Join(workDir, "discuss-transport.log")
+	os.Remove(logFile) // clear old log
+
+	// Spawn self as background transport process
+	exe, _ := os.Executable()
+	transportArgs := append(childArgs, "--transport")
+
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Open log file: %s\n", err)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command(exe, transportArgs...)
+	cmd.Stdout = logFd
+	cmd.Stderr = logFd
+	// On Windows, we can't use SysProcAttr for detaching the same way,
+	// but the process will outlive us since we exit after reading the prompt.
+	if err := cmd.Start(); err != nil {
+		logFd.Close()
+		fmt.Fprintf(os.Stderr, "Start transport: %s\n", err)
+		os.Exit(1)
+	}
+	logFd.Close()
+
+	fmt.Fprintf(os.Stderr, "Transport PID: %d\n", cmd.Process.Pid)
+
+	// Release the child so it's not killed when we exit
+	cmd.Process.Release()
+
+	// Poll for "Prompt written to <path>" in the transport log
+	timeoutSec := 600
+	promptRe := regexp.MustCompile(`Prompt written to (.+)`)
+
+	for elapsed := 0; elapsed < timeoutSec; elapsed += 2 {
+		time.Sleep(2 * time.Second)
+
+		data, err := os.ReadFile(logFile)
+		if err != nil {
+			continue
+		}
+
+		match := promptRe.FindSubmatch(data)
+		if match != nil {
+			promptPath := strings.TrimSpace(string(match[1]))
+			prompt, err := os.ReadFile(promptPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read prompt at %s: %s\n", promptPath, err)
+				os.Exit(1)
+			}
+			fmt.Print(string(prompt))
+			os.Exit(0)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "ERROR: prompt.txt not found after %ds\n", timeoutSec)
+	data, _ := os.ReadFile(logFile)
+	if len(data) > 0 {
+		fmt.Fprintf(os.Stderr, "--- Transport log ---\n%s\n", string(data))
+	}
+	os.Exit(1)
+}
+
+// --- Argument parsing ---
+
+type options struct {
+	configPath     string
+	topic          string
+	others         []string
+	optional       []string
+	context        string
+	contextFile    string
+	mode           string
+	workDir        string
+	maxMessages    int
+	timeoutMinutes int
+	joinTimeout    int
+	agent          string
+	passphrase     string
+	apiURL         string
+	discussionID  int
+	transportMode bool
+}
+
+func parseArgs(args []string, command string) *options {
+	opts := &options{}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--config":
+			if i+1 < len(args) {
+				opts.configPath = args[i+1]
+				i++
+			}
+		case "--topic":
+			if i+1 < len(args) {
+				opts.topic = args[i+1]
+				i++
+			}
+		case "--other":
+			if i+1 < len(args) {
+				opts.others = append(opts.others, args[i+1])
+				i++
+			}
+		case "--optional":
+			if i+1 < len(args) {
+				opts.optional = append(opts.optional, args[i+1])
+				i++
+			}
+		case "--context":
+			if i+1 < len(args) {
+				opts.context = args[i+1]
+				i++
+			}
+		case "--context-file":
+			if i+1 < len(args) {
+				opts.contextFile = args[i+1]
+				i++
+			}
+		case "--mode":
+			if i+1 < len(args) {
+				opts.mode = args[i+1]
+				i++
+			}
+		case "--work-dir":
+			if i+1 < len(args) {
+				opts.workDir = args[i+1]
+				i++
+			}
+		case "--max-messages":
+			if i+1 < len(args) {
+				opts.maxMessages, _ = strconv.Atoi(args[i+1])
+				i++
+			}
+		case "--timeout":
+			if i+1 < len(args) {
+				opts.timeoutMinutes, _ = strconv.Atoi(args[i+1])
+				i++
+			}
+		case "--join-timeout":
+			if i+1 < len(args) {
+				opts.joinTimeout, _ = strconv.Atoi(args[i+1])
+				i++
+			}
+		case "--agent":
+			if i+1 < len(args) {
+				opts.agent = args[i+1]
+				i++
+			}
+		case "--passphrase":
+			if i+1 < len(args) {
+				opts.passphrase = args[i+1]
+				i++
+			}
+		case "--api-url":
+			if i+1 < len(args) {
+				opts.apiURL = args[i+1]
+				i++
+			}
+		case "--transport":
+			opts.transportMode = true
+		default:
+			// Bare numeric argument for join command = discussion ID
+			if command == "join" && opts.discussionID == 0 {
+				if id, err := strconv.Atoi(args[i]); err == nil {
+					opts.discussionID = id
+				}
+			}
+		}
+	}
+
+	return opts
+}
+
+// buildChildArgs reconstructs the CLI arguments for the child transport
+// process, preserving all flags from the original invocation.
+func buildChildArgs(command string, opts *options) []string {
+	args := []string{command}
+	if opts.configPath != "" {
+		args = append(args, "--config", opts.configPath)
+	}
+	if opts.topic != "" {
+		args = append(args, "--topic", opts.topic)
+	}
+	for _, o := range opts.others {
+		args = append(args, "--other", o)
+	}
+	for _, o := range opts.optional {
+		args = append(args, "--optional", o)
+	}
+	if opts.context != "" {
+		args = append(args, "--context", opts.context)
+	}
+	if opts.contextFile != "" {
+		args = append(args, "--context-file", opts.contextFile)
+	}
+	if opts.mode != "" {
+		args = append(args, "--mode", opts.mode)
+	}
+	if opts.workDir != "" {
+		args = append(args, "--work-dir", opts.workDir)
+	}
+	if opts.maxMessages > 0 {
+		args = append(args, "--max-messages", strconv.Itoa(opts.maxMessages))
+	}
+	if opts.timeoutMinutes > 0 {
+		args = append(args, "--timeout", strconv.Itoa(opts.timeoutMinutes))
+	}
+	if opts.joinTimeout > 0 {
+		args = append(args, "--join-timeout", strconv.Itoa(opts.joinTimeout))
+	}
+	if opts.agent != "" {
+		args = append(args, "--agent", opts.agent)
+	}
+	if opts.passphrase != "" {
+		args = append(args, "--passphrase", opts.passphrase)
+	}
+	if opts.apiURL != "" {
+		args = append(args, "--api-url", opts.apiURL)
+	}
+	if opts.discussionID > 0 {
+		args = append(args, strconv.Itoa(opts.discussionID))
+	}
+	return args
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `Usage: discuss create --config .agent.json --topic "..." --other <agent>
+       discuss join --config .agent.json [discussion-id]
+
+Spawns a discussion transport as a background process, waits for the
+prompt file, and outputs its contents to stdout.
+
+Options:
+  --config <path>       Path to .agent.json
+  --topic <text>        Discussion topic (required for create)
+  --other <agent>       Required participant (repeatable)
+  --optional <agent>    Optional participant (repeatable)
+  --context <text>      Discussion context
+  --context-file <path> Read context from file
+  --mode <mode>         Discussion mode: realtime or async (default: realtime)
+  --work-dir <path>     Working directory base
+  --max-messages <n>    Max messages before timeout (default: 200)
+  --timeout <minutes>   Max duration in minutes (default: 120)
+  --join-timeout <sec>  Seconds to wait for invitation (default: 300)
+  --agent <name>        Override agent name from config
+  --passphrase <text>   Override passphrase from config
+  --api-url <url>       Override API URL from config
+`)
+}

--- a/go/client/internal/discuss/apiclient.go
+++ b/go/client/internal/discuss/apiclient.go
@@ -1,0 +1,240 @@
+package discuss
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// APIClient is an HTTP client for the memory API with session-based auth,
+// automatic retry with exponential backoff, and re-login on 401/403.
+// Unlike the shared api.Client (designed for short-lived sync operations),
+// this client is built for long-running transport sessions where network
+// hiccups and session expiry are expected.
+type APIClient struct {
+	baseURL    string
+	agent      string
+	passphrase string
+	token      string
+	httpClient *http.Client
+	logger     *Logger
+}
+
+// HTTPError represents a non-2xx response from the API.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+const (
+	maxRetries   = 3
+	baseDelayMs  = 1000
+)
+
+// retryable status codes — server-side issues worth retrying
+var retryableStatus = map[int]bool{502: true, 503: true, 504: true}
+
+// retryable network error substrings
+var retryableErrors = []string{
+	"connection reset",
+	"connection refused",
+	"i/o timeout",
+	"no such host",
+	"temporary failure",
+	"broken pipe",
+}
+
+// NewAPIClient creates a client but does not log in yet.
+// Call Login() before making authenticated requests.
+func NewAPIClient(baseURL, agent, passphrase string, logger *Logger) *APIClient {
+	return &APIClient{
+		baseURL:    baseURL,
+		agent:      agent,
+		passphrase: passphrase,
+		logger:     logger,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// Login authenticates with the API and stores the session token.
+func (c *APIClient) Login() error {
+	var resp struct {
+		SessionToken string `json:"session_token"`
+		ExpiresAt    string `json:"expires_at"`
+	}
+	err := c.postOnce("/agent/login", map[string]string{
+		"agent":      c.agent,
+		"passphrase": c.passphrase,
+		"subsystem":  "discussion",
+	}, &resp)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+	if resp.SessionToken == "" {
+		return fmt.Errorf("login failed: empty session_token")
+	}
+	c.token = resp.SessionToken
+	c.logger.Log("Logged in as %s (session expires %s)", c.agent, resp.ExpiresAt)
+	return nil
+}
+
+// Logout ends the API session. Non-fatal if it fails.
+func (c *APIClient) Logout() {
+	if c.token == "" {
+		return
+	}
+	c.Post("/agent/logout", map[string]string{"agent": c.agent}, nil)
+	c.logger.Log("Logged out")
+	c.token = ""
+}
+
+// Post sends an authenticated JSON POST with retry logic.
+// On 401/403, re-logs in and retries once.
+func (c *APIClient) Post(path string, body interface{}, result interface{}) error {
+	if c.token == "" {
+		return fmt.Errorf("not logged in — no session token")
+	}
+
+	err := c.postWithRetry(path, body, result)
+	if err == nil {
+		return nil
+	}
+
+	// Check for auth failure — re-login and retry once
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode == 401 || httpErr.StatusCode == 403 {
+			c.logger.Log("Session expired or invalid — re-logging in")
+			if loginErr := c.Login(); loginErr != nil {
+				return fmt.Errorf("re-login failed: %w", loginErr)
+			}
+			return c.postWithRetry(path, body, result)
+		}
+	}
+
+	return err
+}
+
+// PostNoAuth sends a JSON POST without authentication. Used for login
+// and health checks.
+func (c *APIClient) PostNoAuth(path string, body interface{}, result interface{}) error {
+	return c.postOnce(path, body, result)
+}
+
+// Get sends a simple GET request. Used for health checks.
+func (c *APIClient) Get(url string) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+	return nil
+}
+
+// postWithRetry wraps postOnce with exponential backoff retries for
+// transient network errors and 5xx responses.
+func (c *APIClient) postWithRetry(path string, body interface{}, result interface{}) error {
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		lastErr = c.postAuthOnce(path, body, result)
+		if lastErr == nil {
+			return nil
+		}
+		if attempt < maxRetries && isRetryable(lastErr) {
+			delay := time.Duration(baseDelayMs*(1<<attempt)) * time.Millisecond
+			c.logger.Log("Retryable error (attempt %d/%d): %s — retrying in %v",
+				attempt+1, maxRetries+1, lastErr, delay)
+			time.Sleep(delay)
+		}
+	}
+	return lastErr
+}
+
+// postAuthOnce sends a single authenticated POST request.
+func (c *APIClient) postAuthOnce(path string, body interface{}, result interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal body: %w", err)
+	}
+
+	url := c.baseURL + path
+	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response from %s: %w", path, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	if result != nil {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("decode response from %s: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+// postOnce sends a single unauthenticated POST request.
+func (c *APIClient) postOnce(path string, body interface{}, result interface{}) error {
+	savedToken := c.token
+	c.token = ""
+	err := c.postAuthOnce(path, body, result)
+	c.token = savedToken
+	return err
+}
+
+// isRetryable returns true if the error is a transient network issue
+// or server error worth retrying.
+func isRetryable(err error) bool {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return retryableStatus[httpErr.StatusCode]
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, substr := range retryableErrors {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/client/internal/discuss/config.go
+++ b/go/client/internal/discuss/config.go
@@ -1,0 +1,175 @@
+// Package discuss implements the discussion transport — a long-running
+// process that relays messages between a Claude subagent and the memory
+// API's chat system. It manages the full lifecycle: creating or joining
+// a discussion, waiting for participants, running the message polling
+// loop, convergence detection, and clean shutdown.
+package discuss
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// Config holds all settings for a discussion transport session.
+// Populated from CLI flags and .agent.json.
+type Config struct {
+	// Agent credentials (from .agent.json or CLI)
+	Agent      string
+	Passphrase string
+	APIURL     string
+
+	// Discussion parameters
+	Topic                string
+	Others               []string // required participants
+	OptionalParticipants []string // optional participants
+	Context              string   // discussion context text
+	ContextFile          string   // path to context file (read at startup)
+	Mode                 string   // "realtime" or "async"
+	Initiator            bool     // true if this agent created the discussion
+
+	// Limits
+	MaxMessages    int
+	TimeoutMinutes int
+	JoinTimeout    int // seconds to wait for pending invitation
+	MaxRounds      int // round-trips before convergence warning
+
+	// Paths
+	WorkDirBase string // base directory (discuss-<id> appended)
+	WorkDir     string // full path including discuss-<id>
+
+	// Transport tuning
+	PollInterval      time.Duration
+	SendDelay         time.Duration
+	ResultTimeout     int // seconds to wait for result.md before shutdown
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+// Agent credentials must still be set from .agent.json or CLI flags.
+func DefaultConfig() *Config {
+	return &Config{
+		Mode:           "realtime",
+		MaxMessages:    200,
+		TimeoutMinutes: 120,
+		JoinTimeout:    300,
+		MaxRounds:      20,
+		PollInterval:   5 * time.Second,
+		SendDelay:      3 * time.Second,
+		ResultTimeout:  60,
+	}
+}
+
+// LoadAgentConfig reads .agent.json and populates the Config's
+// agent credentials and work directory (if not already set via CLI).
+func (c *Config) LoadAgentConfig(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read config %s: %w", path, err)
+	}
+
+	var raw struct {
+		Agent      string `json:"agent"`
+		Passphrase string `json:"passphrase"`
+		APIURL     string `json:"api_url"`
+		WorkDir    string `json:"work_dir"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("failed to parse config %s: %w", path, err)
+	}
+
+	// CLI flags take precedence — only fill in blanks
+	if c.Agent == "" {
+		c.Agent = raw.Agent
+	}
+	if c.Passphrase == "" {
+		c.Passphrase = raw.Passphrase
+	}
+	if c.APIURL == "" {
+		c.APIURL = raw.APIURL
+	}
+	if c.WorkDirBase == "" && raw.WorkDir != "" {
+		c.WorkDirBase = raw.WorkDir
+	}
+
+	return nil
+}
+
+// Validate checks that required fields are set.
+func (c *Config) Validate() error {
+	if c.Agent == "" {
+		return fmt.Errorf("missing agent name (set in .agent.json or via --agent)")
+	}
+	if c.Passphrase == "" {
+		return fmt.Errorf("missing passphrase (set in .agent.json or via --passphrase)")
+	}
+	if c.APIURL == "" {
+		return fmt.Errorf("missing api_url (set in .agent.json or via --api-url)")
+	}
+	return nil
+}
+
+// SetWorkDir sets the full working directory path based on the discussion ID.
+// Falls back to os.TempDir()/llm if no base was configured.
+func (c *Config) SetWorkDir(discussionID int) {
+	base := c.WorkDirBase
+	if base == "" {
+		base = filepath.Join(os.TempDir(), "llm")
+	}
+	c.WorkDir = filepath.Join(base, fmt.Sprintf("discuss-%d", discussionID))
+}
+
+// OtherAgents returns the combined list of required and optional participants
+// (excluding self).
+func (c *Config) OtherAgents() []string {
+	result := make([]string, 0, len(c.Others)+len(c.OptionalParticipants))
+	result = append(result, c.Others...)
+	result = append(result, c.OptionalParticipants...)
+	return result
+}
+
+// ApplyServerConfig fetches config from the API and applies values
+// that weren't already set via CLI flags. This lets the server provide
+// defaults for things like discussion timeouts and max rounds.
+func ApplyServerConfig(client *APIClient, cfg *Config, logger *Logger) {
+	var resp struct {
+		Config map[string]string `json:"config"`
+	}
+	if err := client.Post("/agent/config", map[string]interface{}{}, &resp); err != nil {
+		logger.Log("WARNING: Could not fetch server config: %s — using defaults", err)
+		return
+	}
+
+	if v, ok := resp.Config["discussion_end_timeout_realtime"]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.ResultTimeout = n
+			logger.Log("Server config: result timeout = %ds", n)
+		}
+	} else {
+		logger.Log("WARNING: discussion_end_timeout_realtime not configured on server, using default %ds", cfg.ResultTimeout)
+	}
+
+	if v, ok := resp.Config["discussion_maxrounds"]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxRounds = n
+			logger.Log("Server config: max rounds = %d", n)
+		}
+	} else {
+		logger.Log("WARNING: discussion_maxrounds not configured on server, using default %d", cfg.MaxRounds)
+	}
+}
+
+// LoadContext reads the context file (if set) into c.Context.
+func (c *Config) LoadContext() error {
+	if c.ContextFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(c.ContextFile)
+	if err != nil {
+		return fmt.Errorf("failed to read context file %s: %w", c.ContextFile, err)
+	}
+	c.Context = string(data)
+	return nil
+}

--- a/go/client/internal/discuss/convergence.go
+++ b/go/client/internal/discuss/convergence.go
@@ -1,0 +1,279 @@
+package discuss
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Convergence states — escalating ladder from normal operation to
+// forced termination when agents can't reach agreement.
+const (
+	StateNormal     = "normal"
+	StateWarned     = "warned"
+	StateForcedVote = "forced-vote"
+	StateCountdown  = "countdown"
+	StateTerminated = "terminated"
+)
+
+// Thresholds for convergence escalation
+const (
+	VoteSilenceThreshold      = 10 // exchanges without any vote triggers secondary signal
+	RejectedConcludeThreshold = 2  // rejected concludes triggers escalation
+)
+
+// Convergence tracks discussion convergence state and detects when
+// agents are stuck in loops or can't reach agreement.
+type Convergence struct {
+	State                  string
+	RoundTripCount         int
+	RoundTripSpeakers      map[string]bool // agents who've spoken in current round-trip
+	ExchangesSinceLastVote int             // messages since last vote activity
+	RejectedConcludeCount  int             // consecutive rejected conclude votes
+	ExchangesSinceWarning  int             // messages since convergence warning
+	ExchangesSinceForcedVote int           // messages since forced conclude vote
+	ForcedVoteID           *int            // vote ID of transport-proposed conclude
+	ProcessedImpasseVotes  map[int]bool    // vote IDs already surfaced as impasses
+
+	maxRounds    int
+	participants []string // all participant names
+	logger       *Logger
+	paths        *Paths
+}
+
+// NewConvergence creates a convergence tracker for the given participants.
+func NewConvergence(participants []string, maxRounds int, logger *Logger, paths *Paths) *Convergence {
+	return &Convergence{
+		State:                 StateNormal,
+		RoundTripSpeakers:     make(map[string]bool),
+		ProcessedImpasseVotes: make(map[int]bool),
+		maxRounds:             maxRounds,
+		participants:          participants,
+		logger:                logger,
+		paths:                 paths,
+	}
+}
+
+// TrackMessage is called when a message is sent or received from any agent.
+func (c *Convergence) TrackMessage(speaker string) {
+	c.ExchangesSinceLastVote++
+	if c.State == StateWarned {
+		c.ExchangesSinceWarning++
+	}
+	if c.State == StateCountdown {
+		c.ExchangesSinceForcedVote++
+	}
+
+	// Track round-trip: completes when all participants have spoken
+	c.RoundTripSpeakers[speaker] = true
+	if len(c.RoundTripSpeakers) >= len(c.participants) {
+		c.RoundTripCount++
+		c.RoundTripSpeakers = make(map[string]bool)
+		c.logger.Log("Round-trip #%d completed (max: %d)", c.RoundTripCount, c.maxRounds)
+	}
+}
+
+// TrackVoteActivity resets the vote-silence counter when any vote is
+// proposed or cast.
+func (c *Convergence) TrackVoteActivity() {
+	c.ExchangesSinceLastVote = 0
+}
+
+// TrackConcludeRejected increments the rejected conclude counter.
+func (c *Convergence) TrackConcludeRejected() {
+	c.RejectedConcludeCount++
+	c.logger.Log("Conclude vote rejected (%d/%d)", c.RejectedConcludeCount, RejectedConcludeThreshold)
+}
+
+// CheckForImpasse detects split general votes and injects an impasse
+// message telling agents to write a structured summary for the user.
+func (c *Convergence) CheckForImpasse(voteResult *VoteStatusResponse) {
+	if voteResult == nil || voteResult.Vote.Status != "closed" || voteResult.Vote.Type == "conclude" {
+		return
+	}
+	if c.ProcessedImpasseVotes[voteResult.Vote.ID] {
+		return
+	}
+	c.ProcessedImpasseVotes[voteResult.Vote.ID] = true
+
+	// Check if the vote split
+	choices := make(map[int]bool)
+	for _, b := range voteResult.Ballots {
+		choices[b.Choice] = true
+	}
+	if len(choices) <= 1 {
+		return // unanimous
+	}
+
+	c.logger.Log("IMPASSE DETECTED: vote #%d split (%d different choices across %d ballots)",
+		voteResult.Vote.ID, len(choices), len(voteResult.Ballots))
+
+	var lines []string
+	for _, b := range voteResult.Ballots {
+		reason := ""
+		if b.Reason != "" {
+			reason = ": " + b.Reason
+		}
+		lines = append(lines, fmt.Sprintf("  - %s voted %d%s", b.Agent, b.Choice, reason))
+	}
+
+	message := fmt.Sprintf("[SYSTEM] Impasse detected: Vote #%d split — no unanimous agreement.\n%s\n\n"+
+		"This disagreement will be surfaced to the user for their decision. "+
+		"Before concluding, write a structured summary with:\n"+
+		"1. Each position's pros and cons (balanced, not advocating)\n"+
+		"2. What you agreed on\n"+
+		"3. The specific point of disagreement\n"+
+		"4. Your recommendation (if any) with reasoning\n\n"+
+		"Then propose a conclude vote.",
+		voteResult.Vote.ID, strings.Join(lines, "\n"))
+
+	c.InjectSystemMessage(message)
+}
+
+// InjectSystemMessage writes a [SYSTEM] message into the subagent's inbox.
+func (c *Convergence) InjectSystemMessage(message string) {
+	filename := fmt.Sprintf("system-%d.txt", time.Now().UnixMilli())
+	content := fmt.Sprintf("From: system\nSent: %s\n\n%s", time.Now().UTC().Format(time.RFC3339), message)
+	c.paths.WriteInboxFile(filename, content)
+	c.paths.AppendTranscript("system", message)
+	c.logger.Log("SYSTEM MESSAGE INJECTED: %.100s...", message)
+}
+
+// Check evaluates convergence signals and escalates if needed.
+// Returns "continue" or "terminate". The client parameter is needed
+// for proposing forced votes.
+func (c *Convergence) Check(client *APIClient, discussionID int, agent string) string {
+	if c.State == StateTerminated {
+		return "terminate"
+	}
+	if c.paths.IsDone() {
+		return "continue"
+	}
+
+	shouldEscalate :=
+		(c.State == StateNormal && c.RoundTripCount >= c.maxRounds) ||
+			(c.State == StateNormal && c.RejectedConcludeCount >= RejectedConcludeThreshold) ||
+			(c.State == StateNormal && c.ExchangesSinceLastVote >= VoteSilenceThreshold && c.RoundTripCount >= c.maxRounds/2)
+
+	if shouldEscalate && c.State == StateNormal {
+		return c.escalateToWarned()
+	}
+
+	if c.State == StateWarned && c.ExchangesSinceWarning >= 3 {
+		return c.escalateToForcedVote(client, discussionID, agent)
+	}
+
+	if c.State == StateForcedVote && c.ForcedVoteID != nil {
+		return c.checkForcedVote(client, agent)
+	}
+
+	if c.State == StateCountdown && c.ExchangesSinceForcedVote >= 2 {
+		return c.escalateToTerminated()
+	}
+
+	return "continue"
+}
+
+func (c *Convergence) escalateToWarned() string {
+	c.State = StateWarned
+	c.ExchangesSinceWarning = 0
+
+	var reason string
+	if c.RoundTripCount >= c.maxRounds {
+		reason = fmt.Sprintf("%d round-trips without resolution", c.RoundTripCount)
+	} else if c.RejectedConcludeCount >= RejectedConcludeThreshold {
+		reason = fmt.Sprintf("%d conclude votes rejected", c.RejectedConcludeCount)
+	} else {
+		reason = fmt.Sprintf("%d exchanges without a vote", c.ExchangesSinceLastVote)
+	}
+
+	warning := fmt.Sprintf("[SYSTEM] Convergence warning: This discussion has reached %s. "+
+		"Please propose a vote, concede a point, or identify the exact disagreement. "+
+		"Continuing to restate positions will trigger escalation.", reason)
+	c.InjectSystemMessage(warning)
+	c.logger.Log("CONVERGENCE: escalated to 'warned' (%s)", reason)
+	return "continue"
+}
+
+func (c *Convergence) escalateToForcedVote(client *APIClient, discussionID int, agent string) string {
+	c.State = StateForcedVote
+	c.ExchangesSinceForcedVote = 0
+	c.logger.Log("CONVERGENCE: grace period expired, proposing forced conclude vote")
+
+	var result struct {
+		Vote struct {
+			ID int `json:"id"`
+		} `json:"vote"`
+	}
+	err := client.Post("/discussion/vote/propose", map[string]interface{}{
+		"discussion_id": discussionID,
+		"proposed_by":   agent,
+		"question":      "[SYSTEM] Forced conclude: discussion has not converged after warning. 1=conclude 2=continue",
+		"type":          "conclude",
+		"threshold":     "majority",
+	}, &result)
+	if err != nil {
+		c.logger.Log("Failed to propose forced conclude: %s", err)
+		c.State = StateCountdown
+		c.ExchangesSinceForcedVote = 0
+		return "continue"
+	}
+
+	id := result.Vote.ID
+	c.ForcedVoteID = &id
+	c.InjectSystemMessage(fmt.Sprintf("[SYSTEM] A forced conclude vote has been proposed (vote #%d). "+
+		"Vote to conclude or continue. If this vote fails, the discussion will be terminated shortly.", id))
+
+	return "continue"
+}
+
+func (c *Convergence) checkForcedVote(client *APIClient, agent string) string {
+	var result VoteStatusResponse
+	err := client.Post("/discussion/vote/status", map[string]interface{}{
+		"vote_id": *c.ForcedVoteID,
+	}, &result)
+	if err != nil {
+		c.logger.Log("Forced vote status check failed: %s", err)
+	} else {
+		if result.Vote.Status == "passed" {
+			c.logger.Log("CONVERGENCE: forced conclude vote passed")
+			return "continue"
+		}
+		if result.Vote.Status == "failed" {
+			c.logger.Log("CONVERGENCE: forced conclude vote rejected — entering countdown")
+			c.State = StateCountdown
+			c.ExchangesSinceForcedVote = 0
+			c.InjectSystemMessage("[SYSTEM] Final warning: The forced conclude vote was rejected. " +
+				"You have 2 more exchanges to reach agreement before this discussion is terminated.")
+			return "continue"
+		}
+	}
+
+	// Vote still open — give it time
+	if c.ExchangesSinceForcedVote >= 4 {
+		c.State = StateCountdown
+		c.ExchangesSinceForcedVote = 0
+		c.InjectSystemMessage("[SYSTEM] Final warning: forced conclude vote timed out. " +
+			"You have 2 more exchanges to reach agreement before this discussion is terminated.")
+	}
+	return "continue"
+}
+
+func (c *Convergence) escalateToTerminated() string {
+	c.State = StateTerminated
+	c.logger.Log("CONVERGENCE: terminated — discussion did not converge")
+	c.InjectSystemMessage("[SYSTEM] This discussion has been terminated due to failure to converge. " +
+		"Please write your result.md summarizing what was agreed and what remains unresolved.")
+	return "terminate"
+}
+
+// Info returns the convergence state for the state file.
+func (c *Convergence) Info() ConvergenceInfo {
+	return ConvergenceInfo{
+		State:                  c.State,
+		RoundTrips:             c.RoundTripCount,
+		MaxRounds:              c.maxRounds,
+		ExchangesSinceLastVote: c.ExchangesSinceLastVote,
+		RejectedConcludes:      c.RejectedConcludeCount,
+	}
+}

--- a/go/client/internal/discuss/files.go
+++ b/go/client/internal/discuss/files.go
@@ -1,0 +1,358 @@
+package discuss
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Paths holds all file/directory paths derived from the working directory.
+type Paths struct {
+	Inbox          string
+	Outbox         string
+	LogFile        string
+	StateFile      string
+	DoneFile       string
+	TranscriptFile string
+	IdleTimeoutFile string
+	PromptFile     string
+	PollScript     string
+	LockDir        string
+	LockInfoFile   string
+	ResultFile     string
+}
+
+// InitPaths creates a Paths struct from the working directory.
+func InitPaths(workDir string) *Paths {
+	lockDir := filepath.Join(workDir, ".lock")
+	return &Paths{
+		Inbox:           filepath.Join(workDir, "inbox"),
+		Outbox:          filepath.Join(workDir, "outbox"),
+		LogFile:         filepath.Join(workDir, "conversation.log"),
+		StateFile:       filepath.Join(workDir, "state.json"),
+		DoneFile:        filepath.Join(workDir, "done"),
+		TranscriptFile:  filepath.Join(workDir, "transcript.md"),
+		IdleTimeoutFile: filepath.Join(workDir, "idle-timeout"),
+		PromptFile:      filepath.Join(workDir, "prompt.txt"),
+		PollScript:      filepath.Join(workDir, "poll.sh"),
+		LockDir:         lockDir,
+		LockInfoFile:    filepath.Join(lockDir, "info.json"),
+		ResultFile:      filepath.Join(workDir, "result.md"),
+	}
+}
+
+// EnsureDirectories creates the inbox and outbox directories.
+func (p *Paths) EnsureDirectories() error {
+	if err := os.MkdirAll(p.Inbox, 0755); err != nil {
+		return fmt.Errorf("create inbox: %w", err)
+	}
+	if err := os.MkdirAll(p.Outbox, 0755); err != nil {
+		return fmt.Errorf("create outbox: %w", err)
+	}
+	return nil
+}
+
+// CleanWorkDir removes stale files from a previous run. Does NOT touch
+// state.json, .lock, or transcript.md — those have their own lifecycle.
+func (p *Paths) CleanWorkDir() {
+	// Clear inbox and outbox contents
+	for _, dir := range []string{p.Inbox, p.Outbox} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+
+	// Remove stale control/log files
+	staleFiles := []string{"done", "idle-timeout", "subagent.log", "conversation.log"}
+	workDir := filepath.Dir(p.LogFile)
+	for _, name := range staleFiles {
+		os.Remove(filepath.Join(workDir, name))
+	}
+}
+
+// IsDone returns true if the done file exists.
+func (p *Paths) IsDone() bool {
+	_, err := os.Stat(p.DoneFile)
+	return err == nil
+}
+
+// IsIdleTimeout returns true if the idle-timeout file exists.
+func (p *Paths) IsIdleTimeout() bool {
+	_, err := os.Stat(p.IdleTimeoutFile)
+	return err == nil
+}
+
+// WriteDone creates the done file with the given reason.
+func (p *Paths) WriteDone(reason string) error {
+	return os.WriteFile(p.DoneFile, []byte(reason), 0644)
+}
+
+// WriteInboxFile writes a message file to the inbox directory.
+func (p *Paths) WriteInboxFile(filename, content string) error {
+	return os.WriteFile(filepath.Join(p.Inbox, filename), []byte(content), 0644)
+}
+
+// ReadInboxFiles returns the list of .txt files in the inbox directory.
+func (p *Paths) ReadInboxFiles() []string {
+	entries, err := os.ReadDir(p.Inbox)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".txt") {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+// InboxFileExists returns true if a specific inbox file exists.
+func (p *Paths) InboxFileExists(filename string) bool {
+	_, err := os.Stat(filepath.Join(p.Inbox, filename))
+	return err == nil
+}
+
+// CheckOutbox reads and removes the first .txt file from the outbox.
+// Returns the file content and true if a file was found, or empty string
+// and false if the outbox is empty.
+func (p *Paths) CheckOutbox() (string, bool) {
+	entries, err := os.ReadDir(p.Outbox)
+	if err != nil {
+		return "", false
+	}
+
+	var files []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".txt") {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files)
+
+	for _, f := range files {
+		path := filepath.Join(p.Outbox, f)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		os.Remove(path)
+		msg := string(data)
+		if strings.TrimSpace(msg) != "" {
+			return msg, true
+		}
+	}
+
+	return "", false
+}
+
+// WritePollScript writes the bash polling script that the subagent
+// uses to wait for new inbox messages or control signals.
+func (p *Paths) WritePollScript(workDir string) {
+	// Use forward slashes for bash compatibility on Windows
+	wd := filepath.ToSlash(workDir)
+	script := fmt.Sprintf(`#!/bin/bash
+# Poll for new inbox messages, done file, or idle timeout.
+# Outputs: NEW_MESSAGES, DONE, or IDLE_TIMEOUT
+idle_count=0
+while true; do
+  files=$(ls %s/inbox/*.txt 2>/dev/null)
+  if [ -n "$files" ]; then echo "NEW_MESSAGES"; echo "$files"; break; fi
+  if [ -f %s/done ]; then echo "DONE"; break; fi
+  idle_count=$((idle_count + 1))
+  if [ $idle_count -ge 60 ]; then echo "IDLE_TIMEOUT"; break; fi
+  sleep 5
+done
+`, wd, wd)
+	os.WriteFile(p.PollScript, []byte(script), 0755)
+}
+
+// --- State file ---
+
+// TransportState is the JSON structure persisted to state.json.
+type TransportState struct {
+	Status          string          `json:"status"`
+	PID             int             `json:"pid"`
+	Port            int             `json:"port"`
+	Heartbeat       string          `json:"heartbeat"`
+	TurnCount       int             `json:"turnCount"`
+	LastDeliveredID int             `json:"lastDeliveredId"`
+	SeenIDs         []int           `json:"seenIds"`
+	Ready           bool            `json:"ready"`
+	StartedAt       string          `json:"startedAt"`
+	Convergence     ConvergenceInfo `json:"convergence"`
+}
+
+// ConvergenceInfo is the convergence section of the state file.
+type ConvergenceInfo struct {
+	State                 string `json:"state"`
+	RoundTrips            int    `json:"roundTrips"`
+	MaxRounds             int    `json:"maxRounds"`
+	ExchangesSinceLastVote int   `json:"exchangesSinceLastVote"`
+	RejectedConcludes     int    `json:"rejectedConcludes"`
+}
+
+// WriteState atomically writes the state file.
+func (p *Paths) WriteState(state *TransportState) {
+	state.Heartbeat = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := p.StateFile + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return
+	}
+	os.Rename(tmp, p.StateFile)
+}
+
+// ReadState reads the state file. Returns nil if it doesn't exist or
+// can't be parsed.
+func (p *Paths) ReadState() *TransportState {
+	data, err := os.ReadFile(p.StateFile)
+	if err != nil {
+		return nil
+	}
+	var state TransportState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil
+	}
+	return &state
+}
+
+// --- Lock file ---
+
+// lockInfo is the JSON written inside the lock directory.
+type lockInfo struct {
+	PID     int   `json:"pid"`
+	Started int64 `json:"started"`
+}
+
+const lockStaleMs = 30000
+
+// AcquireLock prevents two transport instances from running for the
+// same discussion. Uses a PID lockfile inside a lock directory.
+func (p *Paths) AcquireLock() error {
+	err := os.Mkdir(p.LockDir, 0755)
+	if err == nil {
+		// Successfully created — write lock info
+		return p.writeLockInfo()
+	}
+
+	if !os.IsExist(err) {
+		return fmt.Errorf("create lock dir: %w", err)
+	}
+
+	// Lock dir exists — check if stale via mtime
+	info, statErr := os.Stat(p.LockInfoFile)
+	if statErr == nil {
+		age := time.Since(info.ModTime())
+		if age.Milliseconds() < lockStaleMs {
+			// Lock is fresh — read PID for error message
+			data, _ := os.ReadFile(p.LockInfoFile)
+			var li lockInfo
+			json.Unmarshal(data, &li)
+			return fmt.Errorf("another transport (PID %d) is already running", li.PID)
+		}
+	}
+
+	// Stale lock — clean up and recreate
+	os.Remove(p.LockInfoFile)
+	os.Remove(p.LockDir)
+	if err := os.Mkdir(p.LockDir, 0755); err != nil {
+		return fmt.Errorf("recreate lock dir: %w", err)
+	}
+	return p.writeLockInfo()
+}
+
+func (p *Paths) writeLockInfo() error {
+	li := lockInfo{PID: os.Getpid(), Started: time.Now().UnixMilli()}
+	data, _ := json.Marshal(li)
+	return os.WriteFile(p.LockInfoFile, data, 0644)
+}
+
+// TouchLock updates the mtime on the lock info file so it doesn't
+// appear stale to other instances.
+func (p *Paths) TouchLock() {
+	now := time.Now()
+	os.Chtimes(p.LockInfoFile, now, now)
+}
+
+// ReleaseLock removes the lock directory.
+func (p *Paths) ReleaseLock() {
+	os.Remove(p.LockInfoFile)
+	os.Remove(p.LockDir)
+}
+
+// --- Transcript ---
+
+// InitTranscript creates the transcript file with a header.
+func (p *Paths) InitTranscript(agent string, others []string) {
+	header := fmt.Sprintf("# Discussion: %s <-> %s\n\nStarted: %s\n\n---\n\n",
+		agent,
+		strings.Join(others, ", "),
+		time.Now().UTC().Format("2006-01-02 15:04:05"),
+	)
+	os.WriteFile(p.TranscriptFile, []byte(header), 0644)
+}
+
+// AppendTranscript adds a timestamped speaker entry to the transcript.
+func (p *Paths) AppendTranscript(speaker, message string) {
+	ts := time.Now().Format("15:04:05")
+	entry := fmt.Sprintf("**%s** (%s):\n%s\n\n", speaker, ts, message)
+	f, err := os.OpenFile(p.TranscriptFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.WriteString(entry)
+}
+
+// --- Stale PID cleanup ---
+
+// KillStalePID reads a previous state.json and kills the process if
+// it's still alive.
+func (p *Paths) KillStalePID() {
+	prev := p.ReadState()
+	if prev == nil || prev.PID == 0 || prev.PID == os.Getpid() {
+		return
+	}
+	proc, err := os.FindProcess(prev.PID)
+	if err != nil {
+		return
+	}
+	// Check if alive (signal 0 doesn't kill, just checks)
+	if err := proc.Signal(nil); err != nil {
+		return // Not running
+	}
+	proc.Kill()
+}
+
+// --- Helpers ---
+
+// MessageSize returns the size of a message in KB.
+func MessageSize(msg string) string {
+	kb := float64(len(msg)) / 1024.0
+	return fmt.Sprintf("%.1f", kb)
+}
+
+// ParseInboxID extracts the numeric message ID from an inbox filename
+// like "42.txt". Returns -1 if the filename doesn't match.
+func ParseInboxID(filename string) int {
+	name := strings.TrimSuffix(filename, ".txt")
+	id, err := strconv.Atoi(name)
+	if err != nil {
+		return -1
+	}
+	return id
+}

--- a/go/client/internal/discuss/lifecycle.go
+++ b/go/client/internal/discuss/lifecycle.go
@@ -1,0 +1,301 @@
+package discuss
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// --- API response types ---
+
+type discussionResponse struct {
+	Discussion struct {
+		ID        int    `json:"id"`
+		Status    string `json:"status"`
+		Topic     string `json:"topic"`
+		Channel   string `json:"channel"`
+		Context   string `json:"context"`
+		Mode      string `json:"mode"`
+		TimeoutAt string `json:"timeout_at"`
+	} `json:"discussion"`
+}
+
+type joinResponse struct {
+	DiscussionStatus string `json:"discussion_status"`
+}
+
+type pendingResponse struct {
+	InvitedDiscussions []struct {
+		ID     int    `json:"id"`
+		Topic  string `json:"topic"`
+		Status string `json:"status"`
+	} `json:"invited_discussions"`
+	OpenVotes []struct {
+		ID        int    `json:"id"`
+		Type      string `json:"type"`
+		Threshold string `json:"threshold"`
+		Question  string `json:"question"`
+	} `json:"open_votes"`
+}
+
+type statusResponse struct {
+	Discussion struct {
+		ID      int    `json:"id"`
+		Status  string `json:"status"`
+		Topic   string `json:"topic"`
+		Channel string `json:"channel"`
+		Context string `json:"context"`
+		Mode    string `json:"mode"`
+	} `json:"discussion"`
+	Participants []struct {
+		Agent  string `json:"agent"`
+		Status string `json:"status"`
+	} `json:"participants"`
+}
+
+// SetupCreate creates a new discussion and returns the discussion ID.
+// If the server returns a conflict (agent already in a discussion),
+// it attempts to resolve it by joining or leaving the stale discussion.
+func SetupCreate(client *APIClient, cfg *Config, logger *Logger) (int, error) {
+	if err := cfg.LoadContext(); err != nil {
+		return 0, err
+	}
+
+	participants := append([]string{cfg.Agent}, cfg.Others...)
+
+	createBody := map[string]interface{}{
+		"topic":        cfg.Topic,
+		"participants": participants,
+		"created_by":   cfg.Agent,
+		"mode":         cfg.Mode,
+	}
+	if cfg.Context != "" {
+		createBody["context"] = cfg.Context
+	}
+	if len(cfg.OptionalParticipants) > 0 {
+		createBody["optional_participants"] = cfg.OptionalParticipants
+	}
+
+	var resp discussionResponse
+	err := client.Post("/discussion/create", createBody, &resp)
+
+	if err != nil {
+		// Check for DISCUSSION_CONFLICT — agent is already in another discussion
+		if !strings.Contains(err.Error(), "DISCUSSION_CONFLICT") {
+			return 0, fmt.Errorf("create discussion: %w", err)
+		}
+
+		return handleConflict(client, cfg, logger, err, createBody)
+	}
+
+	logger.Log("Created discussion #%d: %s (status: %s)",
+		resp.Discussion.ID, cfg.Topic, resp.Discussion.Status)
+	logger.Log("Channel: discussion-%d, timeout_at: %s",
+		resp.Discussion.ID, resp.Discussion.TimeoutAt)
+
+	return resp.Discussion.ID, nil
+}
+
+// handleConflict resolves a DISCUSSION_CONFLICT by checking the stale
+// discussion's status and either joining it or leaving it and retrying.
+func handleConflict(client *APIClient, cfg *Config, logger *Logger, conflictErr error, createBody map[string]interface{}) (int, error) {
+	// Extract discussion ID from error message
+	msg := conflictErr.Error()
+	var staleID int
+	if _, err := fmt.Sscanf(extractAfter(msg, "discussion #"), "%d", &staleID); err != nil || staleID == 0 {
+		return 0, fmt.Errorf("create discussion: %w", conflictErr)
+	}
+
+	logger.Log("Create rejected — already in discussion #%d", staleID)
+
+	// Check the stale discussion's status
+	var statusResp statusResponse
+	var staleStatus string
+	if err := client.Post("/discussion/status", map[string]interface{}{
+		"discussion_id": staleID,
+	}, &statusResp); err != nil {
+		logger.Log("Could not check status of #%d: %s", staleID, err)
+	} else {
+		staleStatus = statusResp.Discussion.Status
+		logger.Log("Discussion #%d status: %s", staleID, staleStatus)
+	}
+
+	// If the stale discussion is dead, leave and retry
+	if staleStatus != "" && staleStatus != "waiting" && staleStatus != "active" {
+		logger.Log("Discussion #%d is %s — leaving and retrying create", staleID, staleStatus)
+		leaveDiscussion(client, staleID, cfg.Agent, logger)
+	} else {
+		// Still active/waiting — try to join
+		logger.Log("Discussion #%d is still %s — trying to join", staleID, staleStatus)
+		id, err := SetupJoin(client, cfg, logger, staleID)
+		if err == nil {
+			return id, nil
+		}
+		logger.Log("Join #%d failed (%s), leaving and retrying create", staleID, err)
+		leaveDiscussion(client, staleID, cfg.Agent, logger)
+	}
+
+	// Retry create after clearing
+	var resp discussionResponse
+	if err := client.Post("/discussion/create", createBody, &resp); err != nil {
+		return 0, fmt.Errorf("retry create after clearing #%d: %w", staleID, err)
+	}
+
+	logger.Log("Created discussion #%d (after clearing stale #%d)", resp.Discussion.ID, staleID)
+	return resp.Discussion.ID, nil
+}
+
+// SetupJoin joins an existing discussion and populates cfg with the
+// discussion's details.
+func SetupJoin(client *APIClient, cfg *Config, logger *Logger, discussionID int) (int, error) {
+	// Fetch discussion details
+	var statusResp statusResponse
+	if err := client.Post("/discussion/status", map[string]interface{}{
+		"discussion_id": discussionID,
+	}, &statusResp); err != nil {
+		return 0, fmt.Errorf("get discussion status: %w", err)
+	}
+
+	cfg.Topic = statusResp.Discussion.Topic
+	if statusResp.Discussion.Context != "" && cfg.Context == "" {
+		cfg.Context = statusResp.Discussion.Context
+	}
+	if statusResp.Discussion.Mode != "" {
+		cfg.Mode = statusResp.Discussion.Mode
+	}
+
+	// Load context file if specified (overrides server context)
+	if err := cfg.LoadContext(); err != nil {
+		return 0, err
+	}
+
+	// Find other participants
+	var others []string
+	for _, p := range statusResp.Participants {
+		if p.Agent != cfg.Agent {
+			others = append(others, p.Agent)
+		}
+	}
+	cfg.Others = others
+
+	// Join the discussion
+	var joinResp joinResponse
+	if err := client.Post("/discussion/join", map[string]interface{}{
+		"discussion_id": discussionID,
+		"agent":         cfg.Agent,
+	}, &joinResp); err != nil {
+		return 0, fmt.Errorf("join discussion: %w", err)
+	}
+
+	logger.Log("Joined discussion #%d: %s (status: %s)",
+		discussionID, cfg.Topic, joinResp.DiscussionStatus)
+	logger.Log("Channel: discussion-%d, Others: %s",
+		discussionID, strings.Join(others, ", "))
+
+	return discussionID, nil
+}
+
+// AutoDiscoverDiscussion polls for pending invitations until one is found
+// or the timeout expires. Returns the discussion ID.
+func AutoDiscoverDiscussion(client *APIClient, cfg *Config, logger *Logger) (int, error) {
+	pollInterval := 5 * time.Second
+	maxAttempts := int(time.Duration(cfg.JoinTimeout) * time.Second / pollInterval)
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var pending pendingResponse
+		if err := client.Post("/discussion/pending", map[string]interface{}{
+			"agent": cfg.Agent,
+		}, &pending); err != nil {
+			return 0, fmt.Errorf("check pending: %w", err)
+		}
+
+		if len(pending.InvitedDiscussions) > 0 {
+			if len(pending.InvitedDiscussions) > 1 {
+				logger.Log("Multiple pending invitations:")
+				for _, inv := range pending.InvitedDiscussions {
+					logger.Log("  #%d: %s (%s)", inv.ID, inv.Topic, inv.Status)
+				}
+				return 0, fmt.Errorf("multiple pending invitations — specify a discussion ID")
+			}
+			logger.Log("Auto-discovered pending invitation: discussion #%d",
+				pending.InvitedDiscussions[0].ID)
+			return pending.InvitedDiscussions[0].ID, nil
+		}
+
+		if attempt == maxAttempts {
+			return 0, fmt.Errorf("no pending invitations after %ds", cfg.JoinTimeout)
+		}
+
+		logger.Log("No invitations yet, retrying (%d/%d)...", attempt, maxAttempts)
+		time.Sleep(pollInterval)
+	}
+
+	return 0, fmt.Errorf("no pending invitations")
+}
+
+// WaitForReady polls the discussion status until it transitions from
+// "waiting" to "active" (all participants joined).
+func WaitForReady(client *APIClient, discussionID int, cfg *Config, logger *Logger) error {
+	var statusResp statusResponse
+	if err := client.Post("/discussion/status", map[string]interface{}{
+		"discussion_id": discussionID,
+	}, &statusResp); err != nil {
+		return fmt.Errorf("check discussion status: %w", err)
+	}
+
+	if statusResp.Discussion.Status == "active" {
+		logger.Log("Discussion is already active")
+		return nil
+	}
+	if statusResp.Discussion.Status != "waiting" {
+		return fmt.Errorf("discussion is %s — cannot start transport", statusResp.Discussion.Status)
+	}
+
+	logger.Log("Discussion is waiting for participants...")
+
+	for {
+		time.Sleep(cfg.PollInterval)
+
+		if err := client.Post("/discussion/status", map[string]interface{}{
+			"discussion_id": discussionID,
+		}, &statusResp); err != nil {
+			logger.Log("Status check error: %s", err)
+			continue
+		}
+
+		switch statusResp.Discussion.Status {
+		case "active":
+			logger.Log("Discussion is now active — all participants ready")
+			return nil
+		case "timed_out":
+			return fmt.Errorf("discussion timed out waiting for required participants")
+		case "concluded", "cancelled":
+			return fmt.Errorf("discussion was %s before it started", statusResp.Discussion.Status)
+		}
+	}
+}
+
+// leaveDiscussion is a helper that leaves a discussion silently.
+func leaveDiscussion(client *APIClient, id int, agent string, logger *Logger) {
+	err := client.Post("/discussion/leave", map[string]interface{}{
+		"discussion_id": id,
+		"agent":         agent,
+	}, nil)
+	if err != nil {
+		logger.Log("Leave #%d failed: %s", id, err)
+	} else {
+		logger.Log("Left stale discussion #%d", id)
+	}
+}
+
+// extractAfter returns the substring after the first occurrence of prefix.
+func extractAfter(s, prefix string) string {
+	idx := strings.Index(s, prefix)
+	if idx < 0 {
+		return ""
+	}
+	return s[idx+len(prefix):]
+}

--- a/go/client/internal/discuss/logger.go
+++ b/go/client/internal/discuss/logger.go
@@ -1,0 +1,41 @@
+package discuss
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// Logger writes timestamped messages to both stderr and a log file.
+type Logger struct {
+	logFile string
+}
+
+// NewLogger creates a logger that writes to the given file path.
+// The file is created/appended to as messages are logged.
+// Pass "" to log only to stderr.
+func NewLogger(logFile string) *Logger {
+	return &Logger{logFile: logFile}
+}
+
+// Log writes a timestamped message to stderr and the log file.
+func (l *Logger) Log(format string, args ...interface{}) {
+	ts := time.Now().Format("15:04:05")
+	msg := fmt.Sprintf(format, args...)
+	line := fmt.Sprintf("[%s] %s\n", ts, msg)
+
+	fmt.Fprint(os.Stderr, line)
+
+	if l.logFile != "" {
+		f, err := os.OpenFile(l.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err == nil {
+			f.WriteString(line)
+			f.Close()
+		}
+	}
+}
+
+// SetLogFile updates the log file path. Called after workDir is known.
+func (l *Logger) SetLogFile(path string) {
+	l.logFile = path
+}

--- a/go/client/internal/discuss/prompt.go
+++ b/go/client/internal/discuss/prompt.go
@@ -1,0 +1,91 @@
+package discuss
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GeneratePrompt takes the template content (typically embedded in the
+// binary), performs variable substitution, writes the result to prompt.txt,
+// and returns the content.
+func GeneratePrompt(cfg *Config, paths *Paths, discussionID int, proxyPort int, logger *Logger, templateContent string) (string, error) {
+
+	// Build human-readable participant list
+	others := cfg.OtherAgents()
+	var otherAgentsStr string
+	if len(others) == 1 {
+		otherAgentsStr = fmt.Sprintf("the \"%s\" agent", others[0])
+	} else if len(others) > 1 {
+		quoted := make([]string, len(others))
+		for i, a := range others {
+			quoted[i] = fmt.Sprintf("\"%s\"", a)
+		}
+		otherAgentsStr = "agents " + strings.Join(quoted, ", ")
+	} else {
+		otherAgentsStr = "other agents"
+	}
+
+	// Build first-contact text based on role (creator vs joiner)
+	var firstContact string
+	if cfg.Initiator {
+		firstContact = `## First Contact
+
+You are the CREATOR of this discussion. Send your opening message immediately after completing
+your setup steps (defining helper functions). Do not wait for the other side to message first.
+Your opening message should introduce the topic and your initial position.
+
+If no reply arrives within 90 seconds of your opening message, write a diagnostic to outbox:
+"Sent opening message but no reply yet. Is the other participant's transport running?"
+
+If no contact from the other side after 5 minutes total, write "No contact after 5 minutes.
+Exiting." to outbox and exit.`
+	} else {
+		firstContact = `## First Contact
+
+You are JOINING this discussion. After completing your setup steps (defining helper functions),
+begin your polling loop. Your inbox may be empty initially — this is normal, the creator may
+still be launching.
+
+If no message arrives within 90 seconds of your first poll, write a diagnostic to outbox:
+"Joined and waiting — is the creator side running?"
+
+If no contact after 5 minutes total, write "No contact after 5 minutes. Exiting." to outbox
+and exit.`
+	}
+
+	// Context text
+	contextStr := cfg.Context
+	if contextStr == "" {
+		contextStr = "(none)"
+	}
+
+	// Use forward slashes for bash compatibility
+	workDir := filepath.ToSlash(cfg.WorkDir)
+
+	replacements := map[string]string{
+		"[OTHER_AGENTS]":   otherAgentsStr,
+		"[TOPIC]":          cfg.Topic,
+		"[WORK_DIR]":       workDir,
+		"[DISCUSSION_ID]":  fmt.Sprintf("%d", discussionID),
+		"[API_URL]":        fmt.Sprintf("http://127.0.0.1:%d", proxyPort),
+		"[API_KEY]":        "", // proxy handles auth
+		"[MY_AGENT]":       cfg.Agent,
+		"[CONTEXT]":        contextStr,
+		"[GUIDELINES]":     "", // not loading from repo — subagent gets guidelines via its own bootstrap
+		"[FIRST_CONTACT]":  firstContact,
+	}
+
+	prompt := templateContent
+	for placeholder, value := range replacements {
+		prompt = strings.ReplaceAll(prompt, placeholder, value)
+	}
+
+	if err := os.WriteFile(paths.PromptFile, []byte(prompt), 0644); err != nil {
+		return "", fmt.Errorf("write prompt: %w", err)
+	}
+	logger.Log("Prompt written to %s", paths.PromptFile)
+
+	return prompt, nil
+}

--- a/go/client/internal/discuss/proxy.go
+++ b/go/client/internal/discuss/proxy.go
@@ -1,0 +1,330 @@
+package discuss
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// ProxyServer is a local HTTP server that proxies discussion-related
+// API calls from the Claude subagent to the remote memory API. This
+// lets the subagent call endpoints like /vote/propose without needing
+// credentials — the proxy handles authentication.
+type ProxyServer struct {
+	server       *http.Server
+	listener     net.Listener
+	port         int
+	client       *APIClient
+	discussionID int
+	agent        string
+	convergence  *Convergence
+	paths        *Paths
+	logger       *Logger
+	seenVoteIDs  map[int]bool
+	startTime    time.Time
+}
+
+// NewProxyServer creates a proxy server bound to localhost on a random port.
+func NewProxyServer(client *APIClient, discussionID int, agent string,
+	convergence *Convergence, paths *Paths, logger *Logger, startTime time.Time) (*ProxyServer, error) {
+
+	p := &ProxyServer{
+		client:       client,
+		discussionID: discussionID,
+		agent:        agent,
+		convergence:  convergence,
+		paths:        paths,
+		logger:       logger,
+		seenVoteIDs:  make(map[int]bool),
+		startTime:    startTime,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/vote/propose", p.handleVotePropose)
+	mux.HandleFunc("/vote/cast", p.handleVoteCast)
+	mux.HandleFunc("/vote/status", p.handleVoteStatus)
+	mux.HandleFunc("/pending", p.handlePending)
+	mux.HandleFunc("/conclude", p.handleConclude)
+	mux.HandleFunc("/status", p.handleStatus)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	p.port = listener.Addr().(*net.TCPAddr).Port
+	p.listener = listener
+	p.server = &http.Server{Handler: mux}
+
+	return p, nil
+}
+
+// Start begins serving in a background goroutine.
+func (p *ProxyServer) Start() {
+	go p.server.Serve(p.listener)
+	p.logger.Log("Proxy server listening on 127.0.0.1:%d", p.port)
+}
+
+// Port returns the port the server is listening on.
+func (p *ProxyServer) Port() int {
+	return p.port
+}
+
+// Close shuts down the proxy server.
+func (p *ProxyServer) Close() {
+	p.server.Close()
+}
+
+// MarkVoteSeen records a vote ID so checkPendingVotes doesn't re-notify.
+func (p *ProxyServer) MarkVoteSeen(id int) {
+	p.seenVoteIDs[id] = true
+}
+
+// SeenVoteIDs returns the set of vote IDs already seen by the proxy.
+func (p *ProxyServer) SeenVoteIDs() map[int]bool {
+	return p.seenVoteIDs
+}
+
+// --- Handlers ---
+
+func (p *ProxyServer) handleVotePropose(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	var req struct {
+		Question  string `json:"question"`
+		Type      string `json:"type"`
+		Threshold string `json:"threshold"`
+	}
+	if err := p.readBody(r, &req); err != nil {
+		p.writeError(w, 400, err.Error())
+		return
+	}
+
+	p.convergence.TrackVoteActivity()
+
+	voteType := req.Type
+	if voteType == "" {
+		voteType = "general"
+	}
+	threshold := req.Threshold
+	if threshold == "" {
+		threshold = "unanimous"
+	}
+
+	// If proposing a conclude vote, check for an existing one first
+	if voteType == "conclude" {
+		var pending pendingResponse
+		if err := p.client.Post("/discussion/pending", map[string]interface{}{
+			"agent":         p.agent,
+			"discussion_id": p.discussionID,
+		}, &pending); err == nil {
+			for _, v := range pending.OpenVotes {
+				if v.Type == "conclude" {
+					p.logger.Log("Found existing conclude vote #%d, casting yes instead of proposing", v.ID)
+					var result interface{}
+					err := p.client.Post("/discussion/vote/cast", map[string]interface{}{
+						"vote_id": v.ID,
+						"agent":   p.agent,
+						"choice":  1,
+						"reason":  "Auto-agreed to existing conclude vote",
+					}, &result)
+					if err != nil {
+						p.writeError(w, 502, err.Error())
+						return
+					}
+					p.seenVoteIDs[v.ID] = true
+					p.writeJSON(w, result)
+					return
+				}
+			}
+		}
+	}
+
+	var result interface{}
+	err := p.client.Post("/discussion/vote/propose", map[string]interface{}{
+		"discussion_id": p.discussionID,
+		"proposed_by":   p.agent,
+		"question":      req.Question,
+		"type":          voteType,
+		"threshold":     threshold,
+	}, &result)
+	if err != nil {
+		p.writeError(w, 502, err.Error())
+		return
+	}
+	p.writeJSON(w, result)
+}
+
+func (p *ProxyServer) handleVoteCast(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	var req struct {
+		VoteID int    `json:"vote_id"`
+		Choice int    `json:"choice"`
+		Reason string `json:"reason"`
+	}
+	if err := p.readBody(r, &req); err != nil {
+		p.writeError(w, 400, err.Error())
+		return
+	}
+
+	p.convergence.TrackVoteActivity()
+
+	body := map[string]interface{}{
+		"vote_id": req.VoteID,
+		"agent":   p.agent,
+		"choice":  req.Choice,
+	}
+	if req.Reason != "" {
+		body["reason"] = req.Reason
+	}
+
+	var result interface{}
+	err := p.client.Post("/discussion/vote/cast", body, &result)
+	if err != nil {
+		p.writeError(w, 502, err.Error())
+		return
+	}
+
+	// Append to transcript
+	reasonText := ""
+	if req.Reason != "" {
+		reasonText = fmt.Sprintf(" (%s)", req.Reason)
+	}
+	p.paths.AppendTranscript("system",
+		fmt.Sprintf("%s voted %d on vote #%d%s", p.agent, req.Choice, req.VoteID, reasonText))
+
+	p.writeJSON(w, result)
+}
+
+func (p *ProxyServer) handleVoteStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	var req struct {
+		VoteID int `json:"vote_id"`
+	}
+	if err := p.readBody(r, &req); err != nil {
+		p.writeError(w, 400, err.Error())
+		return
+	}
+
+	var result VoteStatusResponse
+	err := p.client.Post("/discussion/vote/status", map[string]interface{}{
+		"vote_id": req.VoteID,
+	}, &result)
+	if err != nil {
+		p.writeError(w, 502, err.Error())
+		return
+	}
+
+	// Track rejected conclude votes for convergence detection
+	if result.Vote.Type == "conclude" && result.Vote.Status == "closed" {
+		choices := make(map[int]bool)
+		for _, b := range result.Ballots {
+			choices[b.Choice] = true
+		}
+		if len(choices) > 1 {
+			p.convergence.TrackConcludeRejected()
+		}
+	}
+
+	// Detect split general votes and surface impasse
+	p.convergence.CheckForImpasse(&result)
+
+	p.writeJSON(w, result)
+}
+
+func (p *ProxyServer) handlePending(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	var result interface{}
+	err := p.client.Post("/discussion/pending", map[string]interface{}{
+		"agent": p.agent,
+	}, &result)
+	if err != nil {
+		p.writeError(w, 502, err.Error())
+		return
+	}
+	p.writeJSON(w, result)
+}
+
+func (p *ProxyServer) handleConclude(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	p.paths.AppendTranscript("system", fmt.Sprintf("%s concluded the discussion", p.agent))
+
+	var result interface{}
+	err := p.client.Post("/discussion/conclude", map[string]interface{}{
+		"discussion_id": p.discussionID,
+		"agent":         p.agent,
+	}, &result)
+	if err != nil {
+		p.writeError(w, 502, err.Error())
+		return
+	}
+	p.writeJSON(w, result)
+}
+
+func (p *ProxyServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		p.writeError(w, 405, "method not allowed")
+		return
+	}
+
+	state := p.paths.ReadState()
+	response := map[string]interface{}{
+		"agent":          p.agent,
+		"discussionId":   p.discussionID,
+		"elapsedMinutes": int(time.Since(p.startTime).Minutes()),
+	}
+	if state != nil {
+		response["status"] = state.Status
+		response["turnCount"] = state.TurnCount
+		response["lastDeliveredId"] = state.LastDeliveredID
+		response["convergence"] = state.Convergence
+	}
+	p.writeJSON(w, response)
+}
+
+// --- Helpers ---
+
+func (p *ProxyServer) readBody(r *http.Request, v interface{}) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, v)
+}
+
+func (p *ProxyServer) writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func (p *ProxyServer) writeError(w http.ResponseWriter, status int, message string) {
+	p.logger.Log("Proxy error: %s", message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/go/client/internal/discuss/transport.go
+++ b/go/client/internal/discuss/transport.go
@@ -1,0 +1,530 @@
+package discuss
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	subagentDeadThreshold = 3 * time.Minute
+	stallWarningDuration  = 90 * time.Second
+	statusCheckInterval   = 10 // check server-side status every N poll cycles
+)
+
+// Transport manages the main message-relay loop between the Claude
+// subagent (via inbox/outbox files) and the remote discussion API
+// (via chat messages).
+type Transport struct {
+	client       *APIClient
+	cfg          *Config
+	paths        *Paths
+	logger       *Logger
+	convergence  *Convergence
+	proxy        *ProxyServer
+	discussionID int
+
+	// State
+	seenIDs         map[int]bool
+	turnCount       int
+	lastDeliveredID int
+	readySignaled   bool
+	startTime       time.Time
+
+	// Subagent death detection
+	lastOutboxTime        time.Time
+	lastInboxDeliveryTime time.Time
+	subagentDeathReported bool
+	stallWarningLogged    bool
+
+	// Server-side status polling
+	statusCheckCounter int
+}
+
+// NewTransport creates a transport for the given discussion.
+func NewTransport(client *APIClient, cfg *Config, paths *Paths, logger *Logger,
+	convergence *Convergence, proxy *ProxyServer, discussionID int) *Transport {
+
+	return &Transport{
+		client:       client,
+		cfg:          cfg,
+		paths:        paths,
+		logger:       logger,
+		convergence:  convergence,
+		proxy:        proxy,
+		discussionID: discussionID,
+		seenIDs:      make(map[int]bool),
+		startTime:    time.Now(),
+		lastOutboxTime: time.Now(),
+	}
+}
+
+// RestoreState loads persisted state from a previous run (crash recovery).
+func (t *Transport) RestoreState() {
+	prev := t.paths.ReadState()
+	if prev == nil {
+		return
+	}
+	for _, id := range prev.SeenIDs {
+		t.seenIDs[id] = true
+	}
+	if prev.LastDeliveredID > 0 {
+		t.lastDeliveredID = prev.LastDeliveredID
+	}
+}
+
+// Run executes the main transport loop: poll for messages, relay to/from
+// the subagent, check convergence, and handle timeouts.
+func (t *Transport) Run() error {
+	channel := fmt.Sprintf("discussion-%d", t.discussionID)
+	t.logger.Log("Discussion transport starting: %s <-> %s",
+		t.cfg.Agent, strings.Join(t.cfg.OtherAgents(), ", "))
+	t.logger.Log("Work dir: %s", t.cfg.WorkDir)
+	t.setStatus("POLLING")
+
+	for {
+		t.paths.TouchLock()
+
+		// 1. Check done
+		if t.paths.IsDone() {
+			t.logger.Log("Done file detected. Discussion concluded.")
+			t.setStatus("DONE")
+			return nil
+		}
+
+		// 2. Check idle timeout
+		if t.paths.IsIdleTimeout() {
+			t.logger.Log("Idle timeout detected. Shutting down.")
+			t.setStatus("IDLE_TIMEOUT")
+			return nil
+		}
+
+		// 3. Check timeout
+		if t.checkTimeout() {
+			t.logger.Log("Timeout reached (%d turns, %dm). Writing timeout notice.",
+				t.turnCount, t.cfg.TimeoutMinutes)
+			t.paths.WriteInboxFile("timeout.txt", "[SYSTEM] Discussion timeout reached. Please wrap up.")
+			t.setStatus("TIMEOUT")
+			time.Sleep(30 * time.Second)
+			if msg, ok := t.paths.CheckOutbox(); ok {
+				t.sendMessage(channel, msg)
+			}
+			t.setStatus("DONE")
+			t.paths.WriteDone("timeout")
+			return nil
+		}
+
+		// 4. Check outbox
+		if msg, ok := t.paths.CheckOutbox(); ok {
+			sizeKB := MessageSize(msg)
+			if !t.lastInboxDeliveryTime.IsZero() {
+				responseTime := int(time.Since(t.lastInboxDeliveryTime).Seconds())
+				t.logger.Log("Outbox: %sKB, response time: %ds", sizeKB, responseTime)
+			} else {
+				t.logger.Log("Outbox: %sKB", sizeKB)
+			}
+			t.lastOutboxTime = time.Now()
+			t.stallWarningLogged = false
+			t.subagentDeathReported = false
+			t.sendMessage(channel, msg)
+			time.Sleep(t.cfg.SendDelay)
+		}
+
+		// 5. Poll for incoming messages
+		messages := t.receiveMessages(channel)
+
+		// 6-7. Process: dedup, write inbox, transcript
+		allIDs, newIDs := t.processReceivedMessages(messages)
+
+		// 8. Poll pending votes
+		t.checkPendingVotes()
+
+		// 9. Convergence detection
+		result := t.convergence.Check(t.client, t.discussionID, t.cfg.Agent)
+		if result == "terminate" {
+			t.logger.Log("Convergence termination — exiting transport loop")
+			t.waitForResult(channel)
+			t.paths.WriteDone("terminated")
+			t.setStatus("TERMINATED")
+			return nil
+		}
+
+		// 10. Periodic server-side status check
+		t.statusCheckCounter++
+		if t.statusCheckCounter >= statusCheckInterval {
+			t.statusCheckCounter = 0
+			if t.checkServerStatus(channel) {
+				return nil
+			}
+		}
+
+		if len(allIDs) > 0 {
+			// Delayed ack — wait for subagent to consume inbox files
+			if len(newIDs) > 0 {
+				t.waitForSubagentReads(newIDs)
+			}
+
+			// Ack all
+			t.ackMessages(allIDs)
+
+			// Record last-delivered-id
+			maxID := 0
+			for _, id := range allIDs {
+				if id > maxID {
+					maxID = id
+				}
+			}
+			t.lastDeliveredID = maxID
+			t.lastInboxDeliveryTime = time.Now()
+
+			if !t.readySignaled {
+				t.readySignaled = true
+				t.logger.Log("Received first message — ready signaled")
+			}
+
+			t.setStatus("MESSAGE_RECEIVED")
+		} else {
+			time.Sleep(t.cfg.PollInterval)
+		}
+
+		// Stall warning
+		if !t.stallWarningLogged &&
+			!t.lastInboxDeliveryTime.IsZero() &&
+			t.lastInboxDeliveryTime.After(t.lastOutboxTime) &&
+			time.Since(t.lastInboxDeliveryTime) > stallWarningDuration {
+			t.stallWarningLogged = true
+			t.logger.Log("WARNING: No outbox response %ds after inbox delivery",
+				int(time.Since(t.lastInboxDeliveryTime).Seconds()))
+		}
+
+		// Subagent death detection
+		if !t.subagentDeathReported &&
+			!t.lastInboxDeliveryTime.IsZero() &&
+			t.lastInboxDeliveryTime.After(t.lastOutboxTime) &&
+			time.Since(t.lastInboxDeliveryTime) > subagentDeadThreshold {
+			t.subagentDeathReported = true
+			t.logger.Log("Subagent appears dead — no outbox activity after inbox delivery")
+			t.reportSubagentDead()
+		}
+	}
+}
+
+// TurnCount returns the number of messages sent.
+func (t *Transport) TurnCount() int {
+	return t.turnCount
+}
+
+// IsTerminated returns true if convergence detection terminated the discussion.
+func (t *Transport) IsTerminated() bool {
+	return t.convergence.State == StateTerminated
+}
+
+// waitForResult gives the subagent time to write result.md after
+// receiving a shutdown notice. Polls for result.md with a 60-second
+// timeout. Also drains any outbox messages while waiting.
+func (t *Transport) waitForResult(channel string) {
+	timeout := time.Duration(t.cfg.ResultTimeout) * time.Second
+	poll := 2 * time.Second
+	start := time.Now()
+
+	for time.Since(start) < timeout {
+		// Drain outbox while waiting
+		if msg, ok := t.paths.CheckOutbox(); ok {
+			t.sendMessage(channel, msg)
+		}
+
+		// Check if result.md exists
+		if _, err := os.Stat(t.paths.ResultFile); err == nil {
+			t.logger.Log("result.md found after %ds", int(time.Since(start).Seconds()))
+			return
+		}
+
+		time.Sleep(poll)
+	}
+
+	t.logger.Log("WARNING: result.md not found after %ds — proceeding with shutdown", int(timeout.Seconds()))
+	// Final outbox drain
+	if msg, ok := t.paths.CheckOutbox(); ok {
+		t.sendMessage(channel, msg)
+	}
+}
+
+// --- Messaging ---
+
+func (t *Transport) receiveMessages(channel string) []ChatMessage {
+	body := map[string]interface{}{
+		"agent":   t.cfg.Agent,
+		"channel": channel,
+	}
+	if t.lastDeliveredID > 0 {
+		body["after_id"] = t.lastDeliveredID
+	}
+
+	var resp ChatReceiveResponse
+	if err := t.client.Post("/chat/receive", body, &resp); err != nil {
+		t.logger.Log("ERROR receiving: %s", err)
+		return nil
+	}
+	return resp.Messages
+}
+
+func (t *Transport) processReceivedMessages(messages []ChatMessage) (allIDs, newIDs []int) {
+	for _, msg := range messages {
+		allIDs = append(allIDs, msg.ID)
+		if t.seenIDs[msg.ID] {
+			continue
+		}
+		t.seenIDs[msg.ID] = true
+		newIDs = append(newIDs, msg.ID)
+
+		content := fmt.Sprintf("From: %s\nSent: %s\n\n%s", msg.FromAgent, msg.SentAt, msg.Message)
+		t.paths.WriteInboxFile(fmt.Sprintf("%d.txt", msg.ID), content)
+		t.paths.AppendTranscript(msg.FromAgent, msg.Message)
+		t.convergence.TrackMessage(msg.FromAgent)
+		t.logger.Log("RECEIVED: id=%d from=%s", msg.ID, msg.FromAgent)
+	}
+	return
+}
+
+func (t *Transport) sendMessage(channel, message string) {
+	err := t.client.Post("/chat/send", map[string]interface{}{
+		"from_agent":    t.cfg.Agent,
+		"discussion_id": t.discussionID,
+		"message":       message,
+		"channel":       channel,
+	}, nil)
+	if err != nil {
+		t.logger.Log("ERROR sending: %s", err)
+		return
+	}
+
+	truncated := message
+	if len(truncated) > 100 {
+		truncated = truncated[:100]
+	}
+	t.logger.Log("SENT: %s...", truncated)
+	t.paths.AppendTranscript(t.cfg.Agent, message)
+	t.convergence.TrackMessage(t.cfg.Agent)
+	t.turnCount++
+}
+
+func (t *Transport) ackMessages(ids []int) {
+	if len(ids) == 0 {
+		return
+	}
+	err := t.client.Post("/chat/ack", map[string]interface{}{
+		"agent":       t.cfg.Agent,
+		"message_ids": ids,
+	}, nil)
+	if err != nil {
+		t.logger.Log("ERROR acking: %s", err)
+	}
+}
+
+// --- Vote polling ---
+
+func (t *Transport) checkPendingVotes() {
+	var resp struct {
+		OpenVotes []struct {
+			ID        int    `json:"id"`
+			Type      string `json:"type"`
+			Threshold string `json:"threshold"`
+			Question  string `json:"question"`
+		} `json:"open_votes"`
+	}
+	err := t.client.Post("/discussion/pending", map[string]interface{}{
+		"agent":         t.cfg.Agent,
+		"discussion_id": t.discussionID,
+	}, &resp)
+	if err != nil {
+		t.logger.Log("ERROR checking votes: %s", err)
+		return
+	}
+
+	for _, vote := range resp.OpenVotes {
+		if t.proxy.SeenVoteIDs()[vote.ID] {
+			continue
+		}
+		t.proxy.MarkVoteSeen(vote.ID)
+
+		notice := fmt.Sprintf("[VOTE PENDING] Vote #%d (%s, %s): %s",
+			vote.ID, vote.Type, vote.Threshold, vote.Question)
+		t.paths.WriteInboxFile(fmt.Sprintf("vote-pending-%d.txt", vote.ID), notice)
+		t.logger.Log("VOTE NOTIFICATION: vote #%d", vote.ID)
+	}
+}
+
+// --- Delayed ack ---
+
+func (t *Transport) waitForSubagentReads(newIDs []int) {
+	timeout := 120 * time.Second
+	start := time.Now()
+	for {
+		allGone := true
+		for _, id := range newIDs {
+			if t.paths.InboxFileExists(fmt.Sprintf("%d.txt", id)) {
+				allGone = false
+				break
+			}
+		}
+
+		if allGone {
+			t.logger.Log("All inbox files consumed by subagent")
+			return
+		}
+
+		if time.Since(start) >= timeout {
+			t.logger.Log("WARNING: Delayed ack timeout (%ds) — acking unconsumed messages",
+				int(timeout.Seconds()))
+			return
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// --- Timeout checks ---
+
+func (t *Transport) checkTimeout() bool {
+	elapsed := time.Since(t.startTime)
+	if elapsed >= time.Duration(t.cfg.TimeoutMinutes)*time.Minute {
+		return true
+	}
+	if t.turnCount >= t.cfg.MaxMessages {
+		return true
+	}
+	return false
+}
+
+// --- Server-side status check ---
+
+func (t *Transport) checkServerStatus(channel string) bool {
+	var resp statusResponse
+	err := t.client.Post("/discussion/status", map[string]interface{}{
+		"discussion_id": t.discussionID,
+	}, &resp)
+	if err != nil {
+		t.logger.Log("Status check failed: %s", err)
+		return false
+	}
+
+	status := resp.Discussion.Status
+	if status == "cancelled" || status == "concluded" {
+		t.logger.Log("Discussion %s server-side. Notifying subagent and shutting down.", status)
+		notice := fmt.Sprintf("[SYSTEM] This discussion has been %s. Please wrap up and write your result file.", status)
+		t.paths.WriteInboxFile(fmt.Sprintf("%s.txt", status), notice)
+		t.paths.AppendTranscript("system", fmt.Sprintf("Discussion %s server-side", status))
+		t.waitForResult(channel)
+		t.paths.WriteDone(status)
+		t.setStatus("DONE")
+		return true
+	}
+
+	return false
+}
+
+// --- Subagent death reporting ---
+
+func (t *Transport) reportSubagentDead() {
+	elapsed := int(time.Since(t.startTime).Minutes())
+	silent := int(time.Since(t.lastOutboxTime).Minutes())
+	t.logger.Log("Subagent death detected: %d messages sent, %dm elapsed, %dm silent",
+		t.turnCount, elapsed, silent)
+
+	t.client.Post("/system/error/report", map[string]interface{}{
+		"source":     "discuss-transport",
+		"error_code": "SUBAGENT_DEAD",
+		"context": map[string]interface{}{
+			"discussion_id":        t.discussionID,
+			"agent":                t.cfg.Agent,
+			"messages_sent":        t.turnCount,
+			"elapsed_minutes":      elapsed,
+			"silent_minutes":       silent,
+			"last_outbox_activity": t.lastOutboxTime.UTC().Format(time.RFC3339),
+			"last_inbox_delivery":  t.lastInboxDeliveryTime.UTC().Format(time.RFC3339),
+		},
+	}, nil)
+}
+
+// --- State management ---
+
+func (t *Transport) setStatus(status string) {
+	seenList := make([]int, 0, len(t.seenIDs))
+	for id := range t.seenIDs {
+		seenList = append(seenList, id)
+	}
+
+	t.paths.WriteState(&TransportState{
+		Status:          status,
+		PID:             os.Getpid(),
+		Port:            t.proxy.Port(),
+		TurnCount:       t.turnCount,
+		LastDeliveredID:  t.lastDeliveredID,
+		SeenIDs:         seenList,
+		Ready:           t.readySignaled,
+		StartedAt:       t.startTime.UTC().Format(time.RFC3339),
+		Convergence:     t.convergence.Info(),
+	})
+}
+
+// --- Post-transport: save transcript and result ---
+
+// SaveTranscript copies the transcript to a persistent location and
+// ingests it into vector memory.
+func (t *Transport) SaveTranscript() {
+	if _, err := os.Stat(t.paths.TranscriptFile); err != nil {
+		return
+	}
+
+	content, err := os.ReadFile(t.paths.TranscriptFile)
+	if err != nil {
+		return
+	}
+
+	slug := fmt.Sprintf("notes/discussions/discussion-%d", t.discussionID)
+	title := fmt.Sprintf("Discussion #%d Transcript — %s", t.discussionID, t.cfg.Topic)
+
+	err = t.client.Post("/documents/save", map[string]interface{}{
+		"namespace": t.cfg.Agent,
+		"slug":      slug,
+		"title":     title,
+		"content":   string(content),
+	}, nil)
+	if err != nil {
+		t.logger.Log("Transcript save failed (non-fatal): %s", err)
+	} else {
+		t.logger.Log("Transcript saved as remote note: %s/%s", t.cfg.Agent, slug)
+	}
+}
+
+// SaveResult uploads result.md as a remote note so it's searchable
+// and accessible to both agents.
+func (t *Transport) SaveResult() {
+	resultPath := filepath.Join(t.cfg.WorkDir, "result.md")
+	content, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.logger.Log("No result.md found — skipping result save")
+		return
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		t.logger.Log("result.md is empty — skipping result save")
+		return
+	}
+
+	slug := fmt.Sprintf("notes/discussions/discussion-%d-result", t.discussionID)
+	title := fmt.Sprintf("Discussion #%d Result — %s", t.discussionID, t.cfg.Topic)
+
+	err = t.client.Post("/documents/save", map[string]interface{}{
+		"namespace": t.cfg.Agent,
+		"slug":      slug,
+		"title":     title,
+		"content":   string(content),
+	}, nil)
+	if err != nil {
+		t.logger.Log("Result save failed (non-fatal): %s", err)
+	} else {
+		t.logger.Log("Result saved as remote note: %s/%s", t.cfg.Agent, slug)
+	}
+}

--- a/go/client/internal/discuss/types.go
+++ b/go/client/internal/discuss/types.go
@@ -1,0 +1,30 @@
+package discuss
+
+// VoteStatusResponse is the response from /discussion/vote/status.
+type VoteStatusResponse struct {
+	Vote struct {
+		ID        int    `json:"id"`
+		Type      string `json:"type"`
+		Status    string `json:"status"`
+		Question  string `json:"question"`
+		Threshold string `json:"threshold"`
+	} `json:"vote"`
+	Ballots []struct {
+		Agent  string `json:"agent"`
+		Choice int    `json:"choice"`
+		Reason string `json:"reason"`
+	} `json:"ballots"`
+}
+
+// ChatMessage represents a message from the chat API.
+type ChatMessage struct {
+	ID        int    `json:"id"`
+	FromAgent string `json:"from_agent"`
+	Message   string `json:"message"`
+	SentAt    string `json:"sent_at"`
+}
+
+// ChatReceiveResponse is the response from /chat/receive.
+type ChatReceiveResponse struct {
+	Messages []ChatMessage `json:"messages"`
+}

--- a/node/api/public/admin/main.js
+++ b/node/api/public/admin/main.js
@@ -206,7 +206,6 @@ createApp({
                 errorLogModule.startErrorLogPolling();
             } else if (currentView.value === 'agents') {
                 agentsModule.loadAgents();
-                if (configModule.configEntries.value.length === 0) configModule.loadConfig();
             } else if (currentView.value === 'comms') {
                 if (commSubTab.value === 'discussions') discussionsModule.loadDiscussions();
                 else if (commSubTab.value === 'chat') chatModule.loadChat();

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -849,4 +849,26 @@ router.post('/agent/sync-mappings', apiRoute('agent', 'sync-mappings', async (re
     res.json({ mappings: result.rows, exclude_slugs: excludeSlugs });
 }));
 
+// POST /agent/config — return whitelisted config values.
+// Agents don't need admin permissions to read these — they're operational
+// parameters that tools like the discuss binary need at runtime.
+// Add keys here as needed.
+const AGENT_CONFIG_KEYS = new Set([
+    'discussion_end_timeout_realtime',
+    'discussion_maxrounds',
+]);
+
+router.post('/agent/config', apiRoute('agent', 'agent-config', async (req, res) => {
+    const keys = [...AGENT_CONFIG_KEYS];
+    const result = await pool.query(
+        'SELECT key, value FROM config WHERE key = ANY($1)',
+        [keys]
+    );
+    const config_values = {};
+    for (const row of result.rows) {
+        config_values[row.key] = row.value;
+    }
+    res.json({ config: config_values });
+}));
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Go discuss binary (`go/client/cmd/discuss/`) replaces Node `discuss.js` + `discuss-launch.js`
- Prompt template embedded via `//go:embed` — no external files needed
- New `/agent/config` endpoint returns whitelisted config values for agent tools
- Server-driven `discussion_end_timeout_realtime` (180s) and `discussion_maxrounds` (20)
- GoReleaser config updated to build `discuss` alongside `memory-sync`
- `waitForResult()` replaces fixed sleep — polls for result.md with configurable timeout
- DB: all three templates updated (work_dir in .agent.json, discuss binary instructions, download paths)
- DB: Smith's startup_instructions and welcome mail updated

## Test plan
- [x] Binary builds clean (Go 1.26.1)
- [x] Smoke test: create discussion, login, wait for participants
- [x] End-to-end test: Go binary (home) <-> Node transport (work), messages + votes + conclude
- [ ] Verify `/agent/config` endpoint returns expected keys after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)