### PR TITLE
Fix live discussion panel height (take 2)

### DIFF
--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -1904,9 +1904,11 @@ dialog article header button[aria-label="Close"]::after {
 }
 
 .dashboard-page-content.dashboard-live-active {
+    flex: 1 1 0;
     display: flex;
     flex-direction: column;
     overflow: hidden !important;
+    min-height: 0;
 }
 
 /* Stat strip — compact horizontal row */


### PR DESCRIPTION
Explicit flex:1 + min-height:0 on dashboard-live-active.