### PR TITLE
Add /v1/auth/verify endpoint for external token validation

### DIFF
--- a/node/api/src/middleware/auth.js
+++ b/node/api/src/middleware/auth.js
@@ -18,6 +18,7 @@ function heartbeat(actorId) {
 const UNAUTHENTICATED_ROUTES = [
     '/agent/login',
     '/admin/login',
+    '/auth/verify',
 ];
 
 async function auth(req, res, next) {

--- a/node/api/src/routes/auth.js
+++ b/node/api/src/routes/auth.js
@@ -1,0 +1,48 @@
+// Auth verification endpoint — lets external services (e.g. ZBBS)
+// check if a session token is valid without needing to duplicate
+// the session validation logic.
+
+const express = require('express');
+const router = express.Router();
+const { validateSessionToken } = require('../services/sessions');
+const { SESSION_KIND } = require('../constants');
+
+// POST /auth/verify
+// Accepts a session token and returns whether it's valid and who it belongs to.
+// No auth required on this endpoint — the token being verified IS the auth.
+router.post('/auth/verify', async (req, res) => {
+    const { token } = req.body;
+
+    if (!token) {
+        return res.status(400).json({ valid: false, error: 'Missing token' });
+    }
+
+    try {
+        // Check web sessions (the kind the village viewer uses)
+        const webRow = await validateSessionToken(token, SESSION_KIND.WEB);
+        if (webRow) {
+            return res.json({
+                valid: true,
+                agent: webRow.name,
+                actor_id: webRow.actor_id,
+            });
+        }
+
+        // Also check API sessions in case an agent token is used
+        const apiRow = await validateSessionToken(token, SESSION_KIND.API);
+        if (apiRow) {
+            return res.json({
+                valid: true,
+                agent: apiRow.name,
+                actor_id: apiRow.actor_id,
+            });
+        }
+
+        return res.json({ valid: false });
+    } catch (err) {
+        console.error('Auth verify error:', err.message);
+        return res.status(500).json({ valid: false, error: 'Internal error' });
+    }
+});
+
+module.exports = router;

--- a/node/api/src/server.js
+++ b/node/api/src/server.js
@@ -17,6 +17,7 @@ const documentRoutes = require('./routes/documents');
 const systemRoutes = require('./routes/system');
 const adminRoutes = require('./routes/admin');
 const registrationRoutes = require('./routes/registration');
+const authRoutes = require('./routes/auth');
 
 const app = express();
 const port = process.env.PORT || 3100;
@@ -51,6 +52,9 @@ app.use('/v1', memoryRoutes);
 app.use('/v1', documentRoutes);
 app.use('/v1', systemRoutes);
 app.use('/v1', adminRoutes);
+
+// Auth verification (public, no auth — the token being verified IS the credential)
+app.use('/v1', authRoutes);
 
 // Registration endpoints (public, no auth)
 app.use(registrationRoutes);


### PR DESCRIPTION
## Summary
- Adds `POST /v1/auth/verify` endpoint that lets external services (ZBBS) validate llm-memory session tokens
- Returns `{valid: true, agent, actor_id}` for valid tokens, `{valid: false}` otherwise
- Checks both web and API session types
- No auth required on the endpoint itself — the token being verified IS the credential

## Context
The ZBBS village viewer authenticates users via llm-memory web sessions. ZBBS API endpoints need to verify those tokens to authorize requests. This endpoint provides that bridge.

## Test plan
- [ ] POST /v1/auth/verify with valid web session token → returns valid + agent name
- [ ] POST /v1/auth/verify with expired/invalid token → returns valid: false
- [ ] POST /v1/auth/verify with no token → returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)