### PR TITLE
providers: coerce numeric config knobs to numbers at send time

### DIFF
--- a/node/api/src/services/providers/anthropic.js
+++ b/node/api/src/services/providers/anthropic.js
@@ -2,6 +2,7 @@
 // Handles structured system prompts with optional cache_control markers.
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -282,7 +283,7 @@ function createCall(model, apiKey, configuration) {
 
         const body = {
             model: model,
-            max_tokens: conf.max_tokens || 4096,
+            max_tokens: asNumber(conf.max_tokens) || 4096,
             system: system,
             messages: messages
         };
@@ -293,8 +294,11 @@ function createCall(model, apiKey, configuration) {
                 type: 'adaptive',
                 effort: conf.thinking_effort
             };
-        } else if (conf.temperature !== undefined) {
-            body.temperature = conf.temperature;
+        } else {
+            const t = asNumber(conf.temperature);
+            if (t !== undefined) {
+                body.temperature = t;
+            }
         }
 
         // Per-call stop sequences. Anthropic allows up to 4.

--- a/node/api/src/services/providers/coerce.js
+++ b/node/api/src/services/providers/coerce.js
@@ -1,0 +1,22 @@
+// Provider-side coercion helpers.
+//
+// Lives in its own module to avoid the circular require chain that would
+// happen if these were defined in providers/index.js (which loads each
+// provider module by name; provider modules can't require index.js back).
+
+// asNumber coerces a config value to a finite number. Returns undefined
+// for anything that isn't (null, '', undefined, NaN, Infinity, non-numeric
+// strings). Provider modules use this on body fields whose underlying API
+// requires numeric types — Anthropic, OpenAI, Google, etc. all reject
+// string-typed temperature even though OpenRouter/llama happens to coerce
+// on its end. Storage stays whatever the user typed (the admin form ends
+// up with string-typed numeric inputs because pg returns numeric columns
+// as strings, and the admin save round-trips them as-is). Each provider
+// enforces its own type contract at send time.
+function asNumber(v) {
+    if (v === null || v === undefined || v === '') return undefined;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+module.exports = { asNumber };

--- a/node/api/src/services/providers/google.js
+++ b/node/api/src/services/providers/google.js
@@ -2,6 +2,7 @@
 // Uses the Generative Language API (generativelanguage.googleapis.com).
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -274,24 +275,29 @@ function createCall(model, apiKey, configuration) {
             generationConfig: {}
         };
 
-        if (conf.max_tokens) {
-            body.generationConfig.maxOutputTokens = conf.max_tokens;
+        const maxTokens = asNumber(conf.max_tokens);
+        if (maxTokens !== undefined) {
+            body.generationConfig.maxOutputTokens = maxTokens;
         }
-        if (conf.temperature !== undefined) {
-            body.generationConfig.temperature = conf.temperature;
+        const temperature = asNumber(conf.temperature);
+        if (temperature !== undefined) {
+            body.generationConfig.temperature = temperature;
         }
-        if (conf.top_p !== undefined) {
-            body.generationConfig.topP = conf.top_p;
+        const topP = asNumber(conf.top_p);
+        if (topP !== undefined) {
+            body.generationConfig.topP = topP;
         }
-        if (conf.top_k !== undefined) {
-            body.generationConfig.topK = conf.top_k;
+        const topK = asNumber(conf.top_k);
+        if (topK !== undefined) {
+            body.generationConfig.topK = topK;
         }
 
         // Thinking budget: 0 = disabled, >0 = enabled with cap.
         // When omitted, model uses its own default thinking behavior.
-        if (conf.thinking_budget !== undefined) {
+        const thinkingBudget = asNumber(conf.thinking_budget);
+        if (thinkingBudget !== undefined) {
             body.generationConfig.thinkingConfig = {
-                thinkingBudget: conf.thinking_budget
+                thinkingBudget: thinkingBudget
             };
         }
 

--- a/node/api/src/services/providers/openai.js
+++ b/node/api/src/services/providers/openai.js
@@ -7,6 +7,7 @@
 // formula in index.js can't account for these without becoming OpenAI-aware.
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -297,8 +298,8 @@ async function callResponses(model, apiKey, conf, fullMessages, opts) {
     };
 
     // /v1/responses uses max_output_tokens. Accept either stored config key.
-    const maxTokens = conf.max_completion_tokens || conf.max_tokens;
-    if (maxTokens) {
+    const maxTokens = asNumber(conf.max_completion_tokens) ?? asNumber(conf.max_tokens);
+    if (maxTokens !== undefined) {
         body.max_output_tokens = maxTokens;
     }
 
@@ -445,8 +446,8 @@ function createCall(model, apiKey, configuration) {
 
         // All OpenAI models now use max_completion_tokens (max_tokens is deprecated).
         // Accept either key from stored config for backwards compatibility.
-        const maxTokens = conf.max_completion_tokens || conf.max_tokens;
-        if (maxTokens) {
+        const maxTokens = asNumber(conf.max_completion_tokens) ?? asNumber(conf.max_tokens);
+        if (maxTokens !== undefined) {
             body.max_completion_tokens = maxTokens;
         }
 
@@ -461,8 +462,11 @@ function createCall(model, apiKey, configuration) {
             var activeReasoning = conf.reasoning_effort && conf.reasoning_effort !== 'none';
             if (activeReasoning) {
                 body.reasoning_effort = conf.reasoning_effort;
-            } else if (conf.temperature !== undefined) {
-                body.temperature = conf.temperature;
+            } else {
+                const t = asNumber(conf.temperature);
+                if (t !== undefined) {
+                    body.temperature = t;
+                }
             }
         }
 

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -11,6 +11,7 @@
 // using catalog pricing, so index.js calculateCost always gets usage.cost.
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -159,12 +160,14 @@ function createCall(model, apiKey, configuration) {
             ].concat(userMessages)
         };
 
-        if (conf.max_tokens) {
-            body.max_tokens = conf.max_tokens;
+        const maxTokens = asNumber(conf.max_tokens);
+        if (maxTokens !== undefined) {
+            body.max_tokens = maxTokens;
         }
 
-        if (conf.temperature !== undefined) {
-            body.temperature = conf.temperature;
+        const temperature = asNumber(conf.temperature);
+        if (temperature !== undefined) {
+            body.temperature = temperature;
         }
 
         // Per-call stop sequences. OpenRouter proxies to many upstreams;

--- a/node/api/src/services/providers/perplexity.js
+++ b/node/api/src/services/providers/perplexity.js
@@ -3,6 +3,7 @@
 // OpenAI-compatible format with additional response fields (citations, search_results).
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -141,11 +142,13 @@ function createCall(model, apiKey, configuration) {
             ]
         };
 
-        if (conf.max_tokens) {
-            body.max_tokens = conf.max_tokens;
+        const maxTokens = asNumber(conf.max_tokens);
+        if (maxTokens !== undefined) {
+            body.max_tokens = maxTokens;
         }
-        if (conf.temperature !== undefined) {
-            body.temperature = conf.temperature;
+        const temperature = asNumber(conf.temperature);
+        if (temperature !== undefined) {
+            body.temperature = temperature;
         }
         if (conf.search_recency_filter) {
             body.search_recency_filter = conf.search_recency_filter;

--- a/node/api/src/services/providers/xai.js
+++ b/node/api/src/services/providers/xai.js
@@ -9,6 +9,7 @@
 // Each search invocation costs $5/1K calls on top of token costs.
 
 const { log } = require('../logger');
+const { asNumber } = require('./coerce');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -201,13 +202,15 @@ function createCall(model, apiKey, configuration) {
         };
 
         // Max output tokens
-        if (conf.max_output_tokens) {
-            body.max_output_tokens = conf.max_output_tokens;
+        const maxOutputTokens = asNumber(conf.max_output_tokens);
+        if (maxOutputTokens !== undefined) {
+            body.max_output_tokens = maxOutputTokens;
         }
 
         // Temperature — only for non-reasoning models
-        if (conf.temperature !== undefined) {
-            body.temperature = conf.temperature;
+        const temperature = asNumber(conf.temperature);
+        if (temperature !== undefined) {
+            body.temperature = temperature;
         }
 
         // Per-call stop sequences. xAI Responses API accepts `stop` like


### PR DESCRIPTION
## Symptom

salem-visitor (anthropic / claude-haiku-4-5) chat fails on every dispatch:

\`\`\`
Anthropic API error 400: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",
  \"message\":\"temperature: Input should be a valid number\"}}
\`\`\`

Engine logs the failure, visitor never decides anything, sits forever outside the tavern.

## Cause

The admin Settings panel ([agents.js:449](https://github.com/jeffdafoe/llm-memory-api/blob/main/node/api/public/admin/agents.js#L449)) round-trips numeric knobs through \`agentSettingsConfig.value\`, which inherits the string-typed values \`pg\` returns for \`numeric\` columns. The save persists them into \`agent_configuration.configuration\` as strings (e.g. \`{\"temperature\":\"0.7\"}\`), then each provider passes them straight through to the upstream API.

OpenRouter / Llama happen to coerce strings on their end, so the bug stayed latent there. Anthropic does not — it rejects with HTTP 400. OpenAI, Google, Perplexity, xAI would all fail the same way for any agent saved through the Settings panel; it just hadn't been exercised yet.

## Fix

New \`providers/coerce.js\` exports \`asNumber(v)\`: returns a finite number for valid inputs, \`undefined\` for null / empty / NaN / Infinity / non-numeric strings.

Lives in its own module rather than \`providers/index.js\` to avoid the circular require chain (index.js loads each provider by name; providers can't require index.js back).

Each provider calls \`asNumber\` on numeric body fields before assigning. Storage stays whatever the user typed (no migration needed); each provider enforces its own type contract at send time.

Coverage:
- **anthropic.js**: temperature, max_tokens
- **openai.js**: temperature, max_tokens, max_completion_tokens (both /v1/responses and chat/completions paths)
- **google.js**: temperature, max_tokens, top_p, top_k, thinking_budget
- **openrouter.js**: temperature, max_tokens
- **perplexity.js**: temperature, max_tokens
- **xai.js**: temperature, max_output_tokens

## Blast radius

- Strings now become numbers before reaching the provider API. No call sites outside the providers — coerce.js is provider-internal.
- Bad input (non-numeric string, NaN, Infinity) is silently dropped instead of being passed through. Provider falls back to its own default. Acceptable: matches the existing behavior for empty-string + sanitizeAgentConfiguration in the admin save path, just extended to the runtime contract.
- No change for already-numeric values — \`asNumber(0.7)\` returns \`0.7\` unchanged.

## Test plan

- [x] Local smoke test: \`require('./src/services/providers')\` loads cleanly (no circular dep).
- [x] \`asNumber\` matrix: '0.7' → 0.7, 0.7 → 0.7, '' → undefined, null → undefined, undefined → undefined, 'abc' → undefined, '0' → 0, 'Infinity' → undefined.
- [ ] Deploy. Verify next salem-visitor tick (Caleb or Elias, both currently parked outside the tavern) actually reaches Anthropic and produces a tool call or speech.
- [ ] Spot-check an OpenAI agent — should still work (was already passing numbers, this is a no-op for numeric input).
- [ ] Spot-check Hannah Boggs (salem-vendor / openrouter) — should still work; openrouter happens to coerce on its end but now we coerce locally too.

— Home