### PR TITLE
Refactor agent identity section, add realm management

### DIFF
--- a/node/api/public/admin/agents.js
+++ b/node/api/public/admin/agents.js
@@ -6,6 +6,7 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
     const agents = ref([]);
     const selectedAgent = ref(null);
     const defaultStorageQuota = ref(52428800); // updated from backend on load
+    const hostedRealms = ref([]); // available realms from config
 
     // Sortable table — default sort by agent name
     const agentSort = useSortable(agents, 'agent', 'asc');
@@ -36,6 +37,9 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
     const agentProfileApiKey = ref('');
     const agentProfilePersonality = ref('');
     const agentProfileDreamMode = ref('none');
+    const agentProfileLearningEnabled = ref(true);
+    const agentProfileStorageQuota = ref('');
+    const agentProfileRealms = ref([]);
     const agentProfileSaving = ref(false);
 
     // Cost budgets
@@ -47,10 +51,8 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
     const agentUsageHistory = ref([]);
     const agentUsageLoading = ref(false);
 
-    // Agent settings (dynamic configuration)
+    // Agent settings (model-specific configuration only)
     const agentSettingsEditing = ref(false);
-    const agentSettingsLearningEnabled = ref(true);
-    const agentSettingsStorageQuota = ref('');
     const agentSettingsConfig = ref({});
     const agentSettingsSaving = ref(false);
 
@@ -246,6 +248,9 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
             if (data.default_storage_quota) {
                 defaultStorageQuota.value = data.default_storage_quota;
             }
+            if (data.hosted_realms) {
+                hostedRealms.value = data.hosted_realms;
+            }
             if (selectedAgent.value) {
                 const updated = data.agents.find(a => a.agent === selectedAgent.value.agent);
                 // Merge list data onto existing selectedAgent so detail-only fields (configuration, expertise, etc.) survive
@@ -269,10 +274,22 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         agentProfileModel.value = selectedAgent.value.model || '';
         agentProfilePersonality.value = selectedAgent.value.personality || '';
         agentProfileDreamMode.value = selectedAgent.value.dream_mode || 'none';
+        agentProfileLearningEnabled.value = selectedAgent.value.learning_enabled !== false;
+        agentProfileStorageQuota.value = selectedAgent.value.storage_quota != null ? Math.round(selectedAgent.value.storage_quota / (1024 * 1024)) : '';
+        agentProfileRealms.value = selectedAgent.value.realms ? [...selectedAgent.value.realms] : [];
         agentProfileApiKey.value = '';
         // Pre-fetch catalog if editing an agent already on OpenRouter
         if (agentProfileProvider.value === 'openrouter') {
             loadOpenRouterCatalog();
+        }
+    }
+
+    function toggleProfileRealm(realm) {
+        const idx = agentProfileRealms.value.indexOf(realm);
+        if (idx >= 0) {
+            agentProfileRealms.value.splice(idx, 1);
+        } else {
+            agentProfileRealms.value.push(realm);
         }
     }
 
@@ -294,12 +311,16 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
     async function saveProfile() {
         agentProfileSaving.value = true;
         try {
+            const quotaBytes = agentProfileStorageQuota.value !== '' ? parseInt(agentProfileStorageQuota.value) * 1024 * 1024 : null;
             const body = {
                 agent: selectedAgent.value.agent,
                 provider: agentProfileProvider.value || null,
                 model: agentProfileModel.value || null,
                 personality: agentProfilePersonality.value || null,
-                dream_mode: agentProfileDreamMode.value || 'none'
+                dream_mode: agentProfileDreamMode.value || 'none',
+                learning_enabled: agentProfileLearningEnabled.value,
+                storage_quota: quotaBytes,
+                realms: agentProfileRealms.value
             };
             if (agentProfileApiKey.value) {
                 body.api_key = agentProfileApiKey.value;
@@ -309,6 +330,9 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
             selectedAgent.value.model = agentProfileModel.value || null;
             selectedAgent.value.personality = agentProfilePersonality.value || null;
             selectedAgent.value.dream_mode = agentProfileDreamMode.value || 'none';
+            selectedAgent.value.learning_enabled = agentProfileLearningEnabled.value;
+            selectedAgent.value.storage_quota = quotaBytes;
+            selectedAgent.value.realms = [...agentProfileRealms.value];
             agentProfileEditing.value = false;
             showToast('Profile updated', 'success');
         } catch (err) {
@@ -363,8 +387,6 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
     function startEditSettings() {
         loadProviderRegistry();
         agentSettingsEditing.value = true;
-        agentSettingsLearningEnabled.value = selectedAgent.value.learning_enabled !== false;
-        agentSettingsStorageQuota.value = selectedAgent.value.storage_quota != null ? Math.round(selectedAgent.value.storage_quota / (1024 * 1024)) : '';
 
         // Load config, filling in defaults from capabilities where not set
         const conf = parseAgentConfig(selectedAgent.value);
@@ -386,16 +408,11 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
             if (version != null) {
                 configCopy._configVersion = version;
             }
-            const quotaBytes = agentSettingsStorageQuota.value !== '' ? parseInt(agentSettingsStorageQuota.value) * 1024 * 1024 : null;
             const body = {
                 agent: selectedAgent.value.agent,
-                learning_enabled: agentSettingsLearningEnabled.value,
-                storage_quota: quotaBytes,
                 configuration: configCopy
             };
             await api('/admin/agents/update', body);
-            selectedAgent.value.learning_enabled = body.learning_enabled;
-            selectedAgent.value.storage_quota = quotaBytes;
             selectedAgent.value.configuration = JSON.stringify(configCopy);
             // Sync legacy columns for display consistency
             if (agentSettingsConfig.value.cache_prompts !== undefined) {
@@ -660,13 +677,15 @@ function useAgents({ api, showToast, showConfirm, onEvent }) {
         agentInstructions, agentInstructionsEditing, agentInstructionsExpanded, agentInstructionsEditContent, agentInstructionsSaving,
         agentExpertise, agentExpertiseEditing, agentExpertiseEditText, agentExpertiseSaving,
         agentPassphraseConfirming, agentNewPassphrase,
-        agentProfileEditing, agentProfileProvider, agentProfileModel, agentProfileApiKey, agentProfilePersonality, agentProfileDreamMode, agentProfileSaving,
+        agentProfileEditing, agentProfileProvider, agentProfileModel, agentProfileApiKey, agentProfilePersonality, agentProfileDreamMode,
+        agentProfileLearningEnabled, agentProfileStorageQuota, agentProfileRealms, agentProfileSaving,
+        hostedRealms,
         loadAgents, viewAgent,
-        startEditProfile, onProfileProviderChange, saveProfile,
+        startEditProfile, onProfileProviderChange, toggleProfileRealm, saveProfile,
         costBudgetEditing, costBudgetDailyValue, costBudgetMonthlyValue, startEditCostBudget, saveCostBudget,
         agentUsageHistory, agentUsageLoading, loadUsageHistory,
         defaultStorageQuota,
-        agentSettingsEditing, agentSettingsLearningEnabled, agentSettingsStorageQuota, agentSettingsConfig, agentSettingsSaving,
+        agentSettingsEditing, agentSettingsConfig, agentSettingsSaving,
         startEditSettings, saveSettings,
         startEditInstructions, cancelEditInstructions, saveInstructions,
         startEditExpertise, cancelEditExpertise, saveExpertise,

--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -1129,10 +1129,22 @@ dialog article header button[aria-label="Close"]::after {
     display: flex;
     align-items: center;
     gap: 14px;
+    margin-bottom: 12px;
+}
+
+/* Agent properties shown below identity header */
+.agent-properties {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px 16px;
+    font-size: 13px;
     padding-bottom: 18px;
     border-bottom: 1px solid var(--border-subtle);
     margin-bottom: 20px;
 }
+.agent-prop { display: flex; gap: 8px; align-items: baseline; }
+.agent-prop-label { color: var(--text-muted); min-width: 70px; }
+.agent-prop-value { color: var(--text); }
 
 .agent-avatar-lg {
     width: 44px;

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -34,12 +34,40 @@
                         <span v-if="selectedAgent.provider || selectedAgent.model">{{ [selectedAgent.provider, selectedAgent.model].filter(Boolean).join(' / ') }}</span>
                         <button v-if="!agentProfileEditing && canDo('agents', 'write')" class="btn btn-ghost btn-compact" @click="startEditProfile" title="Edit"><i class="icon-edit"></i></button>
                     </div>
-                    <div v-if="selectedAgent.personality" class="agent-identity-meta" style="font-style: italic; margin-top: 2px;">{{ selectedAgent.personality }}</div>
-                    <div v-if="selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none'" class="agent-identity-meta" style="margin-top: 2px;">
-                        <span class="badge" :style="{ background: selectedAgent.dream_mode === 'companion' ? '#7c3aed22' : '#0891b222', color: selectedAgent.dream_mode === 'companion' ? '#7c3aed' : '#0891b2' }">
-                            <i :class="selectedAgent.dream_mode === 'companion' ? 'icon-heart' : 'icon-code'" style="margin-right: 3px;"></i>{{ selectedAgent.dream_mode }} dream
+                </div>
+            </div>
+
+            <!-- Agent properties (visible without editing) -->
+            <div v-if="!agentProfileEditing" class="agent-properties">
+                <div v-if="selectedAgent.personality" class="agent-prop">
+                    <span class="agent-prop-label">Personality</span>
+                    <span class="agent-prop-value" style="font-style: italic;">{{ selectedAgent.personality }}</span>
+                </div>
+                <div class="agent-prop">
+                    <span class="agent-prop-label">Dream</span>
+                    <span class="agent-prop-value">
+                        <span v-if="selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none'" class="badge" :style="{ background: selectedAgent.dream_mode === 'companion' ? '#7c3aed22' : '#0891b222', color: selectedAgent.dream_mode === 'companion' ? '#7c3aed' : '#0891b2' }">
+                            <i :class="selectedAgent.dream_mode === 'companion' ? 'icon-heart' : 'icon-code'" style="margin-right: 3px;"></i>{{ selectedAgent.dream_mode }}
                         </span>
-                    </div>
+                        <span v-else class="muted">none</span>
+                    </span>
+                </div>
+                <div class="agent-prop">
+                    <span class="agent-prop-label">Learning</span>
+                    <span class="agent-prop-value">{{ selectedAgent.learning_enabled !== false ? 'on' : 'off' }}</span>
+                </div>
+                <div class="agent-prop">
+                    <span class="agent-prop-label">Storage</span>
+                    <span class="agent-prop-value">{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</span>
+                </div>
+                <div class="agent-prop">
+                    <span class="agent-prop-label">Realms</span>
+                    <span class="agent-prop-value">
+                        <template v-if="selectedAgent.realms && selectedAgent.realms.length">
+                            <span v-for="r in selectedAgent.realms" :key="r" class="badge" :style="{ background: realmColor(r) + '33', color: realmColor(r), marginRight: '4px' }">{{ r }}</span>
+                        </template>
+                        <span v-else class="muted">none</span>
+                    </span>
                 </div>
             </div>
 
@@ -61,15 +89,32 @@
                 <small v-if="modelDeprecation(agentProfileProvider, agentProfileModel)" style="color: var(--error); display: block; margin: 4px 0;">
                     &#9888; {{ modelDeprecation(agentProfileProvider, agentProfileModel) }}
                 </small>
-                <label>Dream Mode
-                    <custom-select v-model="agentProfileDreamMode"
-                        :options="[{ value: 'none', label: 'None' }, { value: 'companion', label: 'Companion' }, { value: 'technical', label: 'Technical' }]"
-                        placeholder="None" />
-                    <small class="ts">Post-session log analysis: companion (emotional/personal) or technical (work/code-focused)</small>
-                </label>
                 <label>Personality
                     <input type="text" v-model="agentProfilePersonality" placeholder="Short personality description">
                 </label>
+                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+                    <label>Dream Mode
+                        <custom-select v-model="agentProfileDreamMode"
+                            :options="[{ value: 'none', label: 'None' }, { value: 'companion', label: 'Companion' }, { value: 'technical', label: 'Technical' }]"
+                            placeholder="None" />
+                    </label>
+                    <label>Storage Quota (MB)
+                        <input type="number" v-model="agentProfileStorageQuota" placeholder="blank = default" min="1">
+                    </label>
+                </div>
+                <label class="checkbox-label">
+                    <input type="checkbox" v-model="agentProfileLearningEnabled"> Learning enabled
+                </label>
+                <div>
+                    <label style="margin-bottom: 4px; display: block;">Realms</label>
+                    <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                        <span v-for="r in hostedRealms" :key="r" class="badge" style="cursor: pointer; user-select: none;"
+                            :style="agentProfileRealms.includes(r)
+                                ? { background: realmColor(r) + '33', color: realmColor(r), border: '1px solid ' + realmColor(r) }
+                                : { background: 'transparent', color: 'var(--text-muted)', border: '1px dashed var(--border)' }"
+                            @click="toggleProfileRealm(r)">{{ r }}</span>
+                    </div>
+                </div>
                 <label v-if="selectedAgent.virtual">API Key
                     <input type="password" v-model="agentProfileApiKey" placeholder="Enter new key to change (leave blank to keep current)">
                 </label>
@@ -165,30 +210,19 @@
                 <small v-if="agentUsageLoading" class="ts">Loading usage...</small>
             </div>
 
-            <!-- Configuration card (virtual agents) -->
-            <div v-if="selectedAgent.virtual" class="agent-card">
+            <!-- Model-specific configuration card (virtual agents with provider+model set) -->
+            <div v-if="selectedAgent.virtual && selectedAgent.provider && selectedAgent.model && Object.keys(capabilitiesFor(selectedAgent.provider, selectedAgent.model)).length > 0" class="agent-card">
                 <div class="agent-card-header">
-                    <span class="agent-card-title"><i class="icon-settings"></i>Configuration</span>
+                    <span class="agent-card-title"><i class="icon-settings"></i>Model Settings</span>
                     <button v-if="!agentSettingsEditing" class="btn btn-ghost btn-compact" @click="startEditSettings" title="Edit"><i class="icon-edit"></i></button>
                 </div>
                 <div v-if="!agentSettingsEditing" style="font-size: 13px; line-height: 1.8;">
-                    <span>Learning: <strong>{{ selectedAgent.learning_enabled !== false ? 'on' : 'off' }}</strong></span>
-                    <br><span>Storage quota: <strong>{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</strong></span>
                     <template v-for="(cap, key) in capabilitiesFor(selectedAgent.provider, selectedAgent.model)" :key="key">
-                        <br><span>{{ cap.label }}: <strong>{{ formatConfigValue(key, parseAgentConfig(selectedAgent)[key], cap) }}</strong></span>
-                    </template>
-                    <template v-if="!selectedAgent.provider || !selectedAgent.model">
-                        <br><span class="ts">Set a provider and model to see configuration options.</span>
+                        <span>{{ cap.label }}: <strong>{{ formatConfigValue(key, parseAgentConfig(selectedAgent)[key], cap) }}</strong></span><br>
                     </template>
                 </div>
                 <!-- Edit mode -->
                 <div v-if="agentSettingsEditing">
-                    <label class="checkbox-label">
-                        <input type="checkbox" v-model="agentSettingsLearningEnabled"> Learning enabled
-                    </label>
-                    <label>Storage quota (MB)
-                        <input type="number" v-model="agentSettingsStorageQuota" placeholder="blank = default" min="1">
-                    </label>
                     <template v-for="(cap, key) in capabilitiesFor(selectedAgent.provider, selectedAgent.model)" :key="key">
                         <div v-if="capabilityVisible(cap, agentSettingsConfig)" style="margin-bottom: 8px;" :style="capabilityDisabled(cap, agentSettingsConfig) ? { opacity: 0.45 } : {}">
                             <label v-if="cap.type === 'boolean'" class="checkbox-label">

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -436,11 +436,12 @@ router.post('/admin/agents', requirePerm('agents', 'read'), adminRoute('agents-l
         delete row.configuration;
     }
 
-    // Include global default storage quota so the frontend can display it
+    // Include global defaults so the frontend can display them
     const config = require('../services/config');
     const defaultStorageQuota = parseInt(config.get('default_storage_quota')) || 52428800;
+    const hostedRealms = (config.get('hosted_realms') || '').split(',').map(r => r.trim()).filter(Boolean);
 
-    res.json({ agents: result.rows, default_storage_quota: defaultStorageQuota });
+    res.json({ agents: result.rows, default_storage_quota: defaultStorageQuota, hosted_realms: hostedRealms });
 }));
 
 // POST /admin/agents/instructions/read — read an agent's startup instructions
@@ -1933,7 +1934,7 @@ router.post('/admin/agents/read', requirePerm('agents', 'read'), adminRoute('age
                 agc.cache_prompts, agc.learning_enabled, agc.max_tokens, agc.temperature,
                 agc.cost_budget_daily, agc.cost_budget_monthly, agc.storage_quota,
                 agc.api_key IS NOT NULL AS has_api_key,
-                agc.dream_mode
+                agc.dream_mode, ac.realms
          FROM agent_configuration agc
          JOIN actors ac ON ac.id = agc.actor_id
          WHERE agc.actor_id = $1`,
@@ -1995,7 +1996,7 @@ router.post('/admin/agents/update', requirePerm('agents', 'write'), adminRoute('
     const agent = sanitize.agentName(req.body.agent);
     const { personality, api_key, configuration, provider, model,
             cost_budget_daily, cost_budget_monthly, storage_quota,
-            cache_prompts, learning_enabled, max_tokens, temperature, dream_mode } = req.body;
+            cache_prompts, learning_enabled, max_tokens, temperature, dream_mode, realms } = req.body;
 
     if (!agent) {
         return res.status(400).json({
@@ -2081,19 +2082,30 @@ router.post('/admin/agents/update', requirePerm('agents', 'write'), adminRoute('
         updates.push(`dream_mode = $${idx++}`);
     }
 
-    if (updates.length === 0) {
+    // Realms lives on actors table, not agent_configuration — handle separately
+    const hasRealmsUpdate = Array.isArray(realms);
+
+    if (updates.length === 0 && !hasRealmsUpdate) {
         return res.status(400).json({
             error: { code: 'BAD_REQUEST', message: 'No fields to update' }
         });
     }
 
-    params.push(actor.id);
-    await pool.query(
-        `UPDATE agent_configuration SET ${updates.join(', ')} WHERE actor_id = $${idx}`,
-        params
-    );
+    if (updates.length > 0) {
+        params.push(actor.id);
+        await pool.query(
+            `UPDATE agent_configuration SET ${updates.join(', ')} WHERE actor_id = $${idx}`,
+            params
+        );
+    }
 
-    logAdmin('agent_update', { agent, fields: updates.map(u => u.split(' ')[0]), user_id: req.authenticatedUser.id });
+    if (hasRealmsUpdate) {
+        await pool.query('UPDATE actors SET realms = $1 WHERE id = $2', [realms, actor.id]);
+    }
+
+    const allFields = updates.map(u => u.split(' ')[0]);
+    if (hasRealmsUpdate) allFields.push('realms');
+    logAdmin('agent_update', { agent, fields: allFields, user_id: req.authenticatedUser.id });
 
     res.json({ agent, updated: true });
 }));


### PR DESCRIPTION
## Summary
- Agent properties (personality, dream mode, learning, storage quota, realms) now visible in identity section without clicking edit
- Learning and storage quota moved from Configuration card to profile edit form
- Configuration card renamed to "Model Settings", only shows when provider/model has capabilities
- Realm toggle badges in profile edit form, populated from `hosted_realms` config (MEM-110)
- Backend: `realms` added to agents/read, `hosted_realms` included in agents list response, realms update writes to actors table

## Test plan
- [ ] Open agent detail — verify personality, dream, learning, storage, realms all visible without editing
- [ ] Click edit pencil — verify all fields editable in one form including realm toggles
- [ ] Toggle realms on/off and save — verify persisted
- [ ] Model Settings card only appears for VAs with provider+model set
- [ ] Non-virtual agents still show the properties section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Home