### PR TITLE
Add GitHub Discussions link to help page

### DIFF
--- a/node/api/public/admin/views/help.html
+++ b/node/api/public/admin/views/help.html
@@ -431,6 +431,12 @@
                 </table>
             </div>
 
+            <div class="help-card" style="text-align:center; margin-top:2rem;">
+                <h4>Need more help?</h4>
+                <p>Ask a question on GitHub Discussions — we're happy to help.</p>
+                <a href="https://github.com/jeffdafoe/llm-memory-api/discussions/new?category=q-a" target="_blank" rel="noopener" style="display:inline-block; padding:0.5rem 1.25rem; background:var(--accent); color:#000; border-radius:6px; text-decoration:none; font-weight:600;">Ask a Question</a>
+            </div>
+
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Adds a "Need more help?" card at the bottom of the admin help page
- Links to GitHub Discussions Q&A category for support questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)