### PR TITLE
Strip agent properties to compact label/value list

### DIFF
--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -1132,64 +1132,16 @@ dialog article header button[aria-label="Close"]::after {
     margin-bottom: 12px;
 }
 
-/* Agent properties — summary tiles below identity header */
+/* Agent properties — compact label/value list below identity header */
 .agent-properties {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
+    font-size: 13px;
+    line-height: 1.8;
     padding-bottom: 18px;
     border-bottom: 1px solid var(--border-subtle);
     margin-bottom: 20px;
 }
-.agent-prop {
-    padding: 10px 12px;
-    border-radius: 8px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
-}
-.agent-prop--personality,
-.agent-prop--realms { grid-column: 1 / -1; }
-.agent-prop-label {
-    margin-bottom: 4px;
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-muted);
-}
-.agent-prop-value {
-    color: var(--text-primary);
-    font-size: 13px;
-    line-height: 1.45;
-}
-.agent-prop-value--numeric {
-    font-variant-numeric: tabular-nums;
-    font-weight: 600;
-}
-.agent-prop-value--clamp {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
 
-/* Status pill — read mode */
-.status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
-    border-radius: 4px;
-    background: var(--accent-subtle);
-    border: 1px solid rgba(59, 130, 246, 0.2);
-    color: var(--accent-text);
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 1;
-}
-
-/* Realm chips — shared between read and edit */
-.realm-chip-list,
+/* Realm chips — edit mode toggles */
 .realm-toggle-group {
     display: flex;
     flex-wrap: wrap;
@@ -1218,10 +1170,6 @@ dialog article header button[aria-label="Close"]::after {
 .realm-chip:focus-visible {
     outline: none;
     border-color: var(--accent);
-}
-.realm-chip-list .realm-chip {
-    cursor: default;
-    pointer-events: none;
 }
 
 /* Identity editor — grouped edit form */

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -39,38 +39,16 @@
 
             <!-- Agent properties (visible without editing) -->
             <div v-if="!agentProfileEditing" class="agent-properties">
-                <div v-if="selectedAgent.personality" class="agent-prop agent-prop--personality">
-                    <div class="agent-prop-label">Personality</div>
-                    <div class="agent-prop-value agent-prop-value--clamp" style="font-style: italic;">{{ selectedAgent.personality }}</div>
-                </div>
-                <div class="agent-prop">
-                    <div class="agent-prop-label">Dream</div>
-                    <div class="agent-prop-value">
-                        <span v-if="selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none'" class="status-pill">
-                            <i :class="selectedAgent.dream_mode === 'companion' ? 'icon-heart' : 'icon-code'"></i>{{ selectedAgent.dream_mode }}
-                        </span>
-                        <span v-else class="muted">none</span>
-                    </div>
-                </div>
-                <div class="agent-prop">
-                    <div class="agent-prop-label">Learning</div>
-                    <div class="agent-prop-value">
-                        <span class="status-pill">{{ selectedAgent.learning_enabled !== false ? 'Enabled' : 'Off' }}</span>
-                    </div>
-                </div>
-                <div class="agent-prop">
-                    <div class="agent-prop-label">Storage</div>
-                    <div class="agent-prop-value agent-prop-value--numeric">{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</div>
-                </div>
-                <div class="agent-prop agent-prop--realms">
-                    <div class="agent-prop-label">Realms</div>
-                    <div class="agent-prop-value">
-                        <div v-if="selectedAgent.realms && selectedAgent.realms.length" class="realm-chip-list">
-                            <span v-for="r in selectedAgent.realms" :key="r" class="realm-chip is-active" :style="{ borderColor: realmColor(r) + '7a', background: realmColor(r) + '1a', color: realmColor(r) }">{{ r }}</span>
-                        </div>
-                        <span v-else class="status-pill">No realms</span>
-                    </div>
-                </div>
+                <div v-if="selectedAgent.personality" style="font-style: italic; color: var(--text-secondary); margin-bottom: 4px;">{{ selectedAgent.personality }}</div>
+                <span>Dream: <strong>{{ selectedAgent.dream_mode && selectedAgent.dream_mode !== 'none' ? selectedAgent.dream_mode : 'none' }}</strong></span>
+                <br><span>Learning: <strong>{{ selectedAgent.learning_enabled !== false ? 'on' : 'off' }}</strong></span>
+                <br><span>Storage: <strong>{{ selectedAgent.storage_quota != null ? Math.round(selectedAgent.storage_quota / (1024 * 1024)) + ' MB' : 'default (' + Math.round(defaultStorageQuota / (1024 * 1024)) + ' MB)' }}</strong></span>
+                <br><span>Realms:
+                    <template v-if="selectedAgent.realms && selectedAgent.realms.length">
+                        <span v-for="(r, i) in selectedAgent.realms" :key="r"><span :style="{ color: realmColor(r) }">{{ r }}</span><span v-if="i < selectedAgent.realms.length - 1">, </span></span>
+                    </template>
+                    <strong v-else>none</strong>
+                </span>
             </div>
 
             <!-- Profile edit form -->


### PR DESCRIPTION
## Summary
- Replace heavy tile treatment with simple `Label: **value**` lines matching Model Settings density
- Remove unused tile/pill/chip-list CSS (~75 lines deleted)
- Personality shown as italic text, realms as colored inline text

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Home