### PR TITLE
MEM-121: scene_id grouping for sim-mode chat

### DIFF
--- a/migrations/MEM-121-chat-scene-id_down.sql
+++ b/migrations/MEM-121-chat-scene-id_down.sql
@@ -1,0 +1,7 @@
+-- MEM-121 down: drop scene_id columns and indexes.
+
+DROP INDEX IF EXISTS idx_cmt_scene;
+ALTER TABLE chat_message_texts DROP COLUMN IF EXISTS scene_id;
+
+DROP INDEX IF EXISTS idx_va_calls_scene;
+ALTER TABLE virtual_agent_calls DROP COLUMN IF EXISTS scene_id;

--- a/migrations/MEM-121-chat-scene-id_up.sql
+++ b/migrations/MEM-121-chat-scene-id_up.sql
@@ -1,0 +1,33 @@
+-- MEM-121: Scene grouping for sim-mode chat (Salem M6.4 follow-up).
+--
+-- A "scene" is one cascade of related ticks: a player or NPC speaks, all
+-- co-located NPCs react, their replies trigger more reactions, and so on
+-- until the chain quiets. The salem-engine mints one UUID at the cascade
+-- origin (PC speak, NPC arrival, baseline hourly tick) and threads it
+-- through `triggerImmediateTick` / `triggerCoLocatedTicks` /
+-- `executeAgentCommit`, so every chat row and provider call produced by
+-- that cascade carries the same scene_id.
+--
+-- Walks intentionally do not carry scene_id forward: a `move_to`
+-- finishes seconds-to-minutes of game time later, by which point the
+-- arrival is a new scene. The engine mints a fresh UUID at the arrival
+-- trigger.
+--
+-- Companion-mode chat rows leave scene_id NULL — those aren't scenes,
+-- and the admin UI renders them as today.
+--
+-- Two columns, one each on chat_message_texts and virtual_agent_calls:
+-- the chat row is the message itself; the call row is the LLM provider
+-- exchange that produced (or consumed) it. Both are useful filters in
+-- the admin UI — chat shows what was said, calls show what was sent
+-- to the model.
+--
+-- Partial indexes only — the vast majority of historical and
+-- companion-mode rows will have NULL scene_id, and we only ever query
+-- by exact scene_id match.
+
+ALTER TABLE chat_message_texts ADD COLUMN scene_id UUID;
+CREATE INDEX idx_cmt_scene ON chat_message_texts (scene_id) WHERE scene_id IS NOT NULL;
+
+ALTER TABLE virtual_agent_calls ADD COLUMN scene_id UUID;
+CREATE INDEX idx_va_calls_scene ON virtual_agent_calls (scene_id) WHERE scene_id IS NOT NULL;

--- a/node/api/public/admin/chat.js
+++ b/node/api/public/admin/chat.js
@@ -1,9 +1,94 @@
 // chat.js — Chat messages view
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 function useChat({ api, showToast, dashboard }) {
     const chatMessages = ref([]);
     const selectedMessage = ref(null);
+    // Set of scene_ids the admin has expanded. Scenes default to collapsed
+    // so the top of the chat list isn't a wall of perception/tool-result
+    // rows whenever Salem is busy.
+    const expandedScenes = ref(new Set());
+
+    // Group chat rows by scene_id for the admin chat list. Companion-mode
+    // and any pre-MEM-121 row has a NULL scene_id and renders as a single
+    // standalone row exactly as before. Sim-mode rows that share a
+    // scene_id collapse into one expandable scene row.
+    //
+    // Ordering: a scene group occupies the slot of its most recent message,
+    // so a fresh tavern conversation lands at the top. Inside the group the
+    // messages render chronologically (oldest first) so the conversation
+    // reads naturally when expanded.
+    const chatGroups = computed(() => {
+        const sceneIndex = new Map(); // scene_id -> group ref
+        const groups = [];
+        for (const msg of chatMessages.value) {
+            if (msg.scene_id) {
+                let group = sceneIndex.get(msg.scene_id);
+                if (!group) {
+                    group = { type: 'scene', scene_id: msg.scene_id, messages: [] };
+                    sceneIndex.set(msg.scene_id, group);
+                    groups.push(group);
+                }
+                group.messages.push(msg);
+            } else {
+                groups.push({ type: 'msg', msg });
+            }
+        }
+        // Flatten single-message scenes back to plain rows. Pagination and
+        // partial cascades both leave us with one-row groups that don't
+        // benefit from a collapsed header — and forcing the admin to expand
+        // a scene just to read one message is a regression versus the
+        // pre-MEM-121 list.
+        for (let i = 0; i < groups.length; i++) {
+            const g = groups[i];
+            if (g.type === 'scene' && g.messages.length === 1) {
+                groups[i] = { type: 'msg', msg: g.messages[0] };
+            }
+        }
+        for (const g of groups) {
+            if (g.type !== 'scene') continue;
+            g.messages.sort((a, b) => new Date(a.sent_at) - new Date(b.sent_at));
+            g.earliest_at = g.messages[0].sent_at;
+            g.latest_at = g.messages[g.messages.length - 1].sent_at;
+            // Surface unacked status on the collapsed header so the admin
+            // doesn't lose the ack indicator that single rows show. The
+            // discussion-id branch of /admin/chat doesn't select acked_at
+            // (delivery-row state is per-recipient, not per-text), so those
+            // messages have `acked_at === undefined` and we treat them as
+            // having no ack tracking — only an explicit NULL means unacked.
+            g.hasUnacked = g.messages.some(m => m.acked_at === null);
+            const seen = new Set();
+            const order = [];
+            for (const m of g.messages) {
+                for (const name of [m.from_agent, m.to_agent]) {
+                    if (name && !seen.has(name)) {
+                        seen.add(name);
+                        order.push(name);
+                    }
+                }
+            }
+            g.participants = order;
+        }
+        groups.sort((a, b) => {
+            const aTime = a.type === 'scene' ? a.latest_at : a.msg.sent_at;
+            const bTime = b.type === 'scene' ? b.latest_at : b.msg.sent_at;
+            return new Date(bTime) - new Date(aTime);
+        });
+        return groups;
+    });
+
+    function toggleScene(sceneId) {
+        const next = new Set(expandedScenes.value);
+        if (next.has(sceneId)) {
+            next.delete(sceneId);
+        } else {
+            next.add(sceneId);
+        }
+        expandedScenes.value = next;
+    }
+    function isSceneExpanded(sceneId) {
+        return expandedScenes.value.has(sceneId);
+    }
 
     async function loadChat() {
         try {
@@ -54,6 +139,7 @@ function useChat({ api, showToast, dashboard }) {
 
     return {
         chatMessages, selectedMessage,
+        chatGroups, expandedScenes, toggleScene, isSceneExpanded,
         loadChat, deleteChat, closeDialogs,
         formatToolCall
     };

--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -798,6 +798,38 @@ tbody tr:last-child td { border-bottom: none; }
     color: var(--text-secondary);
 }
 
+/* Sim-mode scene grouping (MEM-121). The scene header row collapses one
+   cascade of perception/tool-call/tool-result chat rows into a single
+   line so the chat list stays readable when Salem is active. Click the
+   header to expand; sub-rows keep the existing row layout but get a
+   subtle background tint and left indent so they read as members of
+   the group above. */
+.scene-row {
+    background: rgba(113, 113, 122, 0.06);
+    font-weight: 500;
+}
+.scene-row .scene-participants {
+    color: var(--text-secondary);
+    font-size: 12px;
+}
+.scene-row .scene-summary {
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+.scene-child td:first-child,
+.scene-child td:nth-child(2) {
+    padding-left: 18px;
+}
+.scene-child {
+    background: rgba(113, 113, 122, 0.03);
+}
+/* Spacing between the chevron and the unacked dot in the scene-row icon
+   cell. Without this they sit flush. */
+.scene-ack-marker {
+    margin-left: 6px;
+}
+
 /* ── Access view ── */
 .sub-tabs button {
     padding: 10px 16px;

--- a/node/api/public/admin/views/comms.html
+++ b/node/api/public/admin/views/comms.html
@@ -88,23 +88,60 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="msg in chatMessages" :key="msg.id" @click="selectedMessage = msg" class="clickable">
-                        <td class="icon-cell"><i :class="msg.acked_at ? 'icon-check acked-icon' : 'icon-circle unacked-icon'"></i></td>
-                        <td>{{ msg.from_agent }}</td>
-                        <td>{{ msg.to_agent }}</td>
-                        <td>{{ msg.channel || '—' }}</td>
-                        <td class="message-cell">
-                            <template v-if="msg.message">{{ msg.message }}</template>
-                            <template v-else-if="msg.tool_calls && msg.tool_calls.length">
-                                <template v-for="(tc, i) in msg.tool_calls" :key="tc.id || i">
-                                    <em v-if="tc.name === 'speak'" class="tool-speak">&ldquo;{{ tc.input && tc.input.text }}&rdquo;</em>
-                                    <span v-else class="tool-chip">[{{ formatToolCall(tc) }}]</span>
-                                    <span v-if="i < msg.tool_calls.length - 1">&nbsp;</span>
+                    <template v-for="group in chatGroups" :key="group.type === 'scene' ? ('scene-' + group.scene_id) : ('msg-' + group.msg.id)">
+                        <!-- Companion-mode and pre-MEM-121 rows render unchanged. -->
+                        <tr v-if="group.type === 'msg'" @click="selectedMessage = group.msg" class="clickable">
+                            <td class="icon-cell"><i :class="group.msg.acked_at ? 'icon-check acked-icon' : 'icon-circle unacked-icon'"></i></td>
+                            <td>{{ group.msg.from_agent }}</td>
+                            <td>{{ group.msg.to_agent }}</td>
+                            <td>{{ group.msg.channel || '—' }}</td>
+                            <td class="message-cell">
+                                <template v-if="group.msg.message">{{ group.msg.message }}</template>
+                                <template v-else-if="group.msg.tool_calls && group.msg.tool_calls.length">
+                                    <template v-for="(tc, i) in group.msg.tool_calls" :key="tc.id || i">
+                                        <em v-if="tc.name === 'speak'" class="tool-speak">&ldquo;{{ tc.input && tc.input.text }}&rdquo;</em>
+                                        <span v-else class="tool-chip">[{{ formatToolCall(tc) }}]</span>
+                                        <span v-if="i < group.msg.tool_calls.length - 1">&nbsp;</span>
+                                    </template>
                                 </template>
-                            </template>
-                        </td>
-                        <td class="time-cell">{{ formatDate(msg.sent_at) }}</td>
-                    </tr>
+                            </td>
+                            <td class="time-cell">{{ formatDate(group.msg.sent_at) }}</td>
+                        </tr>
+                        <!-- Sim-mode scene group: collapsed header. The icon
+                             cell carries both the expand chevron and an unacked
+                             dot when any child row is unacked, so the admin
+                             doesn't lose the at-a-glance ack indicator they
+                             have on plain rows. -->
+                        <tr v-else @click="toggleScene(group.scene_id)" class="clickable scene-row">
+                            <td class="icon-cell">
+                                <i :class="isSceneExpanded(group.scene_id) ? 'icon-chevron-down' : 'icon-chevron-right'"></i>
+                                <i v-if="group.hasUnacked" class="icon-circle unacked-icon scene-ack-marker"></i>
+                            </td>
+                            <td colspan="3" class="scene-participants">{{ group.participants.join(', ') }}</td>
+                            <td class="message-cell"><span class="scene-summary">Scene · {{ group.messages.length }} messages</span></td>
+                            <td class="time-cell">{{ formatDate(group.latest_at) }}</td>
+                        </tr>
+                        <!-- Expanded scene: chronological sub-rows. -->
+                        <template v-if="group.type === 'scene' && isSceneExpanded(group.scene_id)">
+                            <tr v-for="msg in group.messages" :key="'scene-msg-' + msg.id" @click="selectedMessage = msg" class="clickable scene-child">
+                                <td class="icon-cell"><i :class="msg.acked_at ? 'icon-check acked-icon' : 'icon-circle unacked-icon'"></i></td>
+                                <td>{{ msg.from_agent }}</td>
+                                <td>{{ msg.to_agent }}</td>
+                                <td>{{ msg.channel || '—' }}</td>
+                                <td class="message-cell">
+                                    <template v-if="msg.message">{{ msg.message }}</template>
+                                    <template v-else-if="msg.tool_calls && msg.tool_calls.length">
+                                        <template v-for="(tc, i) in msg.tool_calls" :key="tc.id || i">
+                                            <em v-if="tc.name === 'speak'" class="tool-speak">&ldquo;{{ tc.input && tc.input.text }}&rdquo;</em>
+                                            <span v-else class="tool-chip">[{{ formatToolCall(tc) }}]</span>
+                                            <span v-if="i < msg.tool_calls.length - 1">&nbsp;</span>
+                                        </template>
+                                    </template>
+                                </td>
+                                <td class="time-cell">{{ formatDate(msg.sent_at) }}</td>
+                            </tr>
+                        </template>
+                    </template>
                 </tbody>
             </table>
         </div>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -739,7 +739,7 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
     // For discussion channels, query distinct messages from chat_message_texts
     // to avoid showing duplicate delivery rows
     if (discussionId) {
-        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id
+        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id, cmt.scene_id
                    FROM chat_message_texts cmt
                    JOIN actors fa ON fa.id = cmt.from_actor_id`;
         const conditions = ['cmt.discussion_id = $1'];
@@ -756,7 +756,7 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
         res.json({ messages: result.rows });
     } else {
         // Non-discussion: query delivery rows as before
-        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at
+        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at, cmt.scene_id
                    FROM chat_messages cm
                    JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
                    JOIN actors fa ON fa.id = cmt.from_actor_id

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -43,10 +43,23 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'tool_call_id must be a string' } });
     }
 
+    // Scene grouping (MEM-121) — optional UUID minted by salem-engine at the
+    // start of an event cascade (PC speak, NPC arrival, baseline tick) and
+    // threaded through every reactive tick in that scene. NULL for
+    // companion-mode chat. Validate the format here so a malformed
+    // engine payload fails fast instead of getting rejected at the
+    // Postgres UUID cast.
+    const sceneId = req.body.scene_id;
+    if (sceneId !== undefined && sceneId !== null) {
+        if (typeof sceneId !== 'string' || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sceneId)) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'scene_id must be a UUID string' } });
+        }
+    }
+
     const wait = req.body.wait === true;
 
     const result = await chatSend(from_agent, to_agents, discussionId, message, {
-        toolCalls, toolCallId, toolsOffered,
+        toolCalls, toolCallId, toolsOffered, sceneId,
     });
 
     // wait=true: hold the connection open until the VA reply lands inline.

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -34,6 +34,11 @@ function resolveDiscussionId(discussionId, channel) {
 // `pendingReplyPromise` (or null) so wait-mode HTTP routes can await the
 // VA's reply inline; non-wait callers ignore it and the dispatch stays
 // fire-and-forget.
+//
+// sceneId (MEM-121) is the engine's per-cascade UUID. When present, it
+// rides through to the chat row, the call log, and the VA's reply chat
+// row so the admin UI can group all rows from one tavern conversation
+// (or whatever scene) together. NULL for companion-mode.
 async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     if (!fromAgent || message === undefined || message === null) {
         throw Object.assign(new Error('Required fields: from_agent, message'), { statusCode: 400 });
@@ -44,6 +49,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     const toolCalls = opts && opts.toolCalls !== undefined ? opts.toolCalls : null;
     const toolCallId = opts && opts.toolCallId !== undefined ? opts.toolCallId : null;
     const toolsOffered = opts && opts.toolsOffered !== undefined ? opts.toolsOffered : null;
+    const sceneId = opts && opts.sceneId !== undefined ? opts.sceneId : null;
 
     // Resolve sender
     const fromActor = await requireByName(fromAgent);
@@ -100,8 +106,8 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // Insert one message text row
     const textResult = await pool.query(
         `INSERT INTO chat_message_texts
-            (message, from_actor_id, discussion_id, sent_at, tool_calls, tool_call_id, tools_offered)
-         VALUES ($1, $2, $3, NOW(), $4, $5, $6)
+            (message, from_actor_id, discussion_id, sent_at, tool_calls, tool_call_id, tools_offered, scene_id)
+         VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7)
          RETURNING id, sent_at`,
         [
             message,
@@ -110,6 +116,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
             toolCalls !== null ? JSON.stringify(toolCalls) : null,
             toolCallId,
             toolsOffered !== null ? JSON.stringify(toolsOffered) : null,
+            sceneId,
         ]
     );
     const messageTextId = textResult.rows[0].id;
@@ -135,6 +142,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
             to_agents: results.map(function(r) { return r.agent; }),
             message: message,
             discussion_id: discussionId || null,
+            scene_id: sceneId,
             sent_at: sentAt
         });
     }
@@ -193,7 +201,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     if (dispatches.length === 1) {
                         const d = dispatches[0];
                         pendingReplyPromise = handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                            toolsOffered, toolCallId,
+                            toolsOffered, toolCallId, sceneId,
                         });
                         // Swallow rejection for non-wait callers so unhandled-promise
                         // warnings don't appear; wait-mode awaiters get the error.
@@ -201,7 +209,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     } else {
                         for (const d of dispatches) {
                             handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                                toolsOffered, toolCallId,
+                                toolsOffered, toolCallId, sceneId,
                             }).catch(() => {});
                         }
                     }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -548,6 +548,7 @@ async function logTranscript(agentName, systemPrompt, userMessage, response, usa
 //   cost           — calculated cost (or 0 on failure)
 //   durationMs     — wall-clock time for the call
 //   error          — error object (if the call failed)
+//   sceneId        — engine cascade UUID (MEM-121); NULL outside sim-mode chat
 async function logCall(options) {
     try {
         // Extract the static portion of the system prompt (skip RAG context)
@@ -572,8 +573,8 @@ async function logCall(options) {
              (actor_id, context, context_id, provider, model, system_prompt, user_message,
               response, status, status_code, error_message,
               input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-              cost, duration_ms, usage_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
+              cost, duration_ms, usage_id, scene_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
             [
                 options.actorId,
                 options.context || null,
@@ -593,6 +594,7 @@ async function logCall(options) {
                 options.cost || 0,
                 options.durationMs || null,
                 options.usageId || null,
+                options.sceneId || null,
             ]
         );
     } catch (err) {
@@ -1723,6 +1725,7 @@ function buildToolUseMessages(history, npcAgentName) {
 // chatSend swallow the rejection; wait-mode awaiters surface it as 502).
 async function handleDirectChat(virtualAgentName, fromAgent, messageText, messageId, opts) {
     const toolsOffered = opts && opts.toolsOffered ? opts.toolsOffered : null;
+    const sceneId = opts && opts.sceneId !== undefined ? opts.sceneId : null;
     const isToolUse = Array.isArray(toolsOffered) && toolsOffered.length > 0;
 
     const agent = await loadAgent(virtualAgentName);
@@ -1791,7 +1794,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (isRateLimited(agent.agent)) {
             logVA('direct-chat-rate-limited', { agent: virtualAgentName, from: fromAgent });
             await chatSend(virtualAgentName, [fromAgent], null,
-                '[Error] Rate limited — too many API calls. Please wait before trying again.', null);
+                '[Error] Rate limited — too many API calls. Please wait before trying again.', { sceneId });
             return null;
         }
 
@@ -1800,7 +1803,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (costCheck.limited) {
             logVA('direct-chat-over-cost-limit', { agent: virtualAgentName, from: fromAgent, reason: costCheck.reason });
             await chatSend(virtualAgentName, [fromAgent], null,
-                `[Error] ${costCheck.reason}`, null);
+                `[Error] ${costCheck.reason}`, { sceneId });
             return null;
         }
 
@@ -1819,7 +1822,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             withActivityIndicator(agent.agent, () => providerFn(systemPrompt, userMessage, providerCallOpts)),
             async (err, retryInfo) => {
                 await chatSend(virtualAgentName, [fromAgent], null,
-                    `[Retrying] Initial attempt failed: ${err.message}. Retrying ${retryInfo.retriesRemaining} more time(s) over the next ~${formatDuration(retryInfo.totalSeconds)}.`, null);
+                    `[Retrying] Initial attempt failed: ${err.message}. Retrying ${retryInfo.retriesRemaining} more time(s) over the next ~${formatDuration(retryInfo.totalSeconds)}.`, { sceneId });
             }
         );
         const response = providerResult.text || '';
@@ -1834,15 +1837,18 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             actorId: agent.actor_id, agentName: agent.agent, context: 'chat',
             provider: agent.provider, model: agent.model,
             systemPrompt, userMessage: loggedUserMessage, response, usage, cost: chatCost,
-            durationMs: chatDurationMs, usageId: chatUsageId,
+            durationMs: chatDurationMs, usageId: chatUsageId, sceneId,
         }).catch(() => {});
 
         // Send response as direct chat back to the sender. Tool-use replies
         // persist tool_calls on the reply row so the next turn (if the
         // sender re-enters with tool_results) sees the assistant's prior
-        // tool_call when buildToolUseMessages walks history.
-        await chatSend(agent.agent, [fromAgent], null, response,
-            replyToolCalls.length > 0 ? { toolCalls: replyToolCalls } : null);
+        // tool_call when buildToolUseMessages walks history. The reply row
+        // inherits sceneId so admin sees the perception, the VA reply, and
+        // any subsequent tool result rows grouped under the same scene.
+        const replyOpts = { sceneId };
+        if (replyToolCalls.length > 0) replyOpts.toolCalls = replyToolCalls;
+        await chatSend(agent.agent, [fromAgent], null, response, replyOpts);
 
         // Ack the incoming message (virtual agent "read" it)
         if (messageId) {
@@ -1888,7 +1894,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             provider: agent ? agent.provider : 'unknown', model: agent ? agent.model : 'unknown',
             systemPrompt: typeof systemPrompt !== 'undefined' ? systemPrompt : null,
             userMessage: typeof loggedUserMessage !== 'undefined' ? loggedUserMessage : messageText,
-            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId,
+            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId, sceneId,
         }).catch(() => {});
         logError('virtual-agent', 'direct-chat-error', {
             agent: virtualAgentName,
@@ -1900,7 +1906,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         // Send error feedback to the caller so they know it failed
         try {
             await chatSend(virtualAgentName, [fromAgent], null,
-                `[Error] ${virtualAgentName} is unavailable (${err.message}).`, null);
+                `[Error] ${virtualAgentName} is unavailable (${err.message}).`, { sceneId });
         } catch (sendErr) {
             logVA('error-feedback-failed', { agent: virtualAgentName, error: sendErr.message });
         }


### PR DESCRIPTION
## Summary

Adds an optional `scene_id` UUID on `chat_message_texts` and `virtual_agent_calls` so the salem-engine can group every chat row and provider call from one event cascade — a tavern conversation, a player walking up to an NPC, a baseline tick — under one ID. The admin Comms → Chat view collapses same-scene rows into one expandable header so reading sim-mode activity stops being a wall of perception / tool-call / tool-result rows.

This is the API + UI half. The salem-engine half (mint UUIDs at cascade origins, thread through `runAgentTick` / `triggerImmediateTick` / `triggerCoLocatedTicks` / `executeAgentCommit`) ships in a follow-up PR after this deploys.

The migration is additive and nullable. Existing rows render exactly as before because chat-list grouping only kicks in for non-NULL `scene_id`, and single-row scenes flatten back to plain rows.

## What a scene is

The engine has three cascade-origin events: PC speaks, NPC arrives somewhere after a walk, and the baseline hourly tick. Each origin mints one UUID. That UUID rides through every reactive tick, every `sendChat` call inside those ticks, and every nested speak-cascade those reactors trigger. Walks intentionally do NOT carry scene_id forward — when an NPC's `move_to` finishes seconds-to-minutes of game time later, the arrival fires a fresh UUID because by then it's a new scene. Companion-mode chat rows leave `scene_id` NULL.

## Pieces

- **Migration** — `migrations/MEM-121-chat-scene-id_{up,down}.sql`. Two `ADD COLUMN UUID` + partial indexes.
- **Route** — `/chat/send` accepts optional `scene_id`, validates UUID shape inline (fail-fast 400 instead of waiting on the Postgres cast).
- **Service** — `chatSend` persists `scene_id`, includes it in the WS broadcast, forwards through `handleDirectChat` opts so the VA reply row inherits.
- **Virtual agent** — `handleDirectChat` threads `sceneId` through every `chatSend` it emits (rate-limit / over-cost / retry / final reply / error feedback) so status messages join the same scene group; passes `sceneId` to `logCall` for `virtual_agent_calls.scene_id`.
- **Admin** — `/admin/chat` SELECT adds `cmt.scene_id` on both branches. Dashboard summary widgets untouched.
- **UI store** — new `chatGroups` computed (groups by scene_id, single-message scenes flatten back to plain rows, `hasUnacked` aggregate so the collapsed header keeps the unacked indicator), `expandedScenes` Set, `toggleScene`, `isSceneExpanded`.
- **Template** — chat tab tbody iterates `chatGroups`. Plain rows render unchanged. Scene group header has chevron + unacked dot + participants + "Scene · N messages" + latest time. Click toggles, click sub-row opens existing detail dialog.
- **CSS** — subtle background tint + indent for `.scene-row` / `.scene-child`.

## Code review

Reviewed by `code_review` (mail thread `7cceca62` → `a46b1620`). Two issues caught and fixed pre-merge:

- Single-row scenes were getting hidden behind a header even when only one message with that scene_id was in the result set (paginated views, partial cascades). Fix: flatten single-message groups back to plain rows after grouping.
- Collapsed scene header was hiding ack state. Fix: `hasUnacked` aggregate + dot in the header alongside the chevron, treating `acked_at === undefined` (the discussion-id branch doesn't select it) as "no ack tracking" rather than unacked.

## Test plan

- [ ] Run the migration; confirm both columns + partial indexes exist
- [ ] POST `/chat/send` with no `scene_id` — confirm row inserts, scene_id is NULL, behavior unchanged
- [ ] POST `/chat/send` with a valid `scene_id` UUID — confirm row inserts, virtual_agent_calls.scene_id populates on the VA reply
- [ ] POST `/chat/send` with a malformed `scene_id` — confirm 400 BAD_REQUEST
- [ ] Admin Comms → Chat: existing companion-mode rows render unchanged (single-row layout, ack icon visible)
- [ ] Admin Comms → Chat with multiple sim-mode rows sharing a scene_id: render as collapsed header with chevron, participant list, count, latest time. Click expands chronologically. Sub-row click opens detail dialog.
- [ ] Admin Comms → Chat with one sim-mode row carrying a scene_id: renders as plain row (single-row flatten works).
- [ ] If any sim-mode row is unacked: the collapsed scene header shows the unacked dot.

— Work