### PR TITLE
Remove virtual=false filter from dream processing

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -184,8 +184,7 @@ async function runDream() {
         `SELECT ac.name, ac.id AS actor_id, agc.dream_mode, agc.last_dream_at
          FROM agent_configuration agc
          JOIN actors ac ON ac.id = agc.actor_id
-         WHERE agc.dream_mode IN ('companion', 'technical')
-         AND agc.virtual = false`
+         WHERE agc.dream_mode IN ('companion', 'technical')`
     );
 
     if (agents.rows.length === 0) {


### PR DESCRIPTION
## Summary
- Virtual agents (like zbbs NPC characters) can have conversation logs and `dream_mode` enabled
- The `virtual = false` filter in the dream query was excluding them from the nightly dream run
- Removes the filter so any agent with `dream_mode` set gets processed

## Test plan
- [x] Verify zbbs character agents have `dream_mode = companion` set
- [x] Verify they have conversation logs in their namespace
- [ ] After deploy, trigger a manual dream run or wait for 4am UTC cron

Generated by Home agent