### PR TITLE
MEM-110: Add hosted_realms config entry

### DIFF
--- a/migrations/MEM-110-hosted-realms-config_down.sql
+++ b/migrations/MEM-110-hosted-realms-config_down.sql
@@ -1,0 +1,3 @@
+-- MEM-110 rollback: Remove hosted_realms config entry
+
+DELETE FROM config WHERE key = 'hosted_realms';

--- a/migrations/MEM-110-hosted-realms-config_up.sql
+++ b/migrations/MEM-110-hosted-realms-config_up.sql
@@ -1,0 +1,9 @@
+-- MEM-110: Add hosted_realms config entry
+--
+-- Lists all realms hosted by this instance. Used for realm management UI,
+-- invite code creation, and validation — instead of querying DISTINCT realms
+-- from the actors table.
+
+INSERT INTO config (key, value, description)
+VALUES ('hosted_realms', 'llm-memory,zbbs',
+        'Comma-separated list of all realms hosted by this instance. Used for realm management UI, invite code creation, and validation.');

--- a/node/api/public/admin/core.js
+++ b/node/api/public/admin/core.js
@@ -375,6 +375,15 @@ function useCore() {
         return fallbackColors[Math.abs(hash) % fallbackColors.length];
     }
 
+    function realmColor(realm) {
+        if (!realm) return 'var(--text-muted)';
+        let hash = 0;
+        for (let i = 0; i < realm.length; i++) {
+            hash = realm.charCodeAt(i) + ((hash << 5) - hash);
+        }
+        return fallbackColors[Math.abs(hash) % fallbackColors.length];
+    }
+
     function voteQuestion(text) {
         const match = text.match(/^(.*?\?)\s*(.+)$/);
         if (!match) return { question: text, choices: [] };
@@ -406,7 +415,7 @@ function useCore() {
         api, showConfirm, executeConfirm, cancelConfirm, confirmPrompt,
         showToast, toast,
         formatDate, formatShortDate, timeAgo, formatBytes, formatDuration, formatTime,
-        statusIcon, outcomeIcon, agentColor, voteQuestion, lastSeenColor,
+        statusIcon, outcomeIcon, agentColor, realmColor, voteQuestion, lastSeenColor,
         USER_ROLE_LABEL
     };
 }

--- a/node/api/public/admin/views/agents.html
+++ b/node/api/public/admin/views/agents.html
@@ -11,6 +11,7 @@
                     <col style="width: 16em;">
                     <col style="width: 10em;">
                     <col>
+                    <col style="width: 10em;">
                     <col style="width: 9em;">
                     <col style="width: 9em;">
                     <col class="col-time">
@@ -21,6 +22,7 @@
                         <th class="sortable" @click="toggleAgentSort('agent')">Agent <span class="sort-arrow" v-html="agentSortArrow('agent')"></span></th>
                         <th class="sortable" @click="toggleAgentSort('personality')">Personality <span class="sort-arrow" v-html="agentSortArrow('personality')"></span></th>
                         <th class="sortable" @click="toggleAgentSort('provider')">Provider / Model <span class="sort-arrow" v-html="agentSortArrow('provider')"></span></th>
+                        <th>Realms</th>
                         <th>Who Can See</th>
                         <th>Who Can Use</th>
                         <th class="sortable time-cell" @click="toggleAgentSort('last_seen')">Last Seen <span class="sort-arrow" v-html="agentSortArrow('last_seen')"></span></th>
@@ -42,6 +44,12 @@
                         <td class="muted">
                             {{ [agent.provider, agent.model].filter(Boolean).join(' / ') || '—' }}
                             <br v-if="agent.pricing_info"><small v-if="agent.pricing_info" style="opacity: 0.7;">{{ agent.pricing_info }}</small>
+                        </td>
+                        <td class="ts">
+                            <template v-if="agent.realms && agent.realms.length">
+                                <span v-for="(r, i) in agent.realms" :key="r"><span :style="{ color: realmColor(r) }">{{ r }}</span><span v-if="i < agent.realms.length - 1" class="muted">, </span></span>
+                            </template>
+                            <span v-else class="muted">—</span>
                         </td>
                         <td class="ts">
                             <span class="access-badge" :class="agent.visibility_summary === 'all agents' ? 'access-badge--accent' : ''">

--- a/node/api/public/admin/views/config.html
+++ b/node/api/public/admin/views/config.html
@@ -24,6 +24,7 @@
                     <col style="width: 10em;">
                     <col style="width: 6em;">
                     <col style="width: 10em;">
+                    <col style="width: 10em;">
                     <col>
                     <col class="col-time">
                 </colgroup>
@@ -32,6 +33,7 @@
                         <th class="col-activity"></th>
                         <th class="sortable" @click="toggleActorSort('name')">Name <span class="sort-arrow" v-html="actorSortArrow('name')"></span></th>
                         <th class="sortable" @click="toggleActorSort('is_agent')">Type <span class="sort-arrow" v-html="actorSortArrow('is_agent')"></span></th>
+                        <th>Realms</th>
                         <th class="sortable" @click="toggleActorSort('personality')">Personality <span class="sort-arrow" v-html="actorSortArrow('personality')"></span></th>
                         <th class="sortable" @click="toggleActorSort('provider')">Provider / Model <span class="sort-arrow" v-html="actorSortArrow('provider')"></span></th>
                         <th class="sortable time-cell" @click="toggleActorSort('last_seen')">Last Seen <span class="sort-arrow" v-html="actorSortArrow('last_seen')"></span></th>
@@ -52,6 +54,9 @@
                         <td>
                             <span v-if="actor.is_agent" class="badge badge-type-agent">agent</span>
                             <span v-if="actor.is_user" class="badge badge-type-user">user</span>
+                        </td>
+                        <td>
+                            <span v-for="r in (actor.realms || [])" :key="r" class="badge" :style="{ background: realmColor(r) + '33', color: realmColor(r), marginRight: '4px' }">{{ r }}</span>
                         </td>
                         <td class="muted truncate" style="font-style: italic;">{{ actor.personality || '' }}</td>
                         <td class="muted">

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -378,10 +378,12 @@ router.post('/admin/agents', requirePerm('agents', 'read'), adminRoute('agents-l
     // Subqueries for visibility and VA access summaries shown in the agent list
     let sql = `SELECT s.agent, s.actor_id, s.status, s.last_seen, s.passphrase_rotated_at, s.registered_at, s.provider, s.model, s.virtual, s.personality, s.active_since,
                 s.cost_budget_daily, s.cost_budget_monthly, s.cache_prompts, s.learning_enabled, s.max_tokens, s.temperature, s.dream_mode, s.storage_quota, ac.configuration,
+                a.realms,
                 COALESCE(vis.summary, 'self only') AS visibility_summary,
                 va.summary AS va_access_summary
          FROM agent_status s
          LEFT JOIN agent_configuration ac ON ac.actor_id = s.actor_id
+         LEFT JOIN actors a ON a.id = s.actor_id
          LEFT JOIN LATERAL (
              SELECT CASE
                  WHEN EXISTS (SELECT 1 FROM actor_visibility_configuration WHERE actor_id = s.actor_id AND target_actor_id IS NULL)
@@ -2134,6 +2136,7 @@ router.post('/admin/actors/list', requirePerm('agents', 'read'), adminRoute('act
         `SELECT a.id, a.name, a.created_at, a.visible_to_others, a.created_by,
                 (ac.actor_id IS NOT NULL) AS is_agent,
                 (a.password_hash IS NOT NULL) AS is_user,
+                a.realms,
                 s.status, s.last_seen, s.registered_at,
                 s.provider, s.model, s.virtual, s.personality,
                 s.active_since, ac.configuration,


### PR DESCRIPTION
## Summary
- Adds `hosted_realms` config table entry listing all realms hosted by this instance (`llm-memory,zbbs`)
- Used for realm management UI, invite code creation, and validation — instead of querying DISTINCT realms from actors table

## Test plan
- [ ] Verify config row exists after migration: `SELECT * FROM config WHERE key = 'hosted_realms'`
- [ ] Verify value matches expected realms for this instance

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Home