### PR TITLE
Add agent name to soul synthesis for correct perspective

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -394,7 +394,8 @@ async function runDream() {
                         // No soul yet — first run, start fresh
                     }
 
-                    const soulUserMessage = '## Current soul document\n\n'
+                    const soulUserMessage = '## Agent: ' + agent.name + '\n\n'
+                        + '## Current soul document\n\n'
                         + (existingSoul || '(empty — first run)')
                         + '\n\n## Tonight\'s dream snapshot\n\n'
                         + content;


### PR DESCRIPTION
## Summary
- Soul VA was writing in third person because it didn't know which character it was
- User message now starts with "## Agent: {name}" 
- Soul VA prompt updated to reinforce first-person writing

Generated by Home