### PR TITLE
admin chat: render attend_to(villager) like consume(item)

### DIFF
--- a/node/api/public/admin/components/ToolCallDisplay.js
+++ b/node/api/public/admin/components/ToolCallDisplay.js
@@ -32,6 +32,13 @@
 //                                consume_now / consumers fields are skipped
 //                                — meaningful mechanically but verbose for
 //                                a one-line chat-row chip.
+//   attend_to(villager)       -> [attend_to] + villager name. Without the
+//                                name it's impossible to tell at a glance
+//                                which dispatch is which when the
+//                                chronicler emits multiple attend_to calls
+//                                in the same assistant message (parallel
+//                                tool use), and that's the common case
+//                                during arrival or shift-boundary scenes.
 //   done() / unknown          -> [name] chip only
 //
 // Usage: <tool-call-display :tc="toolCall" />
@@ -71,6 +78,10 @@ const template = `
     <span class="tool-chip">[pay]</span>
     <span v-if="payLabel" class="tool-prose">{{ payLabel }}</span>
 </template>
+<template v-else-if="tc.name === 'attend_to'">
+    <span class="tool-chip">[attend_to]</span>
+    <span v-if="inputVillager" class="tool-prose">{{ inputVillager }}</span>
+</template>
 <span v-else class="tool-chip">[{{ tc.name }}]</span>
 `;
 
@@ -93,6 +104,7 @@ export default {
         const inputDestination = computed(() => input.value.destination || '');
         const inputType = computed(() => input.value.type || '');
         const inputScope = computed(() => input.value.scope || '');
+        const inputVillager = computed(() => input.value.villager || '');
         // 'village' is the chronicler's default scope; only surface a scope
         // chip when the tool call set something else (e.g. local/private).
         const nonDefaultScope = computed(() => {
@@ -152,7 +164,7 @@ export default {
 
         return {
             inputText, inputQuery, inputDestination, inputType,
-            inputScope, nonDefaultScope,
+            inputScope, nonDefaultScope, inputVillager,
             consumeLabel, gatherLabel, payLabel,
         };
     }


### PR DESCRIPTION
## Summary
- Adds an `attend_to(villager)` template branch to `ToolCallDisplay.js` so the admin chat row prints the villager name alongside the chip, matching the existing `consume(item)`, `move_to(destination)`, `pay(...)` patterns.
- Resolves the "this row has two identical `[attend_to]` chips" confusion when the chronicler does parallel tool use (the common case at arrival, shift-boundary, or buffered-flush scenes).

## Why now
Diagnosing a stuck-tiredness bug today, several chronicler messages fired multiple `attend_to` calls in one assistant turn (msg 5439 at dawn: `set_environment` + `attend_to Ezekiel Crane` + `attend_to John Ellis`). The chat row rendered as two indistinguishable `[attend_to]` chips, hiding which villager each call dispatched.

## Test plan
- [ ] Open the admin chat for the salem-chronicler agent and inspect msg 5439, 5405, 5319, 5303, 5243 (each has 2-3 tool calls including `attend_to`)
- [ ] Confirm each `attend_to` chip now reads `[attend_to] <villager name>`
- [ ] Confirm other tool kinds (`set_environment`, `record_event`, `consume`, `pay`, `move_to`) render unchanged

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)