### PR TITLE
Design polish for agent identity section

### DIFF
--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -1132,19 +1132,172 @@ dialog article header button[aria-label="Close"]::after {
     margin-bottom: 12px;
 }
 
-/* Agent properties shown below identity header */
+/* Agent properties — summary tiles below identity header */
 .agent-properties {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 4px 16px;
-    font-size: 13px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
     padding-bottom: 18px;
     border-bottom: 1px solid var(--border-subtle);
     margin-bottom: 20px;
 }
-.agent-prop { display: flex; gap: 8px; align-items: baseline; }
-.agent-prop-label { color: var(--text-muted); min-width: 70px; }
-.agent-prop-value { color: var(--text); }
+.agent-prop {
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+}
+.agent-prop--personality,
+.agent-prop--realms { grid-column: 1 / -1; }
+.agent-prop-label {
+    margin-bottom: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+.agent-prop-value {
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.45;
+}
+.agent-prop-value--numeric {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
+.agent-prop-value--clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* Status pill — read mode */
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    background: var(--accent-subtle);
+    border: 1px solid rgba(59, 130, 246, 0.2);
+    color: var(--accent-text);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+}
+
+/* Realm chips — shared between read and edit */
+.realm-chip-list,
+.realm-toggle-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.realm-chip {
+    appearance: none;
+    border: 1px solid var(--border-default);
+    background: var(--bg-input);
+    color: var(--text-secondary);
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+.realm-chip:hover {
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+}
+.realm-chip.is-active {
+    color: var(--text-primary);
+}
+.realm-chip:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+}
+.realm-chip-list .realm-chip {
+    cursor: default;
+    pointer-events: none;
+}
+
+/* Identity editor — grouped edit form */
+.identity-editor {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+.identity-group {
+    padding: 12px;
+    border-radius: 8px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+}
+.identity-group--sensitive {
+    border-color: rgba(234, 179, 8, 0.2);
+}
+.identity-group-eyebrow {
+    margin-bottom: 10px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+.identity-grid {
+    display: grid;
+    gap: 10px;
+}
+.identity-grid--2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.identity-grid--compact { align-items: start; }
+.identity-field { display: grid; gap: 4px; }
+.identity-field--full { margin-top: 4px; }
+.identity-editor label > span,
+.identity-field > span,
+.field-header > span {
+    display: inline-block;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+.field-header { margin-bottom: 6px; }
+.field-header small,
+.field-help {
+    display: block;
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+/* Learning toggle card */
+.toggle-card { display: grid; gap: 4px; min-height: 100%; }
+.toggle-card__label { margin-bottom: 0 !important; }
+.toggle-card__control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+}
+.toggle-card__control input[type="checkbox"] { margin: 0; }
+.toggle-card__text {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 720px) {
+    .agent-properties,
+    .identity-grid--2 { grid-template-columns: 1fr; }
+    .agent-prop--personality,
+    .agent-prop--realms { grid-column: auto; }
+}
 
 .agent-avatar-lg {
     width: 44px;

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -39,86 +39,113 @@
 
             <!-- Agent properties (visible without editing) -->
             <div v-if="!agentProfileEditing" class="agent-properties">
-                <div v-if="selectedAgent.personality" class="agent-prop">
-                    <span class="agent-prop-label">Personality</span>
-                    <span class="agent-prop-value" style="font-style: italic;">{{ selectedAgent.personality }}</span>
+                <div v-if="selectedAgent.personality" class="agent-prop agent-prop--personality">
+                    <div class="agent-prop-label">Personality</div>
+                    <div class="agent-prop-value agent-prop-value--clamp" style="font-style: italic;">{{ selectedAgent.personality }}</div>
                 </div>
                 <div class="agent-prop">
-                    <span class="agent-prop-label">Dream</span>
-                    <span class="agent-prop-value">
-                        <span v-if="selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none'" class="badge" :style="{ background: selectedAgent.dream_mode === 'companion' ? '#7c3aed22' : '#0891b222', color: selectedAgent.dream_mode === 'companion' ? '#7c3aed' : '#0891b2' }">
-                            <i :class="selectedAgent.dream_mode === 'companion' ? 'icon-heart' : 'icon-code'" style="margin-right: 3px;"></i>{{ selectedAgent.dream_mode }}
+                    <div class="agent-prop-label">Dream</div>
+                    <div class="agent-prop-value">
+                        <span v-if="selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none'" class="status-pill">
+                            <i :class="selectedAgent.dream_mode === 'companion' ? 'icon-heart' : 'icon-code'"></i>{{ selectedAgent.dream_mode }}
                         </span>
                         <span v-else class="muted">none</span>
-                    </span>
+                    </div>
                 </div>
                 <div class="agent-prop">
-                    <span class="agent-prop-label">Learning</span>
-                    <span class="agent-prop-value">{{ selectedAgent.learning_enabled !== false ? 'on' : 'off' }}</span>
+                    <div class="agent-prop-label">Learning</div>
+                    <div class="agent-prop-value">
+                        <span class="status-pill">{{ selectedAgent.learning_enabled !== false ? 'Enabled' : 'Off' }}</span>
+                    </div>
                 </div>
                 <div class="agent-prop">
-                    <span class="agent-prop-label">Storage</span>
-                    <span class="agent-prop-value">{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</span>
+                    <div class="agent-prop-label">Storage</div>
+                    <div class="agent-prop-value agent-prop-value--numeric">{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</div>
                 </div>
-                <div class="agent-prop">
-                    <span class="agent-prop-label">Realms</span>
-                    <span class="agent-prop-value">
-                        <template v-if="selectedAgent.realms && selectedAgent.realms.length">
-                            <span v-for="r in selectedAgent.realms" :key="r" class="badge" :style="{ background: realmColor(r) + '33', color: realmColor(r), marginRight: '4px' }">{{ r }}</span>
-                        </template>
-                        <span v-else class="muted">none</span>
-                    </span>
+                <div class="agent-prop agent-prop--realms">
+                    <div class="agent-prop-label">Realms</div>
+                    <div class="agent-prop-value">
+                        <div v-if="selectedAgent.realms && selectedAgent.realms.length" class="realm-chip-list">
+                            <span v-for="r in selectedAgent.realms" :key="r" class="realm-chip is-active" :style="{ borderColor: realmColor(r) + '7a', background: realmColor(r) + '1a', color: realmColor(r) }">{{ r }}</span>
+                        </div>
+                        <span v-else class="status-pill">No realms</span>
+                    </div>
                 </div>
             </div>
 
             <!-- Profile edit form -->
-            <div v-if="agentProfileEditing" class="agent-card" style="margin-bottom: 20px;">
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
-                    <label>Provider
-                        <custom-select v-model="agentProfileProvider" @update:model-value="onProfileProviderChange"
-                            :options="[{ value: '', label: 'None' }].concat((providerRegistry || []).map(p => ({ value: p.name, label: p.label })))"
-                            placeholder="None" />
-                    </label>
-                    <label>Model
-                        <custom-select v-model="agentProfileModel"
-                            :options="[{ value: '', label: 'None' }].concat(modelsForProvider(agentProfileProvider).map(m => ({ value: m.id, label: m.label + (m.deprecated ? ' (deprecated)' : '') })))"
-                            :allow-custom="agentProfileProvider === 'openrouter'"
-                            placeholder="None" />
-                    </label>
+            <div v-if="agentProfileEditing" class="identity-editor">
+                <div class="identity-group">
+                    <div class="identity-group-eyebrow">Model Configuration</div>
+                    <div class="identity-grid identity-grid--2">
+                        <label><span>Provider</span>
+                            <custom-select v-model="agentProfileProvider" @update:model-value="onProfileProviderChange"
+                                :options="[{ value: '', label: 'None' }].concat((providerRegistry || []).map(p => ({ value: p.name, label: p.label })))"
+                                placeholder="None" />
+                        </label>
+                        <label><span>Model</span>
+                            <custom-select v-model="agentProfileModel"
+                                :options="[{ value: '', label: 'None' }].concat(modelsForProvider(agentProfileProvider).map(m => ({ value: m.id, label: m.label + (m.deprecated ? ' (deprecated)' : '') })))"
+                                :allow-custom="agentProfileProvider === 'openrouter'"
+                                placeholder="None" />
+                        </label>
+                    </div>
+                    <small v-if="modelDeprecation(agentProfileProvider, agentProfileModel)" style="color: var(--error); display: block; margin: 4px 0;">
+                        &#9888; {{ modelDeprecation(agentProfileProvider, agentProfileModel) }}
+                    </small>
                 </div>
-                <small v-if="modelDeprecation(agentProfileProvider, agentProfileModel)" style="color: var(--error); display: block; margin: 4px 0;">
-                    &#9888; {{ modelDeprecation(agentProfileProvider, agentProfileModel) }}
-                </small>
-                <label>Personality
-                    <input type="text" v-model="agentProfilePersonality" placeholder="Short personality description">
-                </label>
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
-                    <label>Dream Mode
-                        <custom-select v-model="agentProfileDreamMode"
-                            :options="[{ value: 'none', label: 'None' }, { value: 'companion', label: 'Companion' }, { value: 'technical', label: 'Technical' }]"
-                            placeholder="None" />
+
+                <div class="identity-group">
+                    <div class="identity-group-eyebrow">Behavior</div>
+                    <label class="identity-field identity-field--full"><span>Personality</span>
+                        <input type="text" v-model="agentProfilePersonality" placeholder="Short personality description">
                     </label>
-                    <label>Storage Quota (MB)
-                        <input type="number" v-model="agentProfileStorageQuota" placeholder="blank = default" min="1">
-                    </label>
-                </div>
-                <label class="checkbox-label">
-                    <input type="checkbox" v-model="agentProfileLearningEnabled"> Learning enabled
-                </label>
-                <div>
-                    <label style="margin-bottom: 4px; display: block;">Realms</label>
-                    <div style="display: flex; gap: 6px; flex-wrap: wrap;">
-                        <span v-for="r in hostedRealms" :key="r" class="badge" style="cursor: pointer; user-select: none;"
-                            :style="agentProfileRealms.includes(r)
-                                ? { background: realmColor(r) + '33', color: realmColor(r), border: '1px solid ' + realmColor(r) }
-                                : { background: 'transparent', color: 'var(--text-muted)', border: '1px dashed var(--border)' }"
-                            @click="toggleProfileRealm(r)">{{ r }}</span>
+                    <div class="identity-grid identity-grid--2 identity-grid--compact">
+                        <label><span>Dream Mode</span>
+                            <custom-select v-model="agentProfileDreamMode"
+                                :options="[{ value: 'none', label: 'None' }, { value: 'companion', label: 'Companion' }, { value: 'technical', label: 'Technical' }]"
+                                placeholder="None" />
+                        </label>
+                        <label class="toggle-card"><span class="toggle-card__label">Learning</span>
+                            <span class="toggle-card__control">
+                                <input type="checkbox" v-model="agentProfileLearningEnabled">
+                                <span class="toggle-card__text">Enable memory learning</span>
+                            </span>
+                        </label>
                     </div>
                 </div>
-                <label v-if="selectedAgent.virtual">API Key
-                    <input type="password" v-model="agentProfileApiKey" placeholder="Enter new key to change (leave blank to keep current)">
-                </label>
-                <div class="dialog-actions" style="margin-top: 12px;">
+
+                <div class="identity-group">
+                    <div class="identity-group-eyebrow">Scope &amp; Limits</div>
+                    <div class="identity-grid identity-grid--2 identity-grid--compact">
+                        <label><span>Storage Quota (MB)</span>
+                            <input type="number" v-model="agentProfileStorageQuota" placeholder="blank = default" min="1">
+                        </label>
+                    </div>
+                    <div class="identity-field identity-field--full" style="margin-top: 8px;">
+                        <div class="field-header">
+                            <span>Realms</span>
+                            <small>Select where this agent can operate</small>
+                        </div>
+                        <div class="realm-toggle-group">
+                            <button v-for="r in hostedRealms" :key="r" type="button" class="realm-chip"
+                                :class="{ 'is-active': agentProfileRealms.includes(r) }"
+                                :aria-pressed="agentProfileRealms.includes(r) ? 'true' : 'false'"
+                                :style="agentProfileRealms.includes(r) ? { borderColor: realmColor(r) + '7a', background: realmColor(r) + '1a', color: realmColor(r) } : {}"
+                                @click="toggleProfileRealm(r)">{{ r }}</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-if="selectedAgent.virtual" class="identity-group identity-group--sensitive">
+                    <div class="identity-group-eyebrow">Credentials</div>
+                    <label class="identity-field identity-field--full"><span>API Key</span>
+                        <input type="password" v-model="agentProfileApiKey" placeholder="Enter new key to change (leave blank to keep current)" autocomplete="off">
+                        <small class="field-help">Stored encrypted for provider access.</small>
+                    </label>
+                </div>
+
+                <div class="dialog-actions" style="margin-top: 4px;">
                     <button class="btn btn-secondary btn-compact" @click="agentProfileEditing = false">Cancel</button>
                     <button class="btn btn-primary btn-compact" @click="saveProfile" :disabled="agentProfileSaving">Save</button>
                 </div>


### PR DESCRIPTION
## Summary
- Read mode: summary tiles with uppercase micro-labels, status pills for dream/learning, realm chips
- Edit mode: grouped into 4 sections (Model Config, Behavior, Scope & Limits, Credentials) with eyebrow labels
- CSS uses actual design tokens from design language doc (blue accent, no gradients, no box-shadows)
- Follow-up to #132 incorporating designer feedback

## Test plan
- [ ] Open agent detail — verify summary tiles render with proper styling
- [ ] Status pills show for dream mode and learning
- [ ] Realm chips render in read mode (non-clickable) and edit mode (toggleable)
- [ ] Edit form groups are visually distinct with eyebrow labels
- [ ] Credentials section has subtle warning border
- [ ] Responsive: collapses to single column at narrow widths

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Home