### PR TITLE
MEM-107: Normalize chat messages — split text from delivery, add discussion_id FK

### DIFF
--- a/go/client/internal/discuss/lifecycle.go
+++ b/go/client/internal/discuss/lifecycle.go
@@ -90,7 +90,7 @@ func SetupCreate(client *APIClient, cfg *Config, logger *Logger) (int, error) {
 
 	logger.Log("Created discussion #%d: %s (status: %s)",
 		resp.Discussion.ID, cfg.Topic, resp.Discussion.Status)
-	logger.Log("Channel: discussion-%d, timeout_at: %s",
+	logger.Log("Discussion ID: %d, timeout_at: %s",
 		resp.Discussion.ID, resp.Discussion.TimeoutAt)
 
 	return resp.Discussion.ID, nil
@@ -189,7 +189,7 @@ func SetupJoin(client *APIClient, cfg *Config, logger *Logger, discussionID int)
 
 	logger.Log("Joined discussion #%d: %s (status: %s)",
 		discussionID, cfg.Topic, joinResp.DiscussionStatus)
-	logger.Log("Channel: discussion-%d, Others: %s",
+	logger.Log("Discussion ID: %d, Others: %s",
 		discussionID, strings.Join(others, ", "))
 
 	return discussionID, nil

--- a/go/client/internal/discuss/transport.go
+++ b/go/client/internal/discuss/transport.go
@@ -78,10 +78,10 @@ func (t *Transport) RestoreState() {
 // Run executes the main transport loop: poll for messages, relay to/from
 // the subagent, check convergence, and handle timeouts.
 func (t *Transport) Run() error {
-	channel := fmt.Sprintf("discussion-%d", t.discussionID)
 	t.logger.Log("Discussion transport starting: %s <-> %s",
 		t.cfg.Agent, strings.Join(t.cfg.OtherAgents(), ", "))
 	t.logger.Log("Work dir: %s", t.cfg.WorkDir)
+	t.logger.Log("Discussion ID: %d", t.discussionID)
 	t.setStatus("POLLING")
 
 	for {
@@ -109,7 +109,7 @@ func (t *Transport) Run() error {
 			t.setStatus("TIMEOUT")
 			time.Sleep(30 * time.Second)
 			if msg, ok := t.paths.CheckOutbox(); ok {
-				t.sendMessage(channel, msg)
+				t.sendMessage(msg)
 			}
 			t.setStatus("DONE")
 			t.paths.WriteDone("timeout")
@@ -128,12 +128,12 @@ func (t *Transport) Run() error {
 			t.lastOutboxTime = time.Now()
 			t.stallWarningLogged = false
 			t.subagentDeathReported = false
-			t.sendMessage(channel, msg)
+			t.sendMessage(msg)
 			time.Sleep(t.cfg.SendDelay)
 		}
 
 		// 5. Poll for incoming messages
-		messages := t.receiveMessages(channel)
+		messages := t.receiveMessages()
 
 		// 6-7. Process: dedup, write inbox, transcript
 		allIDs, newIDs := t.processReceivedMessages(messages)
@@ -145,7 +145,7 @@ func (t *Transport) Run() error {
 		result := t.convergence.Check(t.client, t.discussionID, t.cfg.Agent)
 		if result == "terminate" {
 			t.logger.Log("Convergence termination — exiting transport loop")
-			t.waitForResult(channel)
+			t.waitForResult()
 			t.paths.WriteDone("terminated")
 			t.setStatus("TERMINATED")
 			return nil
@@ -155,7 +155,7 @@ func (t *Transport) Run() error {
 		t.statusCheckCounter++
 		if t.statusCheckCounter >= statusCheckInterval {
 			t.statusCheckCounter = 0
-			if t.checkServerStatus(channel) {
+			if t.checkServerStatus() {
 				return nil
 			}
 		}
@@ -224,7 +224,7 @@ func (t *Transport) IsTerminated() bool {
 // waitForResult gives the subagent time to write result.md after
 // receiving a shutdown notice. Polls for result.md with a 60-second
 // timeout. Also drains any outbox messages while waiting.
-func (t *Transport) waitForResult(channel string) {
+func (t *Transport) waitForResult() {
 	timeout := time.Duration(t.cfg.ResultTimeout) * time.Second
 	poll := 2 * time.Second
 	start := time.Now()
@@ -232,7 +232,7 @@ func (t *Transport) waitForResult(channel string) {
 	for time.Since(start) < timeout {
 		// Drain outbox while waiting
 		if msg, ok := t.paths.CheckOutbox(); ok {
-			t.sendMessage(channel, msg)
+			t.sendMessage(msg)
 		}
 
 		// Check if result.md exists
@@ -247,16 +247,16 @@ func (t *Transport) waitForResult(channel string) {
 	t.logger.Log("WARNING: result.md not found after %ds — proceeding with shutdown", int(timeout.Seconds()))
 	// Final outbox drain
 	if msg, ok := t.paths.CheckOutbox(); ok {
-		t.sendMessage(channel, msg)
+		t.sendMessage(msg)
 	}
 }
 
 // --- Messaging ---
 
-func (t *Transport) receiveMessages(channel string) []ChatMessage {
+func (t *Transport) receiveMessages() []ChatMessage {
 	body := map[string]interface{}{
-		"agent":   t.cfg.Agent,
-		"channel": channel,
+		"agent":         t.cfg.Agent,
+		"discussion_id": t.discussionID,
 	}
 	if t.lastDeliveredID > 0 {
 		body["after_id"] = t.lastDeliveredID
@@ -288,12 +288,11 @@ func (t *Transport) processReceivedMessages(messages []ChatMessage) (allIDs, new
 	return
 }
 
-func (t *Transport) sendMessage(channel, message string) {
+func (t *Transport) sendMessage(message string) {
 	err := t.client.Post("/chat/send", map[string]interface{}{
 		"from_agent":    t.cfg.Agent,
 		"discussion_id": t.discussionID,
 		"message":       message,
-		"channel":       channel,
 	}, nil)
 	if err != nil {
 		// Discussion already concluded — other side left, no recipients
@@ -405,7 +404,7 @@ func (t *Transport) checkTimeout() bool {
 
 // --- Server-side status check ---
 
-func (t *Transport) checkServerStatus(channel string) bool {
+func (t *Transport) checkServerStatus() bool {
 	var resp statusResponse
 	err := t.client.Post("/discussion/status", map[string]interface{}{
 		"discussion_id": t.discussionID,
@@ -421,7 +420,7 @@ func (t *Transport) checkServerStatus(channel string) bool {
 		notice := fmt.Sprintf("[SYSTEM] This discussion has been %s. Please wrap up and write your result file.", status)
 		t.paths.WriteInboxFile(fmt.Sprintf("%s.txt", status), notice)
 		t.paths.AppendTranscript("system", fmt.Sprintf("Discussion %s server-side", status))
-		t.waitForResult(channel)
+		t.waitForResult()
 		t.paths.WriteDone(status)
 		t.setStatus("DONE")
 		return true

--- a/migrations/MEM-107-chat-message-texts_down.sql
+++ b/migrations/MEM-107-chat-message-texts_down.sql
@@ -1,0 +1,35 @@
+-- MEM-107 down: Restore chat_messages to single-table design
+
+BEGIN;
+
+-- 1. Re-add the columns to chat_messages
+ALTER TABLE chat_messages ADD COLUMN message TEXT;
+ALTER TABLE chat_messages ADD COLUMN from_actor_id INTEGER REFERENCES actors(id);
+ALTER TABLE chat_messages ADD COLUMN channel VARCHAR(50);
+ALTER TABLE chat_messages ADD COLUMN sent_at TIMESTAMPTZ DEFAULT NOW();
+
+-- 2. Copy data back from chat_message_texts
+UPDATE chat_messages cm
+SET message = cmt.message,
+    from_actor_id = cmt.from_actor_id,
+    sent_at = cmt.sent_at,
+    channel = CASE
+        WHEN cmt.discussion_id IS NOT NULL THEN 'discussion-' || cmt.discussion_id
+        ELSE NULL
+    END
+FROM chat_message_texts cmt
+WHERE cm.message_text_id = cmt.id;
+
+-- 3. Make columns NOT NULL where needed
+ALTER TABLE chat_messages ALTER COLUMN message SET NOT NULL;
+ALTER TABLE chat_messages ALTER COLUMN from_actor_id SET NOT NULL;
+ALTER TABLE chat_messages ALTER COLUMN sent_at SET NOT NULL;
+
+-- 4. Drop the FK column and index
+DROP INDEX IF EXISTS idx_cm_message_text;
+ALTER TABLE chat_messages DROP COLUMN message_text_id;
+
+-- 5. Drop the new table
+DROP TABLE chat_message_texts;
+
+COMMIT;

--- a/migrations/MEM-107-chat-message-texts_up.sql
+++ b/migrations/MEM-107-chat-message-texts_up.sql
@@ -1,0 +1,108 @@
+-- MEM-107: Split chat_messages into message texts + delivery rows
+--
+-- Before: chat_messages stores one row per recipient, duplicating message text.
+-- After: chat_message_texts stores message content once (with sender, timestamp,
+--        and optional discussion_id). chat_messages becomes a delivery table
+--        referencing the text row.
+
+BEGIN;
+
+-- 1. Create the message text table
+CREATE TABLE chat_message_texts (
+    id SERIAL PRIMARY KEY,
+    message TEXT NOT NULL,
+    from_actor_id INTEGER NOT NULL REFERENCES actors(id),
+    discussion_id INTEGER REFERENCES discussions(id),
+    sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_cmt_discussion ON chat_message_texts (discussion_id) WHERE discussion_id IS NOT NULL;
+CREATE INDEX idx_cmt_from_actor ON chat_message_texts (from_actor_id);
+CREATE INDEX idx_cmt_sent_at ON chat_message_texts (sent_at);
+
+GRANT ALL ON TABLE chat_message_texts TO memory_api;
+GRANT SELECT, INSERT, DELETE, UPDATE ON TABLE chat_message_texts TO claude;
+GRANT ALL ON SEQUENCE chat_message_texts_id_seq TO memory_api;
+GRANT SELECT, USAGE ON SEQUENCE chat_message_texts_id_seq TO claude;
+
+-- 2. Add message_text_id to chat_messages (nullable initially for migration)
+ALTER TABLE chat_messages ADD COLUMN message_text_id INTEGER REFERENCES chat_message_texts(id);
+
+-- 3. Migrate existing data:
+--    For each unique (from_actor_id, message, channel, sent_at) combo,
+--    insert one text row and link all delivery rows to it.
+--    Extract discussion_id from channel string 'discussion-{N}'.
+WITH grouped AS (
+    SELECT
+        from_actor_id,
+        message,
+        channel,
+        sent_at,
+        CASE
+            WHEN channel LIKE 'discussion-%'
+            THEN CAST(SUBSTRING(channel FROM 'discussion-(\d+)') AS INTEGER)
+            ELSE NULL
+        END AS discussion_id,
+        ARRAY_AGG(id) AS delivery_ids
+    FROM chat_messages
+    WHERE deleted_at IS NULL
+    GROUP BY from_actor_id, message, channel, sent_at
+),
+inserted AS (
+    INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at)
+    SELECT message, from_actor_id, discussion_id, sent_at
+    FROM grouped
+    RETURNING id, from_actor_id, message, sent_at
+)
+UPDATE chat_messages cm
+SET message_text_id = ins.id
+FROM inserted ins
+WHERE cm.from_actor_id = ins.from_actor_id
+  AND cm.message = ins.message
+  AND cm.sent_at = ins.sent_at
+  AND cm.message_text_id IS NULL;
+
+-- Also handle soft-deleted messages
+WITH grouped AS (
+    SELECT
+        from_actor_id,
+        message,
+        channel,
+        sent_at,
+        CASE
+            WHEN channel LIKE 'discussion-%'
+            THEN CAST(SUBSTRING(channel FROM 'discussion-(\d+)') AS INTEGER)
+            ELSE NULL
+        END AS discussion_id,
+        ARRAY_AGG(id) AS delivery_ids
+    FROM chat_messages
+    WHERE deleted_at IS NOT NULL AND message_text_id IS NULL
+    GROUP BY from_actor_id, message, channel, sent_at
+),
+inserted AS (
+    INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at)
+    SELECT message, from_actor_id, discussion_id, sent_at
+    FROM grouped
+    RETURNING id, from_actor_id, message, sent_at
+)
+UPDATE chat_messages cm
+SET message_text_id = ins.id
+FROM inserted ins
+WHERE cm.from_actor_id = ins.from_actor_id
+  AND cm.message = ins.message
+  AND cm.sent_at = ins.sent_at
+  AND cm.message_text_id IS NULL;
+
+-- 4. Make message_text_id NOT NULL now that all rows are migrated
+ALTER TABLE chat_messages ALTER COLUMN message_text_id SET NOT NULL;
+
+-- 5. Drop the now-redundant columns from chat_messages
+ALTER TABLE chat_messages DROP COLUMN message;
+ALTER TABLE chat_messages DROP COLUMN from_actor_id;
+ALTER TABLE chat_messages DROP COLUMN channel;
+ALTER TABLE chat_messages DROP COLUMN sent_at;
+
+-- 6. Add index on the FK
+CREATE INDEX idx_cm_message_text ON chat_messages (message_text_id);
+
+COMMIT;

--- a/node/api/public/admin/discussions.js
+++ b/node/api/public/admin/discussions.js
@@ -43,7 +43,7 @@ function useDiscussions({ api, showToast, onEvent }) {
             if (requestId !== currentDiscussionRequest) return;
             selectedDiscussion.value = data;
             // Auto-load transcript
-            const chatData = await api('/admin/chat', { channel: 'discussion-' + id, limit: 500 });
+            const chatData = await api('/admin/chat', { discussion_id: id, limit: 500 });
             if (requestId !== currentDiscussionRequest) return;
             discussionChat.value = chatData.messages.reverse();
             // Scroll dialog to bottom so chat input is visible
@@ -64,7 +64,7 @@ function useDiscussions({ api, showToast, onEvent }) {
 
     async function loadDiscussionChat(id) {
         try {
-            const data = await api('/admin/chat', { channel: 'discussion-' + id, limit: 500 });
+            const data = await api('/admin/chat', { discussion_id: id, limit: 500 });
             discussionChat.value = data.messages.reverse();
             await nextTick();
             scrollDiscussionToBottom();
@@ -143,18 +143,17 @@ function useDiscussions({ api, showToast, onEvent }) {
     // Handle incoming WebSocket chat_message events — append to transcript if relevant
     function handleChatMessage(data) {
         if (!selectedDiscussion.value || !discussionChat.value) return;
-        var expectedChannel = 'discussion-' + selectedDiscussion.value.discussion.id;
-        if (data.channel !== expectedChannel) return;
-        // Avoid duplicates
-        if (discussionChat.value.some(function(m) { return m.id === data.id; })) return;
+        if (data.discussion_id !== selectedDiscussion.value.discussion.id) return;
+        // Avoid duplicates (use message_text_id to prevent fan-out duplication)
+        var dedupId = data.message_text_id || data.id;
+        if (discussionChat.value.some(function(m) { return (m.message_text_id || m.id) === dedupId; })) return;
         discussionChat.value.push({
             id: data.id,
+            message_text_id: data.message_text_id,
             from_agent: data.from_agent,
-            to_agent: data.to_agent,
             message: data.message,
-            channel: data.channel,
-            sent_at: data.sent_at,
-            acked_at: null
+            discussion_id: data.discussion_id,
+            sent_at: data.sent_at
         });
         nextTick().then(scrollDiscussionToBottom);
     }

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -277,19 +277,20 @@ router.post('/admin/dashboard', requirePerm('dashboard', 'read'), adminRoute('da
          LIMIT 10`;
     const discussions = await pool.query(discussionsSql, discussionsParams);
 
-    let chatSql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cm.channel, cm.message, cm.sent_at, cm.acked_at
+    let chatSql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.discussion_id, cmt.message, cmt.sent_at, cm.acked_at
          FROM chat_messages cm
-         JOIN actors fa ON fa.id = cm.from_actor_id
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         JOIN actors fa ON fa.id = cmt.from_actor_id
          JOIN actors ta ON ta.id = cm.to_actor_id
          WHERE fa.name != 'system'
            AND cm.deleted_at IS NULL
-           AND (cm.channel IS NULL OR NOT cm.channel LIKE 'discussion-%')`;
+           AND cmt.discussion_id IS NULL`;
     const chatParams = [];
     if (hasFilter) {
-        chatSql += ' AND (cm.from_actor_id = ANY($1) OR cm.to_actor_id = ANY($1))';
+        chatSql += ' AND (cmt.from_actor_id = ANY($1) OR cm.to_actor_id = ANY($1))';
         chatParams.push(idsArray);
     }
-    chatSql += ` ORDER BY CASE WHEN cm.acked_at IS NULL THEN 0 ELSE 1 END, cm.sent_at DESC LIMIT 15`;
+    chatSql += ` ORDER BY CASE WHEN cm.acked_at IS NULL THEN 0 ELSE 1 END, cmt.sent_at DESC LIMIT 15`;
     const chat = await pool.query(chatSql, chatParams);
 
     let mailSql = `SELECT m.id, fa.name AS from_agent, ta.name AS to_agent, m.subject, m.body, m.sent_at, m.acked_at
@@ -305,9 +306,10 @@ router.post('/admin/dashboard', requirePerm('dashboard', 'read'), adminRoute('da
     mailSql += ` ORDER BY CASE WHEN m.acked_at IS NULL THEN 0 ELSE 1 END, m.sent_at DESC LIMIT 15`;
     const mail = await pool.query(mailSql, mailParams);
 
-    let sysMsgSql = `SELECT cm.id, ta.name AS to_agent, cm.channel, cm.message, cm.sent_at, cm.acked_at
+    let sysMsgSql = `SELECT cm.id, ta.name AS to_agent, cmt.discussion_id, cmt.message, cmt.sent_at, cm.acked_at
          FROM chat_messages cm
-         JOIN actors fa ON fa.id = cm.from_actor_id
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         JOIN actors fa ON fa.id = cmt.from_actor_id
          JOIN actors ta ON ta.id = cm.to_actor_id
          WHERE fa.name = 'system' AND cm.deleted_at IS NULL`;
     const sysMsgParams = [];
@@ -315,7 +317,7 @@ router.post('/admin/dashboard', requirePerm('dashboard', 'read'), adminRoute('da
         sysMsgSql += ' AND cm.to_actor_id = ANY($1)';
         sysMsgParams.push(idsArray);
     }
-    sysMsgSql += ' ORDER BY cm.sent_at DESC LIMIT 15';
+    sysMsgSql += ' ORDER BY cmt.sent_at DESC LIMIT 15';
     const systemMessages = await pool.query(sysMsgSql, sysMsgParams);
 
     // Note counts by namespace, filtered by readable namespaces
@@ -721,30 +723,50 @@ router.post('/admin/discussions/conclude', requirePerm('comms', 'write'), adminR
 
 // POST /admin/chat — list recent chat messages
 router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list', async (req, res) => {
-    const { limit = 50, channel } = req.body;
+    const { limit = 50, discussion_id } = req.body;
     const visibleIds = await getVisibleActorIds(req.actorId);
     const hasFilter = visibleIds !== null;
 
-    let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cm.channel, cm.message, cm.sent_at, cm.acked_at
-               FROM chat_messages cm
-               JOIN actors fa ON fa.id = cm.from_actor_id
-               JOIN actors ta ON ta.id = cm.to_actor_id`;
-    const conditions = ['cm.deleted_at IS NULL'];
-    const params = [];
-    if (channel) {
-        params.push(channel);
-        conditions.push('cm.channel = $' + params.length);
-    }
-    if (hasFilter) {
-        params.push(Array.from(visibleIds));
-        conditions.push('(cm.from_actor_id = ANY($' + params.length + ') OR cm.to_actor_id = ANY($' + params.length + '))');
-    }
-    sql += ' WHERE ' + conditions.join(' AND ');
-    sql += ` ORDER BY cm.sent_at DESC LIMIT $${params.length + 1}`;
-    params.push(limit);
+    const discussionId = discussion_id ? parseInt(discussion_id, 10) : null;
 
-    const result = await pool.query(sql, params);
-    res.json({ messages: result.rows });
+    // For discussion channels, query distinct messages from chat_message_texts
+    // to avoid showing duplicate delivery rows
+    if (discussionId) {
+        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.sent_at, cmt.discussion_id
+                   FROM chat_message_texts cmt
+                   JOIN actors fa ON fa.id = cmt.from_actor_id`;
+        const conditions = ['cmt.discussion_id = $1'];
+        const params = [discussionId];
+        if (hasFilter) {
+            params.push(Array.from(visibleIds));
+            conditions.push('cmt.from_actor_id = ANY($' + params.length + ')');
+        }
+        sql += ' WHERE ' + conditions.join(' AND ');
+        sql += ` ORDER BY cmt.sent_at DESC LIMIT $${params.length + 1}`;
+        params.push(limit);
+
+        const result = await pool.query(sql, params);
+        res.json({ messages: result.rows });
+    } else {
+        // Non-discussion: query delivery rows as before
+        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.sent_at, cm.acked_at
+                   FROM chat_messages cm
+                   JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+                   JOIN actors fa ON fa.id = cmt.from_actor_id
+                   JOIN actors ta ON ta.id = cm.to_actor_id`;
+        const conditions = ['cm.deleted_at IS NULL', 'cmt.discussion_id IS NULL'];
+        const params = [];
+        if (hasFilter) {
+            params.push(Array.from(visibleIds));
+            conditions.push('(cmt.from_actor_id = ANY($' + params.length + ') OR cm.to_actor_id = ANY($' + params.length + '))');
+        }
+        sql += ' WHERE ' + conditions.join(' AND ');
+        sql += ` ORDER BY cmt.sent_at DESC LIMIT $${params.length + 1}`;
+        params.push(limit);
+
+        const result = await pool.query(sql, params);
+        res.json({ messages: result.rows });
+    }
 }));
 
 // POST /admin/mail — list mail
@@ -812,7 +834,9 @@ router.post('/admin/chat/delete', requirePerm('comms', 'delete'), adminRoute('ch
     if (visibleIds !== null) {
         const idsArray = Array.from(visibleIds);
         params.push(idsArray);
-        sql += ' AND (from_actor_id = ANY($2) OR to_actor_id = ANY($2))';
+        sql += ` AND (to_actor_id = ANY($2) OR EXISTS (
+            SELECT 1 FROM chat_message_texts cmt WHERE cmt.id = chat_messages.message_text_id AND cmt.from_actor_id = ANY($2)
+        ))`;
     }
     sql += ' RETURNING id';
     const result = await pool.query(sql, params);
@@ -2474,8 +2498,10 @@ router.post('/admin/actors/delete', requirePerm('agents', 'write'), adminRoute('
             await client.query('DELETE FROM discussion_votes WHERE proposed_by_actor_id = $1', [id]);
             await client.query('DELETE FROM discussion_participants WHERE actor_id = $1', [id]);
 
-            // Chat & mail
-            await client.query('DELETE FROM chat_messages WHERE from_actor_id = $1 OR to_actor_id = $1', [id]);
+            // Chat & mail — delete delivery rows first (FK to chat_message_texts), then orphaned text rows
+            await client.query('DELETE FROM chat_messages WHERE to_actor_id = $1', [id]);
+            await client.query('DELETE FROM chat_messages WHERE message_text_id IN (SELECT id FROM chat_message_texts WHERE from_actor_id = $1)', [id]);
+            await client.query('DELETE FROM chat_message_texts WHERE from_actor_id = $1', [id]);
             await client.query('DELETE FROM mail WHERE from_actor_id = $1 OR to_actor_id = $1', [id]);
 
             // Sessions & keys

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -269,8 +269,9 @@ router.post('/agent/status', apiRoute('agent', 'status', async (req, res) => {
         LEFT JOIN (
             SELECT fa.name AS from_agent, COUNT(*) AS unread_count
             FROM chat_messages cm
-            JOIN actors fa ON fa.id = cm.from_actor_id
-            WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL AND cm.channel IS NULL
+            JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+            JOIN actors fa ON fa.id = cmt.from_actor_id
+            WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL AND cmt.discussion_id IS NULL
             GROUP BY fa.name
         ) c ON c.from_agent = a.agent
         LEFT JOIN (

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -1,32 +1,12 @@
 const { Router } = require('express');
-const pool = require('../db');
-const { log } = require('../services/logger');
-const { requireByName, resolveByName } = require('../services/actors');
+const { chatSend, chatReceive, chatAck, chatStatus, resolveDiscussionId } = require('../services/chat');
 const { apiRoute } = require('../middleware/route-wrapper');
 const sanitize = require('../sanitize');
 
 const router = Router();
 
-const CHANNEL_PATTERN = /^[a-zA-Z0-9_-]{1,50}$/;
-
-function validateChannel(channel) {
-    if (channel === undefined || channel === null) {
-        return { valid: true, value: null };
-    }
-    if (typeof channel !== 'string' || !CHANNEL_PATTERN.test(channel)) {
-        return { valid: false };
-    }
-    return { valid: true, value: channel };
-}
-
-function logChat(action, details) {
-    log('chat', action, details);
-}
-
 router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
-    let { discussion_id } = req.body;
     let message = sanitize.content(req.body.message);
-    let channel = req.body.channel;
     let from_agent = sanitize.agentName(req.body.from_agent);
     let to_agents = Array.isArray(req.body.to_agents)
         ? req.body.to_agents.map(a => a === '*' ? a : sanitize.agentName(a))
@@ -40,116 +20,17 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         from_agent = req.authenticatedAgent;
     }
 
-    if (!from_agent || !message) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Required fields: from_agent, message' }
-        });
-    }
+    // Accept discussion_id directly, or extract from legacy channel string
+    const discussionId = resolveDiscussionId(req.body.discussion_id, req.body.channel);
 
-    if (!to_agents && !discussion_id) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Required: to_agents (array) or discussion_id' }
-        });
-    }
-
-    const ch = validateChannel(channel);
-    if (!ch.valid) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Invalid channel: must match /^[a-zA-Z0-9_-]{1,50}$/' }
-        });
-    }
-
-    // Resolve recipients — union of to_agents and discussion participants
-    const discussionParticipants = new Set();
-    const recipientSet = new Set();
-
-    if (discussion_id) {
-        const fromActor = await requireByName(from_agent);
-        const participants = await pool.query(
-            `SELECT ac.name AS agent FROM discussion_participants dp
-             JOIN actors ac ON ac.id = dp.actor_id
-             WHERE dp.discussion_id = $1 AND dp.status = $2 AND dp.actor_id != $3`,
-            [discussion_id, 'joined', fromActor.id]
-        );
-        for (const row of participants.rows) {
-            discussionParticipants.add(row.agent);
-            recipientSet.add(row.agent);
-        }
-    }
-
-    if (to_agents && to_agents.length === 1 && to_agents[0] === '*') {
-        const fromActor = await requireByName(from_agent);
-        const known = await pool.query(
-            `SELECT ac.name AS agent FROM agent_configuration agc
-             JOIN actors ac ON ac.id = agc.actor_id
-             WHERE agc.actor_id != $1`,
-            [fromActor.id]
-        );
-        for (const row of known.rows) {
-            recipientSet.add(row.agent);
-        }
-    } else if (to_agents) {
-        if (!Array.isArray(to_agents) || to_agents.length === 0) {
-            return res.status(400).json({
-                error: { code: 'BAD_REQUEST', message: 'to_agents must be a non-empty array' }
-            });
-        }
-        for (const agent of to_agents) {
-            recipientSet.add(agent);
-        }
-    }
-
-    // Remove sender from recipients (in case discussion includes them)
-    recipientSet.delete(from_agent);
-
-    const recipients = Array.from(recipientSet);
-    if (recipients.length === 0) {
-        return res.status(400).json({
-            error: { code: 'NO_RECIPIENTS', message: 'No recipients resolved' }
-        });
-    }
-
-    // Validate all recipients exist and resolve actor_ids
-    const fromActor = await requireByName(from_agent);
-    const recipientActors = {};
-    for (const agent of recipients) {
-        const actor = await resolveByName(agent);
-        if (!actor) {
-            return res.status(404).json({
-                error: { code: 'NOT_FOUND', message: `Agent "${agent}" is not registered` }
-            });
-        }
-        recipientActors[agent] = actor;
-    }
-
-    // Insert a message for each recipient
-    // If discussion_id is set, prefix forwarded messages for non-participants
-    const results = [];
-    for (const recipient of recipients) {
-        let msgText = message;
-        if (discussion_id && !discussionParticipants.has(recipient)) {
-            msgText = `[Forwarded from discussion #${discussion_id}] ${message}`;
-        }
-        const result = await pool.query(
-            'INSERT INTO chat_messages (from_actor_id, to_actor_id, message, channel) VALUES ($1, $2, $3, $4) RETURNING id, sent_at',
-            [fromActor.id, recipientActors[recipient].id, msgText, ch.value]
-        );
-        results.push({ id: result.rows[0].id, agent: recipient, sent_at: result.rows[0].sent_at });
-    }
-
-    logChat('send', { from_agent, to_agents: recipients, message_ids: results.map(r => r.id), channel: ch.value, discussion_id: discussion_id || null });
-
-    res.json({
-        from_agent,
-        to_agents: results,
-        sent_at: results[0] ? results[0].sent_at : null
-    });
+    const result = await chatSend(from_agent, to_agents, discussionId, message);
+    res.json(result);
 }));
 
 router.post('/chat/receive', apiRoute('chat', 'receive', async (req, res) => {
     let agent = sanitize.agentName(req.body.agent);
     let from_agent = sanitize.agentName(req.body.from_agent);
-    const { channel, after_id } = req.body;
+    const { after_id } = req.body;
 
     // Enforce agent identity (skip for admin user sessions)
     if (req.authenticatedAgent) {
@@ -159,68 +40,17 @@ router.post('/chat/receive', apiRoute('chat', 'receive', async (req, res) => {
         agent = req.authenticatedAgent;
     }
 
-    if (!agent) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Required field: agent' }
-        });
-    }
-
-    const ch = validateChannel(channel);
-    if (!ch.valid) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Invalid channel: must match /^[a-zA-Z0-9_-]{1,50}$/' }
-        });
-    }
-
     if (after_id !== undefined && (!Number.isInteger(after_id) || after_id < 0)) {
         return res.status(400).json({
             error: { code: 'BAD_REQUEST', message: 'after_id must be a non-negative integer' }
         });
     }
 
-    if (from_agent !== undefined && (typeof from_agent !== 'string' || from_agent.length === 0)) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'from_agent must be a non-empty string' }
-        });
-    }
+    // Accept discussion_id directly, or extract from legacy channel string
+    const discussionId = resolveDiscussionId(req.body.discussion_id, req.body.channel);
 
-    // Build query dynamically — optional channel, after_id, and from_agent filters
-    const actor = await requireByName(agent);
-    let query = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cm.message, cm.sent_at
-                  FROM chat_messages cm
-                  JOIN actors fa ON fa.id = cm.from_actor_id
-                  JOIN actors ta ON ta.id = cm.to_actor_id
-                  WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL`;
-    const params = [actor.id];
-
-    if (ch.value === null) {
-        query += ' AND cm.channel IS NULL';
-    } else {
-        params.push(ch.value);
-        query += ` AND cm.channel = $${params.length}`;
-    }
-
-    if (from_agent) {
-        const fromActor = await requireByName(from_agent);
-        params.push(fromActor.id);
-        query += ` AND cm.from_actor_id = $${params.length}`;
-    }
-
-    if (after_id !== undefined) {
-        params.push(after_id);
-        query += ` AND cm.id > $${params.length}`;
-    }
-
-    query += ' ORDER BY cm.id ASC';
-
-    const result = await pool.query(query, params);
-
-    logChat('receive', { agent, channel: ch.value, after_id: after_id || null, pending_count: result.rows.length, message_ids: result.rows.map(r => r.id) });
-
-    res.json({
-        messages: result.rows,
-        pending_count: result.rows.length
-    });
+    const result = await chatReceive(agent, discussionId, after_id, from_agent);
+    res.json(result);
 }));
 
 router.post('/chat/ack', apiRoute('chat', 'ack', async (req, res) => {
@@ -238,30 +68,12 @@ router.post('/chat/ack', apiRoute('chat', 'ack', async (req, res) => {
         agent = req.authenticatedAgent;
     }
 
-    if (!agent || !ids || !Array.isArray(ids) || ids.length === 0) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Required fields: ids (non-empty array of message IDs)' }
-        });
-    }
-
-    const actor = await requireByName(agent);
-    const result = await pool.query(
-        'UPDATE chat_messages SET acked_at = NOW() WHERE id = ANY($1) AND to_actor_id = $2 AND acked_at IS NULL RETURNING id',
-        [ids, actor.id]
-    );
-
-    logChat('ack', { agent, requested_ids: ids, acked_ids: result.rows.map(r => r.id) });
-
-    res.json({
-        agent,
-        acked: result.rows.length,
-        acked_ids: result.rows.map(r => r.id)
-    });
+    const result = await chatAck(agent, ids);
+    res.json(result);
 }));
 
 router.post('/chat/status', apiRoute('chat', 'status', async (req, res) => {
     let agent = sanitize.agentName(req.body.agent);
-    const { channel } = req.body;
 
     // Enforce agent identity (skip for admin user sessions)
     if (req.authenticatedAgent) {
@@ -271,59 +83,11 @@ router.post('/chat/status', apiRoute('chat', 'status', async (req, res) => {
         agent = req.authenticatedAgent;
     }
 
-    if (!agent) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Required field: agent' }
-        });
-    }
+    // Accept discussion_id directly, or extract from legacy channel string
+    const discussionId = resolveDiscussionId(req.body.discussion_id, req.body.channel);
 
-    const ch = validateChannel(channel);
-    if (!ch.valid) {
-        return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Invalid channel: must match /^[a-zA-Z0-9_-]{1,50}$/' }
-        });
-    }
-
-    const actor = await requireByName(agent);
-    let channelFilter;
-    let params;
-    if (ch.value === null) {
-        channelFilter = 'AND channel IS NULL';
-        params = [actor.id];
-    } else {
-        channelFilter = 'AND channel = $2';
-        params = [actor.id, ch.value];
-    }
-
-    const pending = await pool.query(
-        `SELECT COUNT(*) as count FROM chat_messages WHERE to_actor_id = $1 AND acked_at IS NULL AND deleted_at IS NULL ${channelFilter}`,
-        params
-    );
-
-    const latest = await pool.query(
-        `SELECT MAX(id) as max_id FROM chat_messages WHERE to_actor_id = $1 AND deleted_at IS NULL ${channelFilter}`,
-        params
-    );
-
-    const lastActivity = await pool.query(
-        `SELECT MAX(sent_at) as last_sent FROM chat_messages WHERE to_actor_id = $1 AND deleted_at IS NULL ${channelFilter}`,
-        params
-    );
-
-    const lastAcked = await pool.query(
-        `SELECT MAX(acked_at) as last_acked FROM chat_messages WHERE to_actor_id = $1 AND acked_at IS NOT NULL AND deleted_at IS NULL ${channelFilter}`,
-        params
-    );
-
-    logChat('status', { agent, channel: ch.value });
-
-    res.json({
-        agent,
-        pending_count: parseInt(pending.rows[0].count),
-        max_message_id: latest.rows[0].max_id,
-        last_message_at: lastActivity.rows[0].last_sent,
-        last_ack_at: lastAcked.rows[0].last_acked
-    });
+    const result = await chatStatus(agent, discussionId);
+    res.json(result);
 }));
 
 module.exports = router;

--- a/node/api/src/routes/discussion.js
+++ b/node/api/src/routes/discussion.js
@@ -537,10 +537,8 @@ router.post('/discussion/join', apiRoute('discussion', 'join', async (req, res) 
 
     logDiscussion('join', { discussion_id, agent });
 
-    getDiscussionChannel(discussion_id).then(ch => {
-        sendDiscussionEvent(ch, `${agent} joined the discussion`).catch(err => {
-            console.error('Failed to send join event:', err.message);
-        });
+    sendDiscussionEvent(discussion_id, `${agent} joined the discussion`).catch(err => {
+        console.error('Failed to send join event:', err.message);
     });
 
     // Evaluate readiness if still waiting
@@ -686,10 +684,8 @@ router.post('/discussion/leave', apiRoute('discussion', 'leave', async (req, res
 
     logDiscussion('leave', { discussion_id, agent });
 
-    getDiscussionChannel(discussion_id).then(ch => {
-        sendDiscussionEvent(ch, `${agent} left the discussion`).catch(err => {
-            console.error('Failed to send leave event:', err.message);
-        });
+    sendDiscussionEvent(discussion_id, `${agent} left the discussion`).catch(err => {
+        console.error('Failed to send leave event:', err.message);
     });
 
     res.json({ discussion_id, agent, status: 'left' });
@@ -751,11 +747,9 @@ router.post('/discussion/vote/propose', apiRoute('discussion', 'vote-propose', a
 
     logDiscussion('vote_propose', { discussion_id, vote_id: result.rows[0].id, proposed_by, question, type: voteType });
 
-    getDiscussionChannel(discussion_id).then(ch => {
-        const msg = `${proposed_by} proposed ${voteType} vote #${result.rows[0].id}: ${question}`;
-        sendDiscussionEvent(ch, msg).catch(err => {
-            console.error('Failed to send vote propose event:', err.message);
-        });
+    const voteMsg = `${proposed_by} proposed ${voteType} vote #${result.rows[0].id}: ${question}`;
+    sendDiscussionEvent(discussion_id, voteMsg).catch(err => {
+        console.error('Failed to send vote propose event:', err.message);
     });
 
     res.json({

--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -189,8 +189,7 @@ const TOOLS = [
                 to: { type: 'string', description: 'Recipient agent (e.g., "home", "work") or "*" for broadcast' },
                 message: { type: 'string', description: 'Message to send' },
                 from: { type: 'string', description: 'Sender agent (default: configured agent)' },
-                channel: { type: 'string', description: 'Optional channel for message isolation (e.g., "discussion"). Omit for regular chat.' },
-                discussion_id: { type: 'number', description: 'Send to all joined participants in a discussion (alternative to "to"). Auto-derives channel to discussion-{id} and resolves recipients from joined participants.' }
+                discussion_id: { type: 'number', description: 'Send to all joined participants in a discussion (alternative to "to"). Resolves recipients from joined participants.' }
             },
             required: ['message']
         }
@@ -202,8 +201,7 @@ const TOOLS = [
             type: 'object',
             properties: {
                 agent: { type: 'string', description: 'Agent to check messages for (default: configured agent)' },
-                channel: { type: 'string', description: 'Optional channel to filter by (e.g., "discussion"). Omit for regular chat only.' },
-                discussion_id: { type: 'number', description: 'Filter to messages from a specific discussion. Auto-derives channel to discussion-{id}.' }
+                discussion_id: { type: 'number', description: 'Filter to messages from a specific discussion.' }
             }
         }
     },
@@ -225,7 +223,7 @@ const TOOLS = [
             type: 'object',
             properties: {
                 agent: { type: 'string', description: 'Agent to check status for (default: configured agent)' },
-                channel: { type: 'string', description: 'Optional channel to filter by. Omit for regular chat only.' }
+                discussion_id: { type: 'number', description: 'Filter to a specific discussion. Omit for regular chat only.' }
             }
         }
     },
@@ -387,7 +385,6 @@ const TOOLS = [
             properties: {
                 topic: { type: 'string', description: 'Discussion topic' },
                 participants: { type: 'array', items: { type: 'string' }, description: 'List of participant agent names (must include creator)' },
-                channel: { type: 'string', description: 'Optional chat channel name for this discussion' },
                 created_by: { type: 'string', description: 'Creator agent (default: configured agent)' },
                 mode: { type: 'string', description: 'Discussion mode: "realtime" (transport + subagent, live back-and-forth) or "async" (independent investigation + direct voting). Default: realtime' },
                 context: { type: 'string', description: 'Optional background/context for the discussion (max 10k chars). Visible to joining agents via discussion_status.' }
@@ -827,22 +824,15 @@ const TOOL_HANDLERS = {
         if (args.to) {
             toAgents = [args.to === '*' ? '*' : sanitize.agentName(args.to)];
         }
-        // Auto-detect discussion_id from channel name pattern
-        let discussionId = args.discussion_id;
-        if (!discussionId && args.channel) {
-            const match = args.channel.match(/^discussion-(\d+)$/);
-            if (match) {
-                discussionId = parseInt(match[1], 10);
-            }
-        }
-        const data = await chatSend(fromAgent, toAgents, discussionId, sanitize.content(args.message), args.channel);
+        const discussionId = args.discussion_id || null;
+        const data = await chatSend(fromAgent, toAgents, discussionId, sanitize.content(args.message));
         const targets = data.to_agents.map(r => r.agent).join(', ');
         return `Message sent to ${targets}`;
     },
 
     async chat_receive(args, agent, namespace) {
-        const channel = args.channel || (args.discussion_id ? `discussion-${args.discussion_id}` : undefined);
-        const data = await chatReceive(validateIdentity(args.agent, agent, 'agent'), channel);
+        const discussionId = args.discussion_id || null;
+        const data = await chatReceive(validateIdentity(args.agent, agent, 'agent'), discussionId);
         if (data.messages.length === 0) {
             return 'No new messages.';
         }
@@ -861,7 +851,8 @@ const TOOL_HANDLERS = {
     },
 
     async chat_status(args, agent, namespace) {
-        const data = await chatStatus(validateIdentity(args.agent, agent, 'agent'), args.channel);
+        const discussionId = args.discussion_id || null;
+        const data = await chatStatus(validateIdentity(args.agent, agent, 'agent'), discussionId);
         return `Chat status for ${data.agent}:\n  Pending: ${data.pending_count}\n  Max message ID: ${data.max_message_id}\n  Last message: ${data.last_message_at}\n  Last ack: ${data.last_ack_at}`;
     },
 
@@ -975,10 +966,11 @@ const TOOL_HANDLERS = {
                 COALESCE(m.unread_count, 0)::int AS unread_mail
             FROM agent_status a
             LEFT JOIN (
-                SELECT cm.from_actor_id, COUNT(*) AS unread_count
+                SELECT cmt.from_actor_id, COUNT(*) AS unread_count
                 FROM chat_messages cm
-                WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL AND cm.channel IS NULL
-                GROUP BY cm.from_actor_id
+                JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+                WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL AND cmt.discussion_id IS NULL
+                GROUP BY cmt.from_actor_id
             ) c ON c.from_actor_id = a.actor_id
             LEFT JOIN (
                 SELECT ml.from_actor_id, COUNT(*) AS unread_count
@@ -1082,12 +1074,10 @@ const TOOL_HANDLERS = {
             : args.participants;
         const data = await discussionCreate(
             sanitize.content(args.topic), creator, participants,
-            null, sanitize.identifier(args.channel), args.mode, sanitize.content(args.context)
+            null, null, args.mode, sanitize.content(args.context)
         );
         const parts = data.participants.map(p => `${p.agent} (${p.status})`).join(', ');
-        const channel = args.channel || `discussion-${data.discussion.id}`;
-        let text = `Discussion #${data.discussion.id} created [${data.discussion.mode}]: "${data.discussion.topic}"\nParticipants: ${parts}\nChannel: ${channel}\nUse discussion_id: ${data.discussion.id} with chat_send to message participants.`;
-        return text;
+        return `Discussion #${data.discussion.id} created [${data.discussion.mode}]: "${data.discussion.topic}"\nParticipants: ${parts}\nUse discussion_id: ${data.discussion.id} with chat_send to message participants.`;
     },
 
     async discussion_list(args, agent, namespace) {

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -7,32 +7,33 @@ const { broadcast } = require('./events');
 const systemHandler = require('./system-handler');
 const { resolveByName, resolveMultipleByName, requireByName, canAccessVirtualAgent } = require('./actors');
 
-const CHANNEL_PATTERN = /^[a-zA-Z0-9_-]{1,50}$/;
-
-function validateChannel(channel) {
-    if (channel === undefined || channel === null) {
-        return null;
-    }
-    if (typeof channel !== 'string' || !CHANNEL_PATTERN.test(channel)) {
-        throw Object.assign(new Error('Invalid channel: must match /^[a-zA-Z0-9_-]{1,50}$/'), { statusCode: 400 });
-    }
-    return channel;
-}
-
 function logChat(action, details) {
     log('chat', action, details);
 }
 
-async function chatSend(fromAgent, toAgents, discussionId, message, channel) {
+// Parse discussion_id from either an integer or a legacy 'discussion-{N}' channel string.
+// Returns null if neither is provided.
+function resolveDiscussionId(discussionId, channel) {
+    if (discussionId) {
+        const parsed = parseInt(discussionId, 10);
+        if (isNaN(parsed)) return null;
+        return parsed;
+    }
+    // Legacy backward compat: extract from channel string
+    if (channel) {
+        const match = channel.match(/^discussion-(\d+)$/);
+        if (match) return parseInt(match[1], 10);
+    }
+    return null;
+}
+
+async function chatSend(fromAgent, toAgents, discussionId, message) {
     if (!fromAgent || !message) {
         throw Object.assign(new Error('Required fields: from_agent, message'), { statusCode: 400 });
     }
     if (!toAgents && !discussionId) {
         throw Object.assign(new Error('Required: to_agents (array) or discussion_id'), { statusCode: 400 });
     }
-
-    // Auto-derive channel from discussion_id when not explicitly provided
-    const ch = validateChannel(channel || (discussionId ? `discussion-${discussionId}` : undefined));
 
     // Resolve sender
     const fromActor = await requireByName(fromAgent);
@@ -86,39 +87,44 @@ async function chatSend(fromAgent, toAgents, discussionId, message, channel) {
         }
     }
 
+    // Insert one message text row
+    const textResult = await pool.query(
+        'INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at) VALUES ($1, $2, $3, NOW()) RETURNING id, sent_at',
+        [message, fromActor.id, discussionId || null]
+    );
+    const messageTextId = textResult.rows[0].id;
+    const sentAt = textResult.rows[0].sent_at;
+
+    // Insert one delivery row per recipient
     const results = [];
     for (const recipient of recipients) {
-        let msgText = message;
-        if (discussionId && !discussionParticipants.has(recipient)) {
-            msgText = `[Forwarded from discussion #${discussionId}] ${message}`;
-        }
         const toActor = recipientActors.get(recipient);
         const result = await pool.query(
-            'INSERT INTO chat_messages (from_actor_id, to_actor_id, message, channel) VALUES ($1, $2, $3, $4) RETURNING id, sent_at',
-            [fromActor.id, toActor.id, msgText, ch]
+            'INSERT INTO chat_messages (message_text_id, to_actor_id) VALUES ($1, $2) RETURNING id',
+            [messageTextId, toActor.id]
         );
-        results.push({ id: result.rows[0].id, agent: recipient, sent_at: result.rows[0].sent_at });
+        results.push({ id: result.rows[0].id, agent: recipient, sent_at: sentAt });
     }
 
     // Broadcast to admin WebSocket clients for live updates (once per logical message)
     if (results.length > 0) {
         broadcast('chat_message', {
             id: results[0].id,
+            message_text_id: messageTextId,
             from_agent: fromAgent,
             to_agents: results.map(function(r) { return r.agent; }),
             message: message,
-            channel: ch,
             discussion_id: discussionId || null,
-            sent_at: results[0].sent_at
+            sent_at: sentAt
         });
     }
 
-    logChat('send', { from_agent: fromAgent, to_agents: recipients, message_ids: results.map(r => r.id), channel: ch, discussion_id: discussionId || null });
+    logChat('send', { from_agent: fromAgent, to_agents: recipients, message_text_id: messageTextId, delivery_ids: results.map(r => r.id), discussion_id: discussionId || null });
 
     // Fire-and-forget: if any recipient is 'system', dispatch to system handler
     for (const r of results) {
         if (r.agent === 'system') {
-            systemHandler.handleMessage(r.id, fromAgent, message, ch).catch(() => {});
+            systemHandler.handleMessage(r.id, fromAgent, message, null).catch(() => {});
             break;
         }
     }
@@ -148,7 +154,6 @@ async function chatSend(fromAgent, toAgents, discussionId, message, channel) {
                 if (vr.rows.length === 0) return;
                 const { handleDirectChat } = require('./virtual-agent');
                 for (const row of vr.rows) {
-                    // Access control: check if sender can use this virtual agent
                     const vrActor = recipientActors.get(row.agent);
                     if (vrActor) {
                         const hasAccess = await canAccessVirtualAgent(fromActor.id, vrActor.id);
@@ -161,35 +166,35 @@ async function chatSend(fromAgent, toAgents, discussionId, message, channel) {
         })();
     }
 
-    return { from_agent: fromAgent, to_agents: results, sent_at: results[0] ? results[0].sent_at : null };
+    return { from_agent: fromAgent, to_agents: results, sent_at: sentAt };
 }
 
-async function chatReceive(agent, channel, afterId, fromAgent) {
+async function chatReceive(agent, discussionId, afterId, fromAgent) {
     if (!agent) {
         throw Object.assign(new Error('Required field: agent'), { statusCode: 400 });
     }
 
-    const ch = validateChannel(channel);
     const actor = await requireByName(agent);
 
-    let query = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cm.message, cm.sent_at
+    let query = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.sent_at
                  FROM chat_messages cm
-                 JOIN actors fa ON fa.id = cm.from_actor_id
+                 JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+                 JOIN actors fa ON fa.id = cmt.from_actor_id
                  JOIN actors ta ON ta.id = cm.to_actor_id
                  WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL`;
     const params = [actor.id];
 
-    if (ch === null) {
-        query += ' AND cm.channel IS NULL';
+    if (discussionId) {
+        params.push(discussionId);
+        query += ` AND cmt.discussion_id = $${params.length}`;
     } else {
-        params.push(ch);
-        query += ` AND cm.channel = $${params.length}`;
+        query += ' AND cmt.discussion_id IS NULL';
     }
 
     if (fromAgent) {
         const fromActor = await requireByName(fromAgent);
         params.push(fromActor.id);
-        query += ` AND cm.from_actor_id = $${params.length}`;
+        query += ` AND cmt.from_actor_id = $${params.length}`;
     }
 
     if (afterId !== undefined) {
@@ -201,7 +206,7 @@ async function chatReceive(agent, channel, afterId, fromAgent) {
 
     const result = await pool.query(query, params);
 
-    logChat('receive', { agent, channel: ch, after_id: afterId || null, pending_count: result.rows.length, message_ids: result.rows.map(r => r.id) });
+    logChat('receive', { agent, discussion_id: discussionId || null, after_id: afterId || null, pending_count: result.rows.length, message_ids: result.rows.map(r => r.id) });
 
     return { messages: result.rows, pending_count: result.rows.length };
 }
@@ -223,42 +228,49 @@ async function chatAck(agent, messageIds) {
     return { agent, acked: result.rows.length, acked_ids: result.rows.map(r => r.id) };
 }
 
-async function chatStatus(agent, channel) {
+async function chatStatus(agent, discussionId) {
     if (!agent) {
         throw Object.assign(new Error('Required field: agent'), { statusCode: 400 });
     }
 
-    const ch = validateChannel(channel);
     const actor = await requireByName(agent);
 
-    let channelFilter;
+    let discussionFilter;
     let params;
-    if (ch === null) {
-        channelFilter = 'AND channel IS NULL';
-        params = [actor.id];
+    if (discussionId) {
+        discussionFilter = 'AND cmt.discussion_id = $2';
+        params = [actor.id, discussionId];
     } else {
-        channelFilter = 'AND channel = $2';
-        params = [actor.id, ch];
+        discussionFilter = 'AND cmt.discussion_id IS NULL';
+        params = [actor.id];
     }
 
     const pending = await pool.query(
-        `SELECT COUNT(*) as count FROM chat_messages WHERE to_actor_id = $1 AND acked_at IS NULL AND deleted_at IS NULL ${channelFilter}`,
+        `SELECT COUNT(*) as count FROM chat_messages cm
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         WHERE cm.to_actor_id = $1 AND cm.acked_at IS NULL AND cm.deleted_at IS NULL ${discussionFilter}`,
         params
     );
     const latest = await pool.query(
-        `SELECT MAX(id) as max_id FROM chat_messages WHERE to_actor_id = $1 AND deleted_at IS NULL ${channelFilter}`,
+        `SELECT MAX(cm.id) as max_id FROM chat_messages cm
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         WHERE cm.to_actor_id = $1 AND cm.deleted_at IS NULL ${discussionFilter}`,
         params
     );
     const lastActivity = await pool.query(
-        `SELECT MAX(sent_at) as last_sent FROM chat_messages WHERE to_actor_id = $1 AND deleted_at IS NULL ${channelFilter}`,
+        `SELECT MAX(cmt.sent_at) as last_sent FROM chat_messages cm
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         WHERE cm.to_actor_id = $1 AND cm.deleted_at IS NULL ${discussionFilter}`,
         params
     );
     const lastAcked = await pool.query(
-        `SELECT MAX(acked_at) as last_acked FROM chat_messages WHERE to_actor_id = $1 AND acked_at IS NOT NULL AND deleted_at IS NULL ${channelFilter}`,
+        `SELECT MAX(cm.acked_at) as last_acked FROM chat_messages cm
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         WHERE cm.to_actor_id = $1 AND cm.acked_at IS NOT NULL AND cm.deleted_at IS NULL ${discussionFilter}`,
         params
     );
 
-    logChat('status', { agent, channel: ch });
+    logChat('status', { agent, discussion_id: discussionId || null });
 
     return {
         agent,
@@ -269,4 +281,4 @@ async function chatStatus(agent, channel) {
     };
 }
 
-module.exports = { chatSend, chatReceive, chatAck, chatStatus };
+module.exports = { chatSend, chatReceive, chatAck, chatStatus, resolveDiscussionId };

--- a/node/api/src/services/discussion.js
+++ b/node/api/src/services/discussion.js
@@ -571,10 +571,8 @@ async function discussionConclude(discussionId, agent, { cancel = false } = {}) 
         });
     }
 
-    getDiscussionChannel(discussionId).then(ch => {
-        sendDiscussionEvent(ch, `Discussion ${newStatus} by ${agent}`).catch(err => {
-            console.error('Failed to send conclude event:', err.message);
-        });
+    sendDiscussionEvent(discussionId, `Discussion ${newStatus} by ${agent}`).catch(err => {
+        console.error('Failed to send conclude event:', err.message);
     });
 
     return { discussion_id: discussionId, status: newStatus, outcome };
@@ -623,10 +621,8 @@ async function discussionJoin(discussionId, agent) {
 
     logDiscussion('join', { discussion_id: discussionId, agent });
 
-    getDiscussionChannel(discussionId).then(ch => {
-        sendDiscussionEvent(ch, `${agent} joined the discussion`).catch(err => {
-            console.error('Failed to send join event:', err.message);
-        });
+    sendDiscussionEvent(discussionId, `${agent} joined the discussion`).catch(err => {
+        console.error('Failed to send join event:', err.message);
     });
 
     if (dStatus === 'waiting') {
@@ -727,10 +723,8 @@ async function discussionLeave(discussionId, agent) {
 
     logDiscussion('leave', { discussion_id: discussionId, agent });
 
-    getDiscussionChannel(discussionId).then(ch => {
-        sendDiscussionEvent(ch, `${agent} left the discussion`).catch(err => {
-            console.error('Failed to send leave event:', err.message);
-        });
+    sendDiscussionEvent(discussionId, `${agent} left the discussion`).catch(err => {
+        console.error('Failed to send leave event:', err.message);
     });
 
     // Re-evaluate any open votes — the reduced participant count may now
@@ -776,11 +770,9 @@ async function votePropose(discussionId, proposedBy, question, type, threshold, 
 
     logDiscussion('vote_propose', { discussion_id: discussionId, vote_id: result.rows[0].id, proposed_by: proposedBy, question, type: voteType });
 
-    getDiscussionChannel(discussionId).then(ch => {
-        const msg = `${proposedBy} proposed ${voteType} vote #${result.rows[0].id}: ${question}`;
-        sendDiscussionEvent(ch, msg).catch(err => {
-            console.error('Failed to send vote propose event:', err.message);
-        });
+    const voteMsg = `${proposedBy} proposed ${voteType} vote #${result.rows[0].id}: ${question}`;
+    sendDiscussionEvent(discussionId, voteMsg).catch(err => {
+        console.error('Failed to send vote propose event:', err.message);
     });
 
     // Trigger virtual agents to cast their vote
@@ -851,7 +843,7 @@ async function voteCast(voteId, agent, choice, reason) {
     const voteType = vote.rows[0].type || 'general';
     const voteStatus = updated.rows[0].status;
 
-    getDiscussionChannel(discussionId).then(async (ch) => {
+    (async () => {
         const participants = await pool.query(
             'SELECT actor_id FROM discussion_participants WHERE discussion_id = $1 AND status = $2',
             [discussionId, 'joined']
@@ -866,8 +858,8 @@ async function voteCast(voteId, agent, choice, reason) {
         } else {
             msg += ` ${castCount}/${totalJoined} votes cast.`;
         }
-        sendDiscussionEvent(ch, msg);
-    }).catch(err => {
+        sendDiscussionEvent(discussionId, msg);
+    })().catch(err => {
         console.error('Failed to send vote cast event:', err.message);
     });
 

--- a/node/api/src/services/system-notify.js
+++ b/node/api/src/services/system-notify.js
@@ -2,36 +2,47 @@ const pool = require('../db');
 const systemHandler = require('./system-handler');
 const { requireByName } = require('./actors');
 
-async function sendSystemMessage(toAgent, message, channel) {
+// Insert a text row and a single delivery row for a system message to one agent
+async function sendSystemMessage(toAgent, message, discussionId) {
     const systemActor = await requireByName('system');
     const toActor = await requireByName(toAgent);
-    const result = await pool.query(
-        'INSERT INTO chat_messages (from_actor_id, to_actor_id, message, channel) VALUES ($1, $2, $3, $4) RETURNING id, sent_at',
-        [systemActor.id, toActor.id, message, channel || null]
+
+    const textResult = await pool.query(
+        'INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at) VALUES ($1, $2, $3, NOW()) RETURNING id, sent_at',
+        [message, systemActor.id, discussionId || null]
     );
-    return result.rows[0];
+    const result = await pool.query(
+        'INSERT INTO chat_messages (message_text_id, to_actor_id) VALUES ($1, $2) RETURNING id',
+        [textResult.rows[0].id, toActor.id]
+    );
+    return { id: result.rows[0].id, sent_at: textResult.rows[0].sent_at };
 }
 
-async function sendSystemMessageToMany(toAgents, message, channel) {
+async function sendSystemMessageToMany(toAgents, message, discussionId) {
     const results = [];
     for (const agent of toAgents) {
-        const row = await sendSystemMessage(agent, message, channel);
+        const row = await sendSystemMessage(agent, message, discussionId);
         results.push({ agent, id: row.id, sent_at: row.sent_at });
     }
     return results;
 }
 
-// Post a single system event to a discussion channel.
+// Post a single system event to a discussion.
 // Uses system actor as both sender and receiver — these are broadcast events
 // that appear in admin UI but are ignored by transports (which filter by
 // to_actor_id=self and skip system-to-system messages).
-async function sendDiscussionEvent(channel, message) {
+async function sendDiscussionEvent(discussionId, message) {
     const systemActor = await requireByName('system');
-    const result = await pool.query(
-        'INSERT INTO chat_messages (from_actor_id, to_actor_id, message, channel) VALUES ($1, $2, $3, $4) RETURNING id, sent_at',
-        [systemActor.id, systemActor.id, message, channel]
+
+    const textResult = await pool.query(
+        'INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at) VALUES ($1, $2, $3, NOW()) RETURNING id, sent_at',
+        [message, systemActor.id, discussionId || null]
     );
-    return result.rows[0];
+    const result = await pool.query(
+        'INSERT INTO chat_messages (message_text_id, to_actor_id) VALUES ($1, $2) RETURNING id',
+        [textResult.rows[0].id, systemActor.id]
+    );
+    return { id: result.rows[0].id, sent_at: textResult.rows[0].sent_at };
 }
 
 async function notifyDiscussionInvite(discussionId, topic, createdBy, invitedAgents) {
@@ -41,16 +52,21 @@ async function notifyDiscussionInvite(discussionId, topic, createdBy, invitedAge
 
 // Send a JSON message TO system (reverse direction — triggers system handler).
 // Used by discussion service to trigger virtual agent processing.
-async function notifySystem(payload, channel) {
+async function notifySystem(payload) {
     const message = JSON.stringify(payload);
     const systemActor = await requireByName('system');
+
+    const textResult = await pool.query(
+        'INSERT INTO chat_message_texts (message, from_actor_id, discussion_id, sent_at) VALUES ($1, $2, $3, NOW()) RETURNING id, sent_at',
+        [message, systemActor.id, null]
+    );
     const result = await pool.query(
-        'INSERT INTO chat_messages (from_actor_id, to_actor_id, message, channel) VALUES ($1, $2, $3, $4) RETURNING id, sent_at',
-        [systemActor.id, systemActor.id, message, channel || null]
+        'INSERT INTO chat_messages (message_text_id, to_actor_id) VALUES ($1, $2) RETURNING id',
+        [textResult.rows[0].id, systemActor.id]
     );
     // Dispatch to system handler fire-and-forget
-    systemHandler.handleMessage(result.rows[0].id, 'system', message, channel || null).catch(() => {});
-    return result.rows[0];
+    systemHandler.handleMessage(result.rows[0].id, 'system', message, null).catch(() => {});
+    return { id: result.rows[0].id, sent_at: textResult.rows[0].sent_at };
 }
 
 module.exports = {

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -552,16 +552,15 @@ async function loadDiscussion(discussionId) {
     return { discussion: disc.rows[0], participants: parts.rows };
 }
 
-// Get recent chat history for a discussion channel, excluding system-to-system triggers.
-async function loadChatHistory(channel, limit) {
+// Get recent chat history for a discussion, excluding system messages.
+async function loadChatHistory(discussionId, limit) {
     const result = await pool.query(
-        `SELECT fa.name AS from_agent, ta.name AS to_agent, cm.message, cm.sent_at
-         FROM chat_messages cm
-         JOIN actors fa ON fa.id = cm.from_actor_id
-         JOIN actors ta ON ta.id = cm.to_actor_id
-         WHERE cm.channel = $1 AND cm.deleted_at IS NULL AND NOT (fa.name = 'system' AND ta.name = 'system')
-         ORDER BY cm.id DESC LIMIT $2`,
-        [channel, limit || 50]
+        `SELECT DISTINCT ON (cmt.id) fa.name AS from_agent, cmt.message, cmt.sent_at
+         FROM chat_message_texts cmt
+         JOIN actors fa ON fa.id = cmt.from_actor_id
+         WHERE cmt.discussion_id = $1 AND NOT (fa.name = 'system')
+         ORDER BY cmt.id DESC LIMIT $2`,
+        [discussionId, limit || 50]
     );
     return result.rows.reverse();
 }
@@ -577,13 +576,14 @@ async function loadDirectChatHistory(agent1, agent2) {
     const actor2 = await requireByName(agent2);
 
     const result = await pool.query(
-        `SELECT fa.name AS from_agent, ta.name AS to_agent, cm.message, cm.sent_at
+        `SELECT fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.sent_at
          FROM chat_messages cm
-         JOIN actors fa ON fa.id = cm.from_actor_id
+         JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
+         JOIN actors fa ON fa.id = cmt.from_actor_id
          JOIN actors ta ON ta.id = cm.to_actor_id
-         WHERE cm.channel IS NULL AND cm.deleted_at IS NULL
-         AND ((cm.from_actor_id = $1 AND cm.to_actor_id = $2) OR (cm.from_actor_id = $2 AND cm.to_actor_id = $1))
-         AND cm.sent_at >= NOW() - INTERVAL '1 hour' * $3
+         WHERE cmt.discussion_id IS NULL AND cm.deleted_at IS NULL
+         AND ((cmt.from_actor_id = $1 AND cm.to_actor_id = $2) OR (cmt.from_actor_id = $2 AND cm.to_actor_id = $1))
+         AND cmt.sent_at >= NOW() - INTERVAL '1 hour' * $3
          ORDER BY cm.id DESC LIMIT $4`,
         [actor1.id, actor2.id, hours, maxMessages]
     );
@@ -764,10 +764,10 @@ function buildMailUserMessage(mail) {
     return `From: ${mail.from_agent}\nSubject: ${mail.subject}\n\n${mail.body}`;
 }
 
-// Post an error message to the discussion channel from the virtual agent.
-async function postError(agentName, discussionId, channel, error) {
+// Post an error message to the discussion from the virtual agent.
+async function postError(agentName, discussionId, error) {
     try {
-        await chatSend(agentName, null, discussionId, `[Error: ${error}]`, channel);
+        await chatSend(agentName, null, discussionId, `[Error: ${error}]`);
     } catch (err) {
         logVA('post-error-failed', { agent: agentName, error: err.message });
     }
@@ -836,7 +836,7 @@ async function handleVirtualAgent(payload) {
         return;
     }
 
-    const channel = discussion.channel || `discussion-${discussionId}`;
+
 
     // Find virtual participants who are joined
     const joinedVirtual = [];
@@ -853,7 +853,7 @@ async function handleVirtualAgent(payload) {
     }
 
     // Load chat history
-    const chatHistory = await loadChatHistory(channel, 50);
+    const chatHistory = await loadChatHistory(discussionId, 50);
 
     // For 'message' triggers, skip if the last non-system message was from a virtual agent
     // (prevents infinite response loops)
@@ -881,11 +881,11 @@ async function handleVirtualAgent(payload) {
     for (const agent of joinedVirtual) {
         try {
             if (!agent.api_key) {
-                await postError(agent.agent, discussionId, channel, 'No API key configured');
+                await postError(agent.agent, discussionId, 'No API key configured');
                 continue;
             }
             if (!agent.provider || !agent.model) {
-                await postError(agent.agent, discussionId, channel, 'No provider/model configured');
+                await postError(agent.agent, discussionId, 'No provider/model configured');
                 continue;
             }
 
@@ -903,14 +903,14 @@ async function handleVirtualAgent(payload) {
 
             // Rate limit check
             if (isRateLimited(agent.agent)) {
-                await postError(agent.agent, discussionId, channel, 'Rate limited — too many API calls. Cooling down.');
+                await postError(agent.agent, discussionId, 'Rate limited — too many API calls. Cooling down.');
                 continue;
             }
 
             // Budget check
             const costCheck = await isOverCostLimit(agent);
             if (costCheck.limited) {
-                await postError(agent.agent, discussionId, channel, costCheck.reason);
+                await postError(agent.agent, discussionId, costCheck.reason);
                 continue;
             }
 
@@ -931,16 +931,16 @@ async function handleVirtualAgent(payload) {
                     await castVote(voteId, agent.agent, voteResponse.choice, voteResponse.reason);
                     // Also post the reasoning as a chat message
                     if (voteResponse.reason) {
-                        await chatSend(agent.agent, null, discussionId, voteResponse.reason, channel);
+                        await chatSend(agent.agent, null, discussionId, voteResponse.reason);
                     }
                 } else {
                     // Couldn't parse vote, post response as chat and log
                     logVA('vote-parse-failed', { discussionId, agent: agent.agent });
-                    await chatSend(agent.agent, null, discussionId, response, channel);
+                    await chatSend(agent.agent, null, discussionId, response);
                 }
             } else {
                 // Regular message response
-                await chatSend(agent.agent, null, discussionId, response, channel);
+                await chatSend(agent.agent, null, discussionId, response);
             }
 
             logVA('responded', { discussionId, agent: agent.agent, triggerType, responseLength: response.length });
@@ -971,7 +971,7 @@ async function handleVirtualAgent(payload) {
                 statusCode: 500
             });
             await chatSend(agent.agent, null, discussionId,
-                `[Malfunction] ${agent.agent} encountered an error and is leaving the discussion: ${err.message}`, channel);
+                `[Malfunction] ${agent.agent} encountered an error and is leaving the discussion: ${err.message}`);
             try {
                 const { discussionLeave } = require('./discussion');
                 await discussionLeave(discussionId, agent.agent);
@@ -1049,7 +1049,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         await recordUsage(agent.agent, agent.provider, agent.model, usage, 'chat');
 
         // Send response as direct chat back to the sender
-        await chatSend(agent.agent, [fromAgent], null, response, null);
+        await chatSend(agent.agent, [fromAgent], null, response);
 
         // Ack the incoming message (virtual agent "read" it)
         if (messageId) {

--- a/schema.sql
+++ b/schema.sql
@@ -272,17 +272,41 @@ CREATE VIEW public.agent_status AS
 ALTER VIEW public.agent_status OWNER TO postgres;
 
 --
+-- Name: chat_message_texts; Type: TABLE; Schema: public; Owner: postgres
+-- Stores message content once per logical send (MEM-107)
+--
+
+CREATE TABLE public.chat_message_texts (
+    id integer NOT NULL,
+    message text NOT NULL,
+    from_actor_id integer NOT NULL,
+    discussion_id integer,
+    sent_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE public.chat_message_texts OWNER TO postgres;
+
+CREATE SEQUENCE public.chat_message_texts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.chat_message_texts_id_seq OWNER TO postgres;
+ALTER SEQUENCE public.chat_message_texts_id_seq OWNED BY public.chat_message_texts.id;
+
+--
 -- Name: chat_messages; Type: TABLE; Schema: public; Owner: postgres
+-- Delivery/recipient tracking table (MEM-107)
 --
 
 CREATE TABLE public.chat_messages (
     id integer NOT NULL,
-    message text NOT NULL,
-    sent_at timestamp with time zone DEFAULT now() NOT NULL,
-    acked_at timestamp with time zone,
-    channel character varying(50) DEFAULT NULL::character varying,
-    from_actor_id integer NOT NULL,
+    message_text_id integer NOT NULL,
     to_actor_id integer,
+    acked_at timestamp with time zone,
     deleted_at timestamp with time zone
 );
 
@@ -908,6 +932,8 @@ ALTER TABLE ONLY public.agent_api_keys ALTER COLUMN id SET DEFAULT nextval('publ
 -- Name: chat_messages id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
+ALTER TABLE ONLY public.chat_message_texts ALTER COLUMN id SET DEFAULT nextval('public.chat_message_texts_id_seq'::regclass);
+
 ALTER TABLE ONLY public.chat_messages ALTER COLUMN id SET DEFAULT nextval('public.chat_messages_id_seq'::regclass);
 
 
@@ -1284,14 +1310,18 @@ CREATE UNIQUE INDEX idx_avc_wildcard ON public.actor_visibility_configuration US
 -- Name: idx_chat_messages_to_actor; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_chat_messages_to_actor ON public.chat_messages USING btree (to_actor_id, id);
+CREATE INDEX idx_cmt_discussion ON public.chat_message_texts USING btree (discussion_id) WHERE (discussion_id IS NOT NULL);
+CREATE INDEX idx_cmt_from_actor ON public.chat_message_texts USING btree (from_actor_id);
+CREATE INDEX idx_cmt_sent_at ON public.chat_message_texts USING btree (sent_at);
 
+CREATE INDEX idx_chat_messages_to_actor ON public.chat_messages USING btree (to_actor_id, id);
+CREATE INDEX idx_cm_message_text ON public.chat_messages USING btree (message_text_id);
 
 --
 -- Name: idx_chat_messages_unacked; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_chat_messages_unacked ON public.chat_messages USING btree (to_actor_id, channel) WHERE (acked_at IS NULL);
+CREATE INDEX idx_chat_messages_unacked ON public.chat_messages USING btree (to_actor_id) WHERE (acked_at IS NULL);
 
 
 --
@@ -1518,9 +1548,14 @@ ALTER TABLE ONLY public.agent_permissions
 -- Name: chat_messages fk_chat_from_actor; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public.chat_messages
-    ADD CONSTRAINT fk_chat_from_actor FOREIGN KEY (from_actor_id) REFERENCES public.actors(id);
+ALTER TABLE ONLY public.chat_message_texts
+    ADD CONSTRAINT fk_cmt_from_actor FOREIGN KEY (from_actor_id) REFERENCES public.actors(id);
 
+ALTER TABLE ONLY public.chat_message_texts
+    ADD CONSTRAINT fk_cmt_discussion FOREIGN KEY (discussion_id) REFERENCES public.discussions(id);
+
+ALTER TABLE ONLY public.chat_messages
+    ADD CONSTRAINT fk_cm_message_text FOREIGN KEY (message_text_id) REFERENCES public.chat_message_texts(id);
 
 --
 -- Name: chat_messages fk_chat_to_actor; Type: FK CONSTRAINT; Schema: public; Owner: postgres
@@ -1714,6 +1749,12 @@ GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.agent_status TO claude;
 --
 -- Name: TABLE chat_messages; Type: ACL; Schema: public; Owner: postgres
 --
+
+GRANT ALL ON TABLE public.chat_message_texts TO memory_api;
+GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.chat_message_texts TO claude;
+
+GRANT ALL ON SEQUENCE public.chat_message_texts_id_seq TO memory_api;
+GRANT SELECT,USAGE ON SEQUENCE public.chat_message_texts_id_seq TO claude;
 
 GRANT ALL ON TABLE public.chat_messages TO memory_api;
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE public.chat_messages TO claude;


### PR DESCRIPTION
## Summary
- Split `chat_messages` into `chat_message_texts` (content, sender, discussion_id, timestamp) and `chat_messages` (delivery tracking per recipient). Messages in multi-party discussions are now stored once instead of N times.
- Replace `channel` varchar with `discussion_id` integer FK on `chat_message_texts`. All API endpoints, MCP tools, admin UI, and Go transport updated.
- Legacy channel string accepted at REST route layer for backward compat.

## Migration
- `MEM-107-chat-message-texts_up.sql` / `_down.sql`

## Test plan
- Run migration on dev DB
- Verify chat send/receive via MCP tools
- Verify discussion creation and messaging
- Verify admin UI discussion view
- Verify virtual agent messaging still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)