### PR TITLE
Add stale conversation detection to memory-sync

### DIFF
--- a/go/client/internal/memsync/conversations.go
+++ b/go/client/internal/memsync/conversations.go
@@ -30,7 +30,13 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
         return fmt.Errorf("read project dir: %w", err)
     }
 
-    var candidateIDs []string
+    // Session info sent to server for diff comparison
+    type sessionInfo struct {
+        ID       string `json:"id"`
+        FileSize int64  `json:"file_size"`
+    }
+
+    var candidates []sessionInfo
     // Map lowercase ID to actual filename for case-insensitive matching later
     fileMap := make(map[string]string)
 
@@ -59,22 +65,22 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
         }
 
         lowerID := strings.ToLower(sessionID)
-        candidateIDs = append(candidateIDs, lowerID)
+        candidates = append(candidates, sessionInfo{ID: lowerID, FileSize: info.Size()})
         fileMap[lowerID] = entry.Name()
     }
 
-    if len(candidateIDs) == 0 {
+    if len(candidates) == 0 {
         fmt.Println("Conversations: no new sessions")
         return nil
     }
 
-    // Ask server which sessions are missing
+    // Ask server which sessions are missing or stale (file grew since last upload)
     var diffResult struct {
         Conversations *conversationConfig `json:"conversations"`
     }
     err = client.Post("/agent/memory/sync", map[string]interface{}{
         "conversations": map[string]interface{}{
-            "session_ids": candidateIDs,
+            "sessions": candidates,
         },
     }, &diffResult)
     if err != nil {
@@ -86,17 +92,29 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
         return nil
     }
     missing := diffResult.Conversations.Missing
-    if len(missing) == 0 {
+    stale := diffResult.Conversations.Stale
+    if len(missing) == 0 && len(stale) == 0 {
         fmt.Println("Conversations: all up to date")
         return nil
     }
 
-    // Preprocess and upload missing sessions one at a time
+    // Merge missing + stale into a single upload list
+    toUpload := make([]string, 0, len(missing)+len(stale))
+    toUpload = append(toUpload, missing...)
+    toUpload = append(toUpload, stale...)
+
+    // Preprocess and upload sessions one at a time
     uploaded := 0
+    updated := 0
     convErrors := 0
     serverErrors := 0
 
-    for _, sessionID := range missing {
+    staleSet := make(map[string]bool, len(stale))
+    for _, id := range stale {
+        staleSet[strings.ToLower(id)] = true
+    }
+
+    for _, sessionID := range toUpload {
         // Find the local file
         filename, ok := fileMap[strings.ToLower(sessionID)]
         if !ok {
@@ -125,6 +143,13 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
             dateStr = messages[0].Timestamp.Format("2006-01-02")
         }
 
+        // Get current file size for metadata
+        fileInfo, _ := os.Stat(filePath)
+        var fileSize int64
+        if fileInfo != nil {
+            fileSize = fileInfo.Size()
+        }
+
         // Upload
         upload := conversationUpload{
             SessionID: sessionID,
@@ -137,6 +162,7 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
                 Agent:        agentName,
                 User:         userName,
                 MessageCount: len(messages),
+                FileSize:     fileSize,
                 Source:       "claude-code-jsonl",
             },
         }
@@ -165,12 +191,21 @@ func ConversationSync(client *api.Client, projectDir string, agentName string, u
             if uploadResult.Conversations != nil {
                 count = uploadResult.Conversations.Uploaded
             }
-            uploaded += count
-            fmt.Printf("  CONV conversations/%s-%s\n", dateStr, sessionID)
+            isStale := staleSet[strings.ToLower(sessionID)]
+            if isStale {
+                updated += count
+                fmt.Printf("  CONV UPDATE conversations/%s-%s\n", dateStr, sessionID)
+            } else {
+                uploaded += count
+                fmt.Printf("  CONV conversations/%s-%s\n", dateStr, sessionID)
+            }
         }
     }
 
     summary := fmt.Sprintf("Conversations: %d uploaded", uploaded)
+    if updated > 0 {
+        summary += fmt.Sprintf(", %d updated", updated)
+    }
     if convErrors > 0 {
         summary += fmt.Sprintf(", %d errors", convErrors)
     }
@@ -396,6 +431,7 @@ type conversationMetadata struct {
     Agent        string `json:"agent"`
     User         string `json:"user"`
     MessageCount int    `json:"message_count"`
+    FileSize     int64  `json:"file_size"`
     Source       string `json:"source"`
 }
 

--- a/go/client/internal/memsync/memory.go
+++ b/go/client/internal/memsync/memory.go
@@ -153,6 +153,7 @@ type memorySyncResponse struct {
 type conversationConfig struct {
     RetentionDays int      `json:"retention_days,omitempty"`
     Missing       []string `json:"missing,omitempty"`
+    Stale         []string `json:"stale,omitempty"`
     Uploaded      int      `json:"uploaded,omitempty"`
     UploadErrors  []struct {
         SessionID string `json:"session_id"`

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -748,36 +748,85 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
             const retentionDays = parseInt(config.get('conversation_retention_days')) || 30;
             conversationsResponse.retention_days = retentionDays;
 
-            // If client sent session_ids, compare against existing conversation notes
+            // Compare client sessions against existing conversation notes.
+            // Supports two formats:
+            //   - Legacy: session_ids = ["id1", "id2"] (no stale detection)
+            //   - New:    sessions = [{id: "id1", file_size: 12345}, ...] (with stale detection)
+            const sessions = req.body.conversations.sessions;
             const sessionIds = req.body.conversations.session_ids;
-            if (Array.isArray(sessionIds) && sessionIds.length > 0) {
+            const hasNewFormat = Array.isArray(sessions) && sessions.length > 0;
+            const hasLegacyFormat = Array.isArray(sessionIds) && sessionIds.length > 0;
+
+            if (hasNewFormat || hasLegacyFormat) {
                 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
                 const maxIds = 1000;
-                if (sessionIds.length > maxIds) {
+
+                // Normalize file_size to a bounded non-negative integer
+                function normalizeFileSize(value) {
+                    const n = Number(value);
+                    return Number.isInteger(n) && n >= 0 ? n : 0;
+                }
+
+                // Normalize both formats into {id, file_size} pairs
+                const rawItems = hasNewFormat
+                    ? sessions
+                        .filter(s => s && typeof s === 'object')
+                        .map(s => ({ id: s.id, file_size: normalizeFileSize(s.file_size) }))
+                    : sessionIds.map(id => ({ id, file_size: 0 }));
+
+                if (rawItems.length > maxIds) {
                     conversationsResponse.error = 'Too many session IDs (max ' + maxIds + ')';
                 } else {
                     const seen = new Set();
-                    const validIds = [];
-                    for (const id of sessionIds) {
-                        if (typeof id !== 'string' || !uuidRegex.test(id)) continue;
-                        const lower = id.toLowerCase();
+                    const validItems = [];
+                    for (const item of rawItems) {
+                        if (typeof item.id !== 'string' || !uuidRegex.test(item.id)) continue;
+                        const lower = item.id.toLowerCase();
                         if (seen.has(lower)) continue;
                         seen.add(lower);
-                        validIds.push(lower);
+                        validItems.push({ id: lower, file_size: normalizeFileSize(item.file_size) });
                     }
 
-                    // Query by metadata->session_id — no slug parsing, no row cap
+                    const validIds = validItems.map(item => item.id);
+
+                    // Query existing sessions with their stored file_size from metadata.
+                    // Uses MAX to handle any duplicate rows per session, and regex guard
+                    // on the cast to avoid blowing up on non-numeric stored values.
                     const existingResult = await pool.query(`
-                        SELECT metadata->>'session_id' AS session_id
+                        SELECT metadata->>'session_id' AS session_id,
+                               MAX(
+                                   CASE
+                                       WHEN metadata->>'file_size' ~ '^[0-9]+$'
+                                       THEN (metadata->>'file_size')::bigint
+                                       ELSE 0
+                                   END
+                               ) AS file_size
                         FROM documents
                         WHERE namespace = $1 AND kind = 'conversation' AND deleted_at IS NULL
                           AND metadata->>'session_id' = ANY($2)
+                        GROUP BY metadata->>'session_id'
                     `, [agent, validIds]);
-                    const existingSessionIds = new Set(
-                        existingResult.rows.map(r => r.session_id.toLowerCase())
-                    );
 
-                    conversationsResponse.missing = validIds.filter(id => !existingSessionIds.has(id));
+                    const existingMap = new Map();
+                    for (const row of existingResult.rows) {
+                        existingMap.set(row.session_id.toLowerCase(), parseInt(row.file_size) || 0);
+                    }
+
+                    const missing = [];
+                    const stale = [];
+                    for (const item of validItems) {
+                        if (!existingMap.has(item.id)) {
+                            missing.push(item.id);
+                        } else if (hasNewFormat && item.file_size > existingMap.get(item.id)) {
+                            // File grew since last upload — session was extended
+                            stale.push(item.id);
+                        }
+                    }
+
+                    conversationsResponse.missing = missing;
+                    if (stale.length > 0) {
+                        conversationsResponse.stale = stale;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Conversation sync now detects sessions whose local file grew since last upload and re-uploads them
- Go client sends `{id, file_size}` pairs instead of plain session IDs
- Server compares client file_size vs stored file_size, returns both `missing` and `stale` arrays
- Backward compatible with legacy `session_ids` format
- Code review feedback addressed: null safety on sessions array, file_size validation, safe SQL cast, GROUP BY for duplicate rows

## Test plan
- [ ] Deploy server change, run memory-sync — first run will re-upload all sessions (stored file_size is 0)
- [ ] Subsequent syncs should show "all up to date" 
- [ ] Mid-session sync followed by session-end sync should show "updated" for the current session

🤖 Generated with [Claude Code](https://claude.com/claude-code)