### PR TITLE
Notes search: collapse results to one row per note

### DIFF
--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -302,10 +302,14 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
     // make deleted documents look like raw ingests and incorrectly include them.
     const softDeleteFilter = 'AND (d.id IS NULL OR d.deleted_at IS NULL)';
 
-    let sql;
+    // Inner SELECT scores chunks through the full pipeline (vector + BM25 +
+    // filename + access + decay + kind weight). Outer SELECT collapses to one
+    // row per note: keep the highest-scoring chunk as the snippet, expose
+    // chunk_count so callers can see "this note matched in N places".
+    let innerSql;
 
     if (!namespace || namespace === '*') {
-        sql = `
+        innerSql = `
             SELECT mc.source_file, mc.heading, mc.chunk_text, mc.namespace,
                    ((1 - (mc.embedding <=> $1)) + ${filenameBoostExpr} + ${bm25BoostExpr} + ${accessBoostExpression})
                    * ${decayExpression} * ${kindWeightExpression} AS similarity
@@ -316,7 +320,7 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
             LIMIT $2
         `;
     } else {
-        sql = `
+        innerSql = `
             SELECT mc.source_file, mc.heading, mc.chunk_text, mc.namespace,
                    ((1 - (mc.embedding <=> $1)) + ${filenameBoostExpr} + ${bm25BoostExpr} + ${accessBoostExpression})
                    * ${decayExpression} * ${kindWeightExpression} AS similarity
@@ -328,17 +332,25 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
         `;
     }
 
+    const finalLimitIdx = paramIdx;
+    params.push(maxResults);
+    paramIdx++;
+
+    const sql = `
+        SELECT source_file, heading, chunk_text, namespace, similarity, chunk_count
+        FROM (
+            SELECT source_file, heading, chunk_text, namespace, similarity,
+                   ROW_NUMBER() OVER (PARTITION BY namespace, source_file ORDER BY similarity DESC) AS rn,
+                   COUNT(*) OVER (PARTITION BY namespace, source_file) AS chunk_count
+            FROM (${innerSql}) candidates
+        ) ranked
+        WHERE rn = 1
+        ORDER BY similarity DESC
+        LIMIT $${finalLimitIdx}
+    `;
+
     const result = await pool.query(sql, params);
-    let rows = result.rows;
-
-    // Trim the candidate pool down to the requested result count.
-    // All boosts (BM25, filename, decay, access, kind weight) have been
-    // applied, so the final ordering reflects the full scoring pipeline.
-    if (rows.length > maxResults) {
-        rows = rows.slice(0, maxResults);
-    }
-
-    return { results: rows };
+    return { results: result.rows };
 }
 
 async function deleteMemory(namespace, sourceFile) {


### PR DESCRIPTION
## Summary

`/v1/memory/search` (and transitively `/admin/notes/search` + the MCP `search` tool) now returns one row per note instead of one row per matching chunk. The chunk that "wins" for each note is the highest-scoring one in the candidate pool. New `chunk_count` field surfaces "this note matched in N places."

Every consumer (admin UI, work's MCP, home's MCP, Salem engine) was already mentally deduping by source_file. Admin UI's `:key="r.source_file"` was producing Vue duplicate-key warnings whenever multi-chunk hits surfaced. This is a strict default-improvement.

## What changed

- Wraps the existing scoring SELECT in an inline subquery.
- Outer query: `ROW_NUMBER() OVER (PARTITION BY namespace, source_file ORDER BY similarity DESC)` + `COUNT(*) OVER (...)`, filter `rn = 1`.
- Final `LIMIT` is now in SQL; the JS-side `rows.slice(0, maxResults)` is gone.
- No new endpoint, no opt-in flag, no migration.

## Compatibility

Response shape: same fields (`source_file`, `heading`, `chunk_text`, `namespace`, `similarity`) plus a new `chunk_count` integer. No consumer breaks. Admin UI's duplicate-key warning silently goes away.

## Pool sizing note

Pool multiplier left at the existing 3x default. Worst case is fewer-than-requested distinct notes if the candidate pool collapses to one popular note. Acceptable; we can bump `search_pool_multiplier` config if it bites in practice.

## Code-reviewed

Reviewed by `code_review` agent — one fix applied (move final LIMIT into SQL).

## Test plan

- [ ] Hit `/v1/memory/search` with a query that has multiple chunks per note in any namespace; verify response has one row per (namespace, source_file).
- [ ] Verify `chunk_count` reflects the actual chunk count in the candidate pool.
- [ ] Admin UI semantic search still works; no Vue duplicate-key warnings in console.
- [ ] MCP `search` tool returns cleaner result list.

Pairs with the engine-side recall tool PR on llm-memory-plugin-salem-1692. Either can deploy first; deploying API first gives recall-tool tool_results a cleaner format.

— Work