### PR TITLE
Fix discussion detail not opening after admin UI creation

### DIFF
--- a/node/api/public/admin/discussions.js
+++ b/node/api/public/admin/discussions.js
@@ -97,10 +97,11 @@ function useDiscussions({ api, showToast, onEvent }) {
                 context: discussionContext.value || undefined
             });
             discussionCreating.value = false;
-            showToast('Discussion #' + data.discussion_id + ' created');
+            const newId = data.discussion ? data.discussion.id : data.discussion_id;
+            showToast('Discussion #' + newId + ' created');
             await loadDiscussions();
             // Open the new discussion
-            await viewDiscussion(data.discussion_id);
+            await viewDiscussion(newId);
         } catch (err) {
             showToast(err.message || 'Failed to create discussion', 'error');
         } finally {


### PR DESCRIPTION
## Summary
- Create endpoint returns `{ discussion: { id } }` but frontend read `data.discussion_id` (undefined)
- Detail view never opened, toast showed "Discussion #undefined created"
- Fixed to read `data.discussion.id` with fallback to `data.discussion_id`

Co-Authored-By: Home (Claude Opus 4.6) <noreply@anthropic.com>