### PR TITLE
chat/send: allow null message on tool_call_results path

### DIFF
--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -45,15 +45,6 @@ function resolveDiscussionId(discussionId, channel) {
 // row so the admin UI can group all rows from one tavern conversation
 // (or whatever scene) together. NULL for companion-mode.
 async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
-    if (!fromAgent || message === undefined || message === null) {
-        throw Object.assign(new Error('Required fields: from_agent, message'), { statusCode: 400 });
-    }
-    if (!toAgents && !discussionId) {
-        throw Object.assign(new Error('Required: to_agents (array) or discussion_id'), { statusCode: 400 });
-    }
-    const toolCalls = opts && opts.toolCalls !== undefined ? opts.toolCalls : null;
-    const toolCallId = opts && opts.toolCallId !== undefined ? opts.toolCallId : null;
-    const toolsOffered = opts && opts.toolsOffered !== undefined ? opts.toolsOffered : null;
     // toolCallResults (parallel-tool-call path): an array of { id, content }
     // pairs, one per tool the model emitted in its prior assistant reply.
     // When non-empty, persists N tool-result rows in one request instead of
@@ -69,6 +60,21 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     const toolCallResults = opts && Array.isArray(opts.toolCallResults) && opts.toolCallResults.length > 0
         ? opts.toolCallResults : null;
     const persistOnly = Boolean(opts && opts.persistOnly === true);
+    if (!fromAgent) {
+        throw Object.assign(new Error('Required field: from_agent'), { statusCode: 400 });
+    }
+    // toolCallResults substitutes for `message` — N tool-result rows in
+    // lieu of one user-text row. The route enforces mutual exclusivity, so
+    // require `message` only on the singular path.
+    if (!toolCallResults && (message === undefined || message === null)) {
+        throw Object.assign(new Error('Required field: message'), { statusCode: 400 });
+    }
+    if (!toAgents && !discussionId) {
+        throw Object.assign(new Error('Required: to_agents (array) or discussion_id'), { statusCode: 400 });
+    }
+    const toolCalls = opts && opts.toolCalls !== undefined ? opts.toolCalls : null;
+    const toolCallId = opts && opts.toolCallId !== undefined ? opts.toolCallId : null;
+    const toolsOffered = opts && opts.toolsOffered !== undefined ? opts.toolsOffered : null;
     const sceneId = opts && opts.sceneId !== undefined ? opts.sceneId : null;
     // sceneStructure (MEM-127) — denormalized structure-name stamp from the
     // engine. Pre-resolved engine-side because the village_object/asset


### PR DESCRIPTION
## Summary

- Fixes a service-layer regression deployed in 57c4c32: every salem-engine request using the new `tool_call_results` / `persist_only` body shape (introduced for parallel tool calls) was rejected with `400 BAD_REQUEST: Required fields: from_agent, message`.
- Splits the combined fromAgent/message guard and only requires `message` when `toolCallResults` is null. Route already enforces mutual exclusivity, so the tool-results path is safe — `rowSpecs` uses `spec.message` from each tool-result entry, and `handleDirectChat`'s tool-use branch builds the user message from history rather than dereferencing the inline `messageText`.

## Impact

NPC ticks and chronicler harness are entirely broken in production right now (every iter=1 + every persistToolResults call returns 400). Confirmed via salem journalctl: chronicler dispatch, agent ticks, terminal commits all dying with this error since the deploy at 22:16 UTC.

## Test plan

- [x] Diff inspection: confirmed no downstream null-deref of outer `message` on the tool-results path
- [ ] Deploy to VPS, watch `journalctl -u salem-engine` for the 400 errors to stop
- [ ] Trigger an NPC tick (PC knock at a shop) and verify a `done` row lands in `agent_action_log`
- [ ] Verify chronicler dispatch round-trips cleanly (next dusk-phase boundary)

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)