### PR TITLE
Make minimum password length configurable

### DIFF
--- a/node/api/public/admin/core.js
+++ b/node/api/public/admin/core.js
@@ -209,8 +209,8 @@ function useCore() {
             changePasswordError.value = 'New passwords do not match';
             return;
         }
-        if (changePasswordForm.value.newPassword.length < 4) {
-            changePasswordError.value = 'Password must be at least 4 characters';
+        if (changePasswordForm.value.newPassword.length < 1) {
+            changePasswordError.value = 'Password is required';
             return;
         }
         changePasswordSaving.value = true;

--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -350,7 +350,7 @@
                         UI Access (admin dashboard login)
                     </label>
                     <label v-if="newActorUiAccess">Password
-                        <input type="password" v-model="newActorPassword" placeholder="Minimum 4 characters">
+                        <input type="password" v-model="newActorPassword" placeholder="Minimum 10 characters">
                     </label>
                 </div>
             </template>

--- a/node/api/public/admin/views/misc-dialogs.html
+++ b/node/api/public/admin/views/misc-dialogs.html
@@ -143,7 +143,7 @@
                     </div>
                     <div>
                         <div class="ts" style="margin-bottom: 4px;">New password</div>
-                        <input type="password" v-model="changePasswordForm.newPassword" placeholder="Min 4 characters" style="width: 100%; margin: 0;">
+                        <input type="password" v-model="changePasswordForm.newPassword" placeholder="Min 10 characters" style="width: 100%; margin: 0;">
                     </div>
                     <div>
                         <div class="ts" style="margin-bottom: 4px;">Confirm new password</div>

--- a/node/api/public/landing/register.html
+++ b/node/api/public/landing/register.html
@@ -679,8 +679,8 @@ function checkPasswords() {
         updateRegisterBtn();
         return;
     }
-    if (pw.length < 8) {
-        statusEl.textContent = 'Must be at least 8 characters';
+    if (pw.length < 10) {
+        statusEl.textContent = 'Must be at least 10 characters';
         statusEl.className = 'name-status taken';
         updateRegisterBtn();
         return;

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -207,9 +207,10 @@ router.post('/admin/change-password', async (req, res) => {
         });
     }
 
-    if (new_password.length < 4) {
+    const minPwLen = parseInt(config.get('minimum_password_length')) || 10;
+    if (new_password.length < minPwLen) {
         return res.status(400).json({
-            error: { code: 'BAD_REQUEST', message: 'Password must be at least 4 characters' }
+            error: { code: 'BAD_REQUEST', message: 'Password must be at least ' + minPwLen + ' characters' }
         });
     }
 
@@ -1721,9 +1722,10 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
 
     // Validate UI access fields
     if (ui_access) {
-        if (!password || password.length < 4) {
+        const minPwLen = parseInt(config.get('minimum_password_length')) || 10;
+        if (!password || password.length < minPwLen) {
             return res.status(400).json({
-                error: { code: 'BAD_REQUEST', message: 'Password must be at least 4 characters' }
+                error: { code: 'BAD_REQUEST', message: 'Password must be at least ' + minPwLen + ' characters' }
             });
         }
     }
@@ -2399,9 +2401,10 @@ router.post('/admin/actors/password', requirePerm('agents', 'write'), adminRoute
         logAdmin('actor_password_clear', { actor_id: actorId, actor_name: actor.name, user_id: req.authenticatedUser.id });
         res.json({ message: 'UI access removed', is_user: false });
     } else {
-        if (typeof password !== 'string' || password.length < 4) {
+        const minPwLen = parseInt(config.get('minimum_password_length')) || 10;
+        if (typeof password !== 'string' || password.length < minPwLen) {
             return res.status(400).json({
-                error: { code: 'BAD_REQUEST', message: 'Password must be at least 4 characters' }
+                error: { code: 'BAD_REQUEST', message: 'Password must be at least ' + minPwLen + ' characters' }
             });
         }
         const salt = generateSalt();

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -69,8 +69,9 @@ router.post('/api/register', async (req, res) => {
     }
 
     const { password, dream_mode } = req.body;
-    if (!password || password.length < 8) {
-        return res.status(400).json({ error: 'Password must be at least 8 characters' });
+    const minPwLen = parseInt(config.get('minimum_password_length')) || 10;
+    if (!password || password.length < minPwLen) {
+        return res.status(400).json({ error: 'Password must be at least ' + minPwLen + ' characters' });
     }
     const validDreamModes = ['none', 'companion', 'technical'];
     const dreamMode = validDreamModes.includes(dream_mode) ? dream_mode : 'none';


### PR DESCRIPTION
## Summary
- New `minimum_password_length` config item (default: 10)
- All four server-side validation points read from config instead of hardcoding 4 or 8
- Frontend placeholders updated, client-side check simplified to defer to server

Generated by Home