### PR TITLE
Fix /v1/auth/verify route ordering

### DIFF
--- a/node/api/src/middleware/auth.js
+++ b/node/api/src/middleware/auth.js
@@ -18,7 +18,6 @@ function heartbeat(actorId) {
 const UNAUTHENTICATED_ROUTES = [
     '/agent/login',
     '/admin/login',
-    '/auth/verify',
 ];
 
 async function auth(req, res, next) {

--- a/node/api/src/middleware/auth.js
+++ b/node/api/src/middleware/auth.js
@@ -18,6 +18,7 @@ function heartbeat(actorId) {
 const UNAUTHENTICATED_ROUTES = [
     '/agent/login',
     '/admin/login',
+    '/auth/verify',
 ];
 
 async function auth(req, res, next) {

--- a/node/api/src/routes/auth.js
+++ b/node/api/src/routes/auth.js
@@ -1,0 +1,48 @@
+// Auth verification endpoint — lets external services (e.g. ZBBS)
+// check if a session token is valid without needing to duplicate
+// the session validation logic.
+
+const express = require('express');
+const router = express.Router();
+const { validateSessionToken } = require('../services/sessions');
+const { SESSION_KIND } = require('../constants');
+
+// POST /auth/verify
+// Accepts a session token and returns whether it's valid and who it belongs to.
+// No auth required on this endpoint — the token being verified IS the auth.
+router.post('/auth/verify', async (req, res) => {
+    const { token } = req.body;
+
+    if (!token) {
+        return res.status(400).json({ valid: false, error: 'Missing token' });
+    }
+
+    try {
+        // Check web sessions (the kind the village viewer uses)
+        const webRow = await validateSessionToken(token, SESSION_KIND.WEB);
+        if (webRow) {
+            return res.json({
+                valid: true,
+                agent: webRow.name,
+                actor_id: webRow.actor_id,
+            });
+        }
+
+        // Also check API sessions in case an agent token is used
+        const apiRow = await validateSessionToken(token, SESSION_KIND.API);
+        if (apiRow) {
+            return res.json({
+                valid: true,
+                agent: apiRow.name,
+                actor_id: apiRow.actor_id,
+            });
+        }
+
+        return res.json({ valid: false });
+    } catch (err) {
+        console.error('Auth verify error:', err.message);
+        return res.status(500).json({ valid: false, error: 'Internal error' });
+    }
+});
+
+module.exports = router;

--- a/node/api/src/server.js
+++ b/node/api/src/server.js
@@ -42,6 +42,9 @@ app.use(oauthRoutes);
 // MCP Streamable HTTP endpoint (HMAC auth via mcp-auth middleware)
 app.use(mcpRoutes);
 
+// Auth verification (public, no auth — the token being verified IS the credential)
+app.use('/v1', authRoutes);
+
 app.use('/v1', auth);
 app.use('/v1', opportunisticHeartbeat);
 app.use('/v1', agentRoutes);
@@ -52,9 +55,6 @@ app.use('/v1', memoryRoutes);
 app.use('/v1', documentRoutes);
 app.use('/v1', systemRoutes);
 app.use('/v1', adminRoutes);
-
-// Auth verification (public, no auth — the token being verified IS the credential)
-app.use('/v1', authRoutes);
 
 // Registration endpoints (public, no auth)
 app.use(registrationRoutes);

--- a/node/api/src/server.js
+++ b/node/api/src/server.js
@@ -17,6 +17,7 @@ const documentRoutes = require('./routes/documents');
 const systemRoutes = require('./routes/system');
 const adminRoutes = require('./routes/admin');
 const registrationRoutes = require('./routes/registration');
+const authRoutes = require('./routes/auth');
 
 const app = express();
 const port = process.env.PORT || 3100;
@@ -51,6 +52,9 @@ app.use('/v1', memoryRoutes);
 app.use('/v1', documentRoutes);
 app.use('/v1', systemRoutes);
 app.use('/v1', adminRoutes);
+
+// Auth verification (public, no auth — the token being verified IS the credential)
+app.use('/v1', authRoutes);
 
 // Registration endpoints (public, no auth)
 app.use(registrationRoutes);


### PR DESCRIPTION
## Summary
- Mount auth verify routes before the auth middleware so they don't get intercepted by the admin router's requireUser middleware
- Remove /auth/verify from unauthenticated routes list (no longer needed since it's before the middleware)

## Context
Follow-up to #94. The admin router uses `router.use(requireUser)` which fires for all `/v1/*` requests, not just `/admin/*`. Moving auth routes before the auth middleware entirely sidesteps this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)