### PR TITLE
chat/send: surface 502 REPLY_FAILED when VA is missing api_key/provider/model

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2095,8 +2095,15 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     if (!agent || !agent.virtual) return null;
 
     if (!agent.api_key || !agent.provider || !agent.model) {
+        // Throw rather than return null: wait=true callers (the salem engine
+        // is the canonical one) await this promise via the chat/send route,
+        // which catches and maps to 502 REPLY_FAILED. Returning null silently
+        // resolves with reply=null and the caller can't tell a misconfigured
+        // VA from a quiet one — a visitor with no api_key would freeze on
+        // arrival, sit forever, no error surfaced. Non-wait callers in
+        // chat.js already swallow rejections with .catch(() => {}).
         logVA('direct-chat-skip', { agent: virtualAgentName, reason: 'missing config' });
-        return null;
+        throw new Error('Agent ' + virtualAgentName + ' missing provider/model/api_key');
     }
 
     logVA('direct-chat-processing', { agent: virtualAgentName, from: fromAgent, tool_use: isToolUse });


### PR DESCRIPTION
## Symptom

A `salem-visitor` VA was created in `agent_configuration` with `provider=anthropic` and `model=claude-haiku-4-5` but no `api_key`. The Salem engine spawned visitors normally — they walked from a village-edge tile to the tavern and entered an outdoor huddle — but every subsequent agent tick failed silently:

\`\`\`
agent-tick Caleb Wendell the wool-buyer iter=0: chat response missing reply
  (body: {\"from_agent\":\"salem-engine\",\"to_agents\":[{...,\"agent\":\"salem-visitor\",...}],\"reply\":null})
\`\`\`

Result: visitors froze at (1488, 656) outside the tavern for hours until \`visitor_expires_at\` cleared them. No error code surfaced to the engine, no admin signal, no retry — just \`reply: null\` on HTTP 200.

## Cause

\`handleDirectChat\` in \`node/api/src/services/virtual-agent.js\` returned \`null\` when the target VA was missing \`api_key\`, \`provider\`, or \`model\`. The chat/send wait-mode path (\`routes/chat.js:148-158\`) awaits \`pendingReplyPromise\`, gets \`null\`, and returns \`{ reply: null }\` with HTTP 200. Engine sees a successful response with no payload and gives up — same shape it would see if the VA legitimately chose not to reply.

Compare with the existing \`decryptApiKey()\` failure path: a malformed encrypted key throws, the wait-mode \`catch (replyErr)\` block at \`routes/chat.js:159\` maps it to \`502 REPLY_FAILED { code, message }\`, and the engine logs the failure visibly.

## Fix

Throw instead of returning null on missing config. The existing wait-mode catch already produces the right error shape — no route changes needed.

## Blast radius

- **wait=true callers** (Salem engine): get \`502 REPLY_FAILED { message: 'Agent salem-visitor missing provider/model/api_key' }\`. Identical shape to the encrypted-key error, which the engine already handles.
- **non-wait callers**: \`services/chat.js:403\` and \`:411\` already swallow rejections with \`.catch(() => {})\`. No behavior change.
- **Other call sites of \`handleDirectChat\`**: only \`services/chat.js\` calls it. Both branches handle rejection.
- **\`!agent || !agent.virtual\` guard at line 2095**: unchanged. That case (sending to a human or a missing actor) is filtered upstream by the route's wait=true precondition.

## Test plan

- [ ] Configure a VA with \`provider\`/\`model\` set but \`api_key=NULL\`, send chat with \`wait=true\`, expect \`502 REPLY_FAILED\` (not HTTP 200 with \`reply: null\`).
- [ ] Configure a VA with a malformed encrypted key — verify existing \`Invalid encrypted API key format\` path still returns the same \`502 REPLY_FAILED\` shape (no regression).
- [ ] Send chat to a properly-configured VA in wait mode — verify normal \`{ reply: {...} }\` response (no regression on the happy path).
- [ ] After deploy + setting the salem-visitor api_key, spawn a visitor and verify they no longer freeze at the tavern (the original symptom).

— Home