### PR TITLE
Fix dashboard live discussion chat using old channel param

### DIFF
--- a/node/api/public/admin/dashboard.js
+++ b/node/api/public/admin/dashboard.js
@@ -34,7 +34,7 @@ function useDashboard({ api, authenticated, onEvent }) {
             try {
                 const [detail, chat] = await Promise.all([
                     api('/admin/discussions/detail', { discussion_id: d.id }),
-                    api('/admin/chat', { channel: 'discussion-' + d.id, limit: 500 })
+                    api('/admin/chat', { discussion_id: d.id, limit: 500 })
                 ]);
                 return {
                     discussion: detail.discussion,
@@ -61,7 +61,7 @@ function useDashboard({ api, authenticated, onEvent }) {
                 try {
                     const [detail, chat] = await Promise.all([
                         api('/admin/discussions/detail', { discussion_id: live.discussion.id }),
-                        api('/admin/chat', { channel: 'discussion-' + live.discussion.id, limit: 500 })
+                        api('/admin/chat', { discussion_id: live.discussion.id, limit: 500 })
                     ]);
                     if (detail.discussion.status !== 'active') return null;
                     return {


### PR DESCRIPTION
## Summary
- Dashboard was sending `{ channel: 'discussion-N' }` to `/admin/chat` but MEM-107 changed the endpoint to use `{ discussion_id: N }`
- The old `channel` param was silently ignored, returning non-discussion messages instead of the discussion transcript
- Dashboard live discussions appeared empty or showed wrong messages

Co-Authored-By: Home (Claude Opus 4.6) <noreply@anthropic.com>