### PR TITLE
Sim-mode prompt: load Impressions from co-located people, skip RAG

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -767,13 +767,42 @@ async function loadSoul(agentName) {
     }
 }
 
+// Build a filesystem-safe slug for a person-context note. Display names
+// flow in from engine perceptions in sim mode, including future player
+// names — anything that isn't a fully trusted internal slug. So we
+// whitelist [a-z0-9-] and reject anything that empties out, instead of
+// just whitespace-to-hyphen which would let a name like "../secrets" or
+// "foo/bar" build a path that traverses out of `context/people/`.
+//
+// Diacritic stripping via NFKD normalize + combining-mark removal so
+// "Renée" reads as "renee" rather than getting silently flattened to
+// nothing. Non-Latin scripts still won't slug well; if/when those
+// matter, switch to an explicit stored slug field rather than deriving
+// filesystem paths from display names.
+//
+// Returns null if the input is unusable (empty, non-string, no surviving
+// characters), so callers can skip the read entirely.
+function personContextSlug(name) {
+    if (!name || typeof name !== 'string') return null;
+    const slug = name
+        .trim()
+        .normalize('NFKD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+    return slug || null;
+}
+
 // Load per-person relationship files for a virtual agent.
 // counterparts is an array of names the VA is interacting with — either
 // agent slugs (companion mode: "home", "wendy") or display names (sim
-// mode: "Josiah Thorne", "Jefferey"). Slug = lowercased name with
-// whitespace replaced by hyphens, so a display name like "Josiah Thorne"
-// is read from `context/people/josiah-thorne`. Companion-mode slugs
-// have no whitespace, so the transform is a no-op there.
+// mode: "Josiah Thorne", "Jefferey"). Slug derivation goes through
+// personContextSlug above, which is path-traversal safe. Companion-mode
+// slugs have no whitespace and are already lowercase ASCII, so the
+// transform is a no-op there.
 // Returns formatted string or empty. Never throws.
 async function loadPeopleContext(agentName, counterparts) {
     if (!counterparts || counterparts.length === 0) {
@@ -782,8 +811,12 @@ async function loadPeopleContext(agentName, counterparts) {
 
     const sections = [];
     for (const person of counterparts) {
+        const slug = personContextSlug(person);
+        if (!slug) {
+            logVA('people-context-invalid-name', { agent: agentName, person });
+            continue;
+        }
         try {
-            const slug = person.toLowerCase().replace(/\s+/g, '-');
             const note = await readNote(agentName, 'context/people/' + slug);
             if (note && note.content) {
                 sections.push('## Your impressions of ' + person + '\n\n' + note.content);
@@ -1788,7 +1821,11 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         let peopleContext;
         if (isSimChat) {
             ragContext = '';
-            const coLocated = extractCoLocatedNames(messageText);
+            // Dedupe in case the perception ever lists a name twice (e.g. a
+            // future engine rev that surfaces multiple roles for the same
+            // person). Without this, loadPeopleContext would emit duplicate
+            // "## Your impressions of X" sections.
+            const coLocated = [...new Set(extractCoLocatedNames(messageText))];
             if (coLocated.length > 0) {
                 peopleContext = await loadPeopleContext(agent.agent, coLocated);
             } else {

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -768,7 +768,12 @@ async function loadSoul(agentName) {
 }
 
 // Load per-person relationship files for a virtual agent.
-// counterparts is an array of agent names the VA is interacting with.
+// counterparts is an array of names the VA is interacting with — either
+// agent slugs (companion mode: "home", "wendy") or display names (sim
+// mode: "Josiah Thorne", "Jefferey"). Slug = lowercased name with
+// whitespace replaced by hyphens, so a display name like "Josiah Thorne"
+// is read from `context/people/josiah-thorne`. Companion-mode slugs
+// have no whitespace, so the transform is a no-op there.
 // Returns formatted string or empty. Never throws.
 async function loadPeopleContext(agentName, counterparts) {
     if (!counterparts || counterparts.length === 0) {
@@ -778,7 +783,8 @@ async function loadPeopleContext(agentName, counterparts) {
     const sections = [];
     for (const person of counterparts) {
         try {
-            const note = await readNote(agentName, 'context/people/' + person.toLowerCase());
+            const slug = person.toLowerCase().replace(/\s+/g, '-');
+            const note = await readNote(agentName, 'context/people/' + slug);
             if (note && note.content) {
                 sections.push('## Your impressions of ' + person + '\n\n' + note.content);
             }
@@ -792,6 +798,24 @@ async function loadPeopleContext(agentName, counterparts) {
     }
 
     return sections.join('\n\n');
+}
+
+// Parse co-located people from a Salem engine perception. The engine
+// includes a "Here:\n  Name1\n  Name2" block listing other people at
+// the NPC's current location (other NPCs by display name, players by
+// in-game name). Returns an array of display names, empty when alone.
+//
+// Used in sim mode to derive the Impressions counterpart list from the
+// world state instead of from `fromAgent` (which is always "salem-engine"
+// — not a person — and would otherwise cause Impressions to be empty).
+function extractCoLocatedNames(perceptionText) {
+    if (!perceptionText) return [];
+    const match = perceptionText.match(/^Here:\s*\n((?:  +.+\n?)+)/m);
+    if (!match) return [];
+    return match[1]
+        .split('\n')
+        .map(function (line) { return line.trim(); })
+        .filter(function (line) { return line.length > 0; });
 }
 
 // --- Typed prompt blocks ---
@@ -1742,21 +1766,6 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         // Load recent direct chat history between the two agents (time-windowed)
         const history = await loadDirectChatHistory(virtualAgentName, fromAgent);
 
-        // RAG context from the agent's namespace.
-        // If the latest message is very short, combine with previous message for better RAG.
-        let ragQuery = messageText;
-        if (messageText.trim().split(/\s+/).length < 5 && history.length >= 2) {
-            const prev = history[history.length - 2];
-            ragQuery = prev.message + ' ' + messageText;
-        }
-        const ragContext = await loadRAGContext(agent.agent, ragQuery);
-        const soul = await loadSoul(agent.agent);
-        const peopleContext = await loadPeopleContext(agent.agent, [fromAgent]);
-
-        // Build prompts. Tool-use path builds OpenAI-shape messages[] from
-        // history (tool_calls + tool_call_id flow through assistant/tool
-        // roles); plain-text path uses the legacy timestamp-prefixed wrap.
-        //
         // Sim mode: when the sender is 'salem-engine' (the Salem village
         // simulator's service actor driving NPC ticks), swap the chat-shape
         // system prompt for a sim-shape one. The companion DirectChat /
@@ -1764,6 +1773,41 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         // frames perceptions as world state and pushes for tool-call output.
         // See buildSimChatSystemPrompt above for the rationale.
         const isSimChat = fromAgent === 'salem-engine';
+
+        // Context loading differs by mode.
+        //
+        // Companion mode: RAG-search the agent's notes by message content;
+        // counterpart for Impressions is the sender (one human agent).
+        //
+        // Sim mode: skip RAG (the 50+ message tool-use history is already
+        // the recall channel — RAG against the engine's perception text
+        // returns noise) and derive Impressions counterparts from the
+        // engine's "Here:" block (co-located people by display name)
+        // instead of fromAgent (which is "salem-engine" — not a person).
+        let ragContext;
+        let peopleContext;
+        if (isSimChat) {
+            ragContext = '';
+            const coLocated = extractCoLocatedNames(messageText);
+            if (coLocated.length > 0) {
+                peopleContext = await loadPeopleContext(agent.agent, coLocated);
+            } else {
+                peopleContext = '';
+            }
+        } else {
+            let ragQuery = messageText;
+            if (messageText.trim().split(/\s+/).length < 5 && history.length >= 2) {
+                const prev = history[history.length - 2];
+                ragQuery = prev.message + ' ' + messageText;
+            }
+            ragContext = await loadRAGContext(agent.agent, ragQuery);
+            peopleContext = await loadPeopleContext(agent.agent, [fromAgent]);
+        }
+        const soul = await loadSoul(agent.agent);
+
+        // Build prompts. Tool-use path builds OpenAI-shape messages[] from
+        // history (tool_calls + tool_call_id flow through assistant/tool
+        // roles); plain-text path uses the legacy timestamp-prefixed wrap.
         let systemPrompt;
         if (isSimChat) {
             systemPrompt = buildSimChatSystemPrompt(agent, ragContext, soul, peopleContext);


### PR DESCRIPTION
## Summary

Fixes two empty-block bugs in the Phase A sim-mode prompt builder. Verified against `zbbs-john-ellis` call 1187 (12:40 UTC, game 08:00 Tuesday) — Impressions and Recall blocks were both empty in the actual prompt sent to Llama, even though `buildSimChatSystemPrompt` is supposed to include them.

## What was wrong

**1. Impressions never populated.**
\`\`\`js
const peopleContext = await loadPeopleContext(agent.agent, [fromAgent]);
\`\`\`
In sim mode \`fromAgent === 'salem-engine'\`. So every NPC was looking up its impressions of \`salem-engine\` (which has no relationship file, and shouldn't — the engine isn't a person). The actual co-located people — present in the engine's "Here:\n  Name1\n  Name2" block — were never used.

**2. Recall (RAG) was searched against the engine perception as the query.**
\`\`\`js
let ragQuery = messageText;
\`\`\`
\`messageText\` in sim mode is the full perception ("You are John Ellis the tavernkeeper. Your home and work: Tavern. ..."), ~600 chars of generic framing. Embedding that as a search query doesn't return anything above the 0.3 similarity threshold, so Recall stays empty regardless. And the 50-message tool-use history is already the richer recall channel — RAG here was either empty or noise.

## What changed

In \`handleDirectChat\` (sim-mode branch only):
- Parse the engine's "Here:" block via new \`extractCoLocatedNames(perceptionText)\` helper, use those display names as the Impressions counterpart list.
- Skip RAG entirely (\`ragContext = ''\`).

In \`loadPeopleContext\`: normalize whitespace to hyphens when building the slug. Companion-mode counterparts have no whitespace (\`home\`, \`wendy\`), so this is a no-op there. Sim-mode display names like \`Josiah Thorne\` now read from \`context/people/josiah-thorne\`.

Companion-mode behavior is unchanged.

## Convention coordination

The \`dream-sim-people\` pipeline (home's queue) should write impressions notes keyed by the same convention: lowercased display name with whitespace replaced by hyphens, under \`context/people/<slug>\` in the NPC's namespace. So John Ellis's note about Josiah lives at \`zbbs-john-ellis/context/people/josiah-thorne\`.

## Test plan
- [ ] Deploy
- [ ] Trigger a tick on an NPC at a multi-NPC location (e.g. Tavern with Jefferey + Josiah)
- [ ] Inspect \`virtual_agent_calls.system_prompt\` — confirm \`<Impressions>\` block is no longer present (still empty until dream-sim-people lands) but the counterpart-loading code path runs without error
- [ ] Confirm \`<Recall>\` block is absent in sim-mode prompts
- [ ] Confirm companion-mode prompts still include both blocks

— Work