### PR TITLE
Sim-mode tool-use history: prune redundant perceptions + inline prior tool-call payloads

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -1650,6 +1650,48 @@ async function handleVirtualAgent(payload) {
     }
 }
 
+// Prune consecutive engine→NPC perception rows in sim-mode chat history,
+// keeping only the latest in each consecutive run. Sim-mode multi-NPC
+// scenes generate progressive perceptions (each successive event-tick
+// adds new "Recent:" speech to the perception text), so the latest in
+// a consecutive run subsumes the earlier ones — they're redundant in
+// the model's context and waste input tokens.
+//
+// Tool-result rows (engine→NPC with tool_call_id set, e.g. "[OK] You
+// spoke. Continue your turn...") are NOT collapsed — they pair with
+// specific assistant tool_calls via tool_call_id and dropping them
+// breaks the OpenAI tool-use protocol.
+//
+// Only call this for sim-mode (fromAgent === 'salem-engine'). Companion
+// mode consecutive user-role messages are real distinct human messages,
+// not redundant perceptions, and must be preserved.
+function pruneSimHistory(history, npcAgentName) {
+    const npcLower = npcAgentName.toLowerCase();
+    const out = [];
+    let pendingPerception = null;
+    for (const row of history) {
+        const fromLower = (row.from_agent || '').toLowerCase();
+        const isFromNpc = fromLower === npcLower;
+        const isToolResult = !isFromNpc && row.tool_call_id;
+        if (isFromNpc || isToolResult) {
+            if (pendingPerception !== null) {
+                out.push(pendingPerception);
+                pendingPerception = null;
+            }
+            out.push(row);
+        } else {
+            // engine→NPC perception (user role, no tool_call_id) —
+            // overwrite pending so only the latest in a consecutive run
+            // lands in the output.
+            pendingPerception = row;
+        }
+    }
+    if (pendingPerception !== null) {
+        out.push(pendingPerception);
+    }
+    return out;
+}
+
 // Build OpenAI-shape messages[] from chat history for the tool-use branch
 // (MEM-119). Each history row maps to one message:
 //   - row from this VA + has tool_calls → role=assistant with tool_calls
@@ -1770,7 +1812,19 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         } else {
             systemPrompt = buildDirectChatSystemPrompt(agent, ragContext, soul, peopleContext);
         }
-        const toolUseMessages = isToolUse ? buildToolUseMessages(history, virtualAgentName) : null;
+        // Sim mode: prune consecutive engine→NPC perception rows in the
+        // tool-use history so the latest perception in each run is the only
+        // one the model sees. Multi-NPC scenes generate progressive
+        // perceptions (Recent: grows on each event-tick) and the latest
+        // subsumes the earlier ones.
+        let toolUseMessages = null;
+        if (isToolUse) {
+            let toolUseHistory = history;
+            if (isSimChat) {
+                toolUseHistory = pruneSimHistory(history, virtualAgentName);
+            }
+            toolUseMessages = buildToolUseMessages(toolUseHistory, virtualAgentName);
+        }
         const userMessage = isToolUse ? '' : buildDirectChatUserMessage(history, fromAgent, messageText);
 
         // Audit-log payload: providers receive userMessage as a string (empty

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -1665,30 +1665,37 @@ async function handleVirtualAgent(payload) {
 // Only call this for sim-mode (fromAgent === 'salem-engine'). Companion
 // mode consecutive user-role messages are real distinct human messages,
 // not redundant perceptions, and must be preserved.
-function pruneSimHistory(history, npcAgentName) {
-    const npcLower = npcAgentName.toLowerCase();
+//
+// The collapse predicate is the explicit shape of an engine perception:
+// from_agent === 'salem-engine' AND no tool_call_id. Anything else (this
+// NPC's own assistant rows, tool_result rows, future engine event rows
+// that aren't progressive perceptions, system/admin rows) flushes the
+// pending perception and passes through unchanged.
+function isEnginePerception(row) {
+    return (row.from_agent || '').toLowerCase() === 'salem-engine'
+        && !row.tool_call_id;
+}
+
+function pruneSimHistory(history) {
     const out = [];
     let pendingPerception = null;
+    const flush = () => {
+        if (pendingPerception !== null) {
+            out.push(pendingPerception);
+            pendingPerception = null;
+        }
+    };
     for (const row of history) {
-        const fromLower = (row.from_agent || '').toLowerCase();
-        const isFromNpc = fromLower === npcLower;
-        const isToolResult = !isFromNpc && row.tool_call_id;
-        if (isFromNpc || isToolResult) {
-            if (pendingPerception !== null) {
-                out.push(pendingPerception);
-                pendingPerception = null;
-            }
-            out.push(row);
-        } else {
-            // engine→NPC perception (user role, no tool_call_id) —
-            // overwrite pending so only the latest in a consecutive run
+        if (isEnginePerception(row)) {
+            // Overwrite pending so only the latest in a consecutive run
             // lands in the output.
             pendingPerception = row;
+            continue;
         }
+        flush();
+        out.push(row);
     }
-    if (pendingPerception !== null) {
-        out.push(pendingPerception);
-    }
+    flush();
     return out;
 }
 
@@ -1759,11 +1766,17 @@ function buildToolUseMessages(history, npcAgentName) {
                         const input = (typeof tc.input === 'string')
                             ? safeParseJSON(tc.input)
                             : (tc.input || {});
-                        if (tc.name === 'speak' && input && input.text) {
-                            lines.push('(I said aloud: "' + input.text + '")');
-                        } else if (tc.name === 'move_to' && input && input.destination) {
+                        if (tc.name === 'speak' && input && typeof input.text === 'string' && input.text) {
+                            // JSON.stringify so embedded quotes / newlines /
+                            // backslashes in the spoken text don't mangle
+                            // the paraphrase or terminate the quoted span.
+                            lines.push('(I said aloud: ' + JSON.stringify(input.text) + ')');
+                        } else if (tc.name === 'move_to' && input && typeof input.destination === 'string' && input.destination) {
+                            // typeof guard so we don't render `[object Object]`
+                            // if a future engine rev passes a structured
+                            // destination ({type, id}) instead of a string.
                             lines.push('(I walked to ' + input.destination + ')');
-                        } else if (tc.name === 'chore' && input && input.type) {
+                        } else if (tc.name === 'chore' && input && typeof input.type === 'string' && input.type) {
                             lines.push('(I ran a chore: ' + input.type + ')');
                         }
                     }
@@ -1871,7 +1884,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (isToolUse) {
             let toolUseHistory = history;
             if (isSimChat) {
-                toolUseHistory = pruneSimHistory(history, virtualAgentName);
+                toolUseHistory = pruneSimHistory(history);
             }
             toolUseMessages = buildToolUseMessages(toolUseHistory, virtualAgentName);
         }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -1733,6 +1733,44 @@ function buildToolUseMessages(history, npcAgentName) {
                         },
                     };
                 });
+                // Salience: prior speak/move_to/chore tool_calls carry
+                // semantically-meaningful payloads (the spoken text, the
+                // destination, the chore type). When this row was emitted
+                // the model had it as a fresh decision; when REPLAYED in
+                // history, the payload sits inside tool_calls.arguments
+                // JSON, which the language-modeling pass treats as "an
+                // action I took" rather than "speech I said" / "place I
+                // walked to". That makes it weak as a "do not repeat
+                // yourself" signal — observed empirically as NPC
+                // tavernkeepers re-greeting the same person across
+                // adjacent turns with near-identical phrasing.
+                //
+                // Mirror the payload into `content` as a brief
+                // first-person paraphrase. tool_calls structure is
+                // preserved (protocol-correct, paired with tool results
+                // by tool_call_id); content adds the natural-language
+                // copy so prior speeches/moves are salient as language
+                // alongside other agents' speech in the perception's
+                // "Recent:" block. Skip look_around (tool result IS the
+                // information) and done (no payload worth surfacing).
+                if (!msg.content) {
+                    const lines = [];
+                    for (const tc of raw) {
+                        const input = (typeof tc.input === 'string')
+                            ? safeParseJSON(tc.input)
+                            : (tc.input || {});
+                        if (tc.name === 'speak' && input && input.text) {
+                            lines.push('(I said aloud: "' + input.text + '")');
+                        } else if (tc.name === 'move_to' && input && input.destination) {
+                            lines.push('(I walked to ' + input.destination + ')');
+                        } else if (tc.name === 'chore' && input && input.type) {
+                            lines.push('(I ran a chore: ' + input.type + ')');
+                        }
+                    }
+                    if (lines.length > 0) {
+                        msg.content = lines.join('\n');
+                    }
+                }
             }
             messages.push(msg);
         } else if (row.tool_call_id) {
@@ -1746,6 +1784,18 @@ function buildToolUseMessages(history, npcAgentName) {
         }
     }
     return messages;
+}
+
+// Defensive JSON parse — tool_calls.arguments may have been stored as a
+// string by some providers and as parsed JSON by others. Returns {} on
+// any parse failure so the salience-mirroring code can fall through
+// without throwing.
+function safeParseJSON(s) {
+    try {
+        return JSON.parse(s);
+    } catch (e) {
+        return {};
+    }
 }
 
 // Handle a direct chat message sent to a virtual agent (no discussion).


### PR DESCRIPTION
Two related changes to how sim-mode tool-use history is reconstructed before being sent to the model.

## 1. Prune redundant consecutive engine→NPC perceptions

Multi-NPC scenes generate progressive perceptions: each successive event-tick on an NPC adds new "Recent:" speech to the perception text. The latest perception in a consecutive run subsumes the earlier ones, so feeding all of them to the model is redundant context.

New \`pruneSimHistory\` walks chat history and collapses consecutive engine→NPC perception rows (user-role, no tool_call_id), keeping only the latest in each run. Tool-result rows (has tool_call_id) and assistant rows are preserved unchanged — OpenAI tool-use protocol stays intact.

Sample: John Ellis call_id 1187 (Monday 19:00–20:00 4-NPC Tavern) — 5 redundant perceptions dropped out of ~50 messages (~10% reduction). Quiet ticks ~0%; busy multi-NPC scenes can hit 20–30%.

## 2. Inline prior tool-call payloads as natural-language content

When a prior \`speak\` / \`move_to\` / \`chore\` tool_call is replayed in history, the semantically-meaningful payload (the spoken text, the destination, the chore type) sits inside \`tool_calls.arguments\` JSON. The language-modeling pass treats that as "an action I took," not "speech I said" — weak as a "do not repeat yourself" signal. Observed empirically as NPC tavernkeepers re-greeting the same person across adjacent turns with near-identical phrasing.

Fix: mirror the payload into the assistant message's \`content\` as a brief first-person paraphrase:

- \`speak\` → \`(I said aloud: "Good morrow, Jefferey!")\`
- \`move_to\` → \`(I walked to Well (Roofed))\`
- \`chore\` → \`(I ran a chore: outhouse)\`

\`tool_calls\` structure preserved (protocol-correct, paired with tool results via tool_call_id); \`content\` adds the natural-language copy. Skip \`look_around\` (the tool result IS the info) and \`done\` (no payload worth surfacing). Skip when content is already non-empty.

This makes John's prior speeches as linguistically salient as the engine's "Recent:" attributions of other NPCs' speeches — both now in natural-language form, so the model can integrate them uniformly when deciding what to say next.

## Behavior delta

- **Sim mode (\`fromAgent === 'salem-engine'\`)**: both changes apply.
- **Companion mode**: prune NOT applied. Natural-language inlining applies if any companion-mode tool_calls happen to be \`speak\`/\`move_to\`/\`chore\` (currently no companion-mode flow uses these tools, so no companion-mode behavior change in practice).

## Why both together

Both target the same path (sim-mode tool-use history reconstruction in \`buildToolUseMessages\` / pre-call). They compose: pruning removes redundant turns, inlining makes the surviving turns more salient. Same review, same deploy.

## Test plan
- [ ] Deploy
- [ ] Inspect a multi-NPC sim tick's \`virtual_agent_calls.user_message\` — confirm consecutive duplicate engine perceptions are collapsed
- [ ] Confirm assistant rows now have \`content\` like \`(I said aloud: "...")\` alongside their \`tool_calls\` for prior speak/move_to/chore turns
- [ ] Confirm look_around / done assistant rows still have empty \`content\`
- [ ] Confirm tool-result rows ([OK] You spoke...) preserved
- [ ] Confirm a companion-mode chat (e.g. \`home\` → \`code_review\`) still includes all user messages

— Work