### PR TITLE
fix(virtual-agent): parse v2 perception format in extractCoLocatedNames [ZBBS-WORK-347]

### DIFF
--- a/node/api/scripts/test-extract-co-located-names.js
+++ b/node/api/scripts/test-extract-co-located-names.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Standalone unit test for extractCoLocatedNames (virtual-agent.js).
+//
+// Pins the parser to v2 Salem engine perception format:
+//   ## Around you
+//   inside: <Tavern> [tavern]
+//   huddle: <id> with Name1, Name2, the keeper, a stranger
+//   atmosphere: ...
+//
+// And verifies the failure modes that bit stateful Salem NPCs before the
+// v2 rewrite of this function:
+//   - v1 "Here:\n  Name" format produces empty (v1 is being deleted).
+//   - Acquaintance descriptors ("the X", "a stranger") are filtered so
+//     they don't reach personContextSlug and produce bogus lookups.
+//   - Solo / not-in-huddle states return empty.
+//
+// Run: node scripts/test-extract-co-located-names.js
+// Exits 0 on pass, 1 on any failure.
+//
+// virtual-agent.js requires a few modules at load that touch DB/Express
+// internals. None are exercised by extractCoLocatedNames — but the
+// top-level require could touch the environment. Stub the heavy
+// dependencies before loading the module to keep the test pure.
+
+const Module = require('module');
+const origRequire = Module.prototype.require;
+
+// Stub ../db, ../models/*, anything that would open a pool. The parser
+// is pure; we only need the exported function reference.
+const stubExports = {};
+Module.prototype.require = function (id) {
+    if (id === '../db' || id === './db') return { query: async () => ({ rows: [] }) };
+    if (/\/(notes|chat|mail|api-spend|metering|conversations|llm-clients|system-handler)$/.test(id)) {
+        return new Proxy(stubExports, {
+            get: function () { return function () { return Promise.resolve(null); }; }
+        });
+    }
+    return origRequire.apply(this, arguments);
+};
+
+const { extractCoLocatedNames } = require('../src/services/virtual-agent');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assertEqual(label, got, want) {
+    const gotJson = JSON.stringify(got);
+    const wantJson = JSON.stringify(want);
+    if (gotJson === wantJson) {
+        passed++;
+    } else {
+        failed++;
+        failures.push('  FAIL [' + label + ']: got ' + gotJson + ', want ' + wantJson);
+    }
+}
+
+// ---------- v2 happy paths ----------
+
+assertEqual(
+    'two acquainted peers',
+    extractCoLocatedNames(
+        '## Around you\n' +
+        'inside: Tavern [tavern]\n' +
+        'huddle: h1 with Prudence Ward, Josiah Thorne\n' +
+        'atmosphere: quiet\n'
+    ),
+    ['Prudence Ward', 'Josiah Thorne']
+);
+
+assertEqual(
+    'single acquainted peer',
+    extractCoLocatedNames(
+        '## Around you\n' +
+        'inside: Apothecary [pw_apothecary]\n' +
+        'huddle: h2 with Prudence Ward\n'
+    ),
+    ['Prudence Ward']
+);
+
+assertEqual(
+    'name with apostrophe + hyphen survives intact',
+    extractCoLocatedNames('huddle: h1 with Mary O\'Brien, Jean-Luc Picard\n'),
+    ["Mary O'Brien", 'Jean-Luc Picard']
+);
+
+// ---------- v2 acquaintance-descriptor filtering ----------
+
+assertEqual(
+    'mixed acquainted + role + stranger drops descriptors',
+    extractCoLocatedNames('huddle: h1 with Prudence Ward, the keeper, a stranger\n'),
+    ['Prudence Ward']
+);
+
+assertEqual(
+    'all unacquainted yields empty',
+    extractCoLocatedNames('huddle: h1 with the keeper, the blacksmith, a stranger\n'),
+    []
+);
+
+assertEqual(
+    'capitalized "The X" player name is NOT filtered',
+    extractCoLocatedNames('huddle: h1 with The Mountain, Sansa Stark\n'),
+    ['The Mountain', 'Sansa Stark']
+);
+
+// ---------- v2 solo / no-huddle states ----------
+
+assertEqual(
+    'alone in huddle (you are the only member)',
+    extractCoLocatedNames(
+        '## Around you\n' +
+        'inside: Tavern [tavern]\n' +
+        'huddle: h1 (you are the only member)\n'
+    ),
+    []
+);
+
+assertEqual(
+    'not in a huddle',
+    extractCoLocatedNames(
+        '## Around you\n' +
+        'inside: outdoors\n' +
+        'huddle: not in a huddle\n'
+    ),
+    []
+);
+
+assertEqual(
+    'no Around-you block at all',
+    extractCoLocatedNames('## Orders you\'re waiting on\n- order id 7\n'),
+    []
+);
+
+// ---------- defensive ----------
+
+assertEqual('null input', extractCoLocatedNames(null), []);
+assertEqual('undefined input', extractCoLocatedNames(undefined), []);
+assertEqual('empty string', extractCoLocatedNames(''), []);
+
+// ---------- v1 format (deliberately UNSUPPORTED) ----------
+// v1 emitted "Here:\n  Name (inside)" — that engine is being deleted
+// post-v2-go-live (project_salem_v1_deletion). The v2 parser should NOT
+// match v1's shape; this pins the deliberate scope.
+
+assertEqual(
+    'v1 "Here:" format returns empty (v1 unsupported)',
+    extractCoLocatedNames('Here:\n  Prudence Ward (inside)\n'),
+    []
+);
+
+// ---------- Report ----------
+
+if (failed > 0) {
+    console.log('FAILED ' + failed + ' / ' + (passed + failed));
+    failures.forEach(function (f) { console.log(f); });
+    process.exit(1);
+}
+console.log('PASS ' + passed + ' / ' + (passed + failed));
+process.exit(0);

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -925,30 +925,50 @@ async function loadPeopleContext(agentName, counterparts) {
     return sections.join('\n\n');
 }
 
-// Parse co-located people from a Salem engine perception. The engine
-// includes a "Here:\n  Name1\n  Name2" block listing other people at
-// the NPC's current location (other NPCs by display name, players by
-// in-game name). Returns an array of display names, empty when alone.
+// Parse co-located people from a Salem engine perception (v2 format).
+//
+// The v2 engine's "## Around you" block lists co-huddle peers inline on a
+// single "huddle:" line: `huddle: <id> with Name1, Name2, the keeper, a stranger`.
+// Solo / not-in-huddle states have fixed suffixes ("(you are the only
+// member)", "not in a huddle") that don't match the `with <names>` pattern
+// and short-circuit to an empty list.
+//
+// Returns an array of display names for ACQUAINTED peers only — the
+// engine acquaintance-gates names at render time (engine/sim/perception/
+// render.go:renderHuddleMember), so unacquainted peers arrive as
+// descriptors like "the keeper" or "a stranger" that have no
+// `context/people/<slug>` to load and are filtered out here. False
+// positive on a player named "The Mountain" is dodged by leaving the
+// regex case-sensitive: only lowercase "the X" matches the descriptor
+// shape that the engine actually emits.
 //
 // Used in sim mode to derive the Impressions counterpart list from the
 // world state instead of from `fromAgent` (which is always "salem-engine"
 // — not a person — and would otherwise cause Impressions to be empty).
 function extractCoLocatedNames(perceptionText) {
     if (!perceptionText) return [];
-    const match = perceptionText.match(/^Here:\s*\n((?:  +.+\n?)+)/m);
+    // Anchor on the huddle line specifically (not the broader "## Around
+    // you" header) so the "(you are the only member)" / "not in a huddle"
+    // suffixes don't accidentally match — those don't carry "with <names>".
+    const match = perceptionText.match(/^huddle:\s+\S+\s+with\s+(.+)$/m);
     if (!match) return [];
     return match[1]
-        .split('\n')
-        .map(function (line) { return line.trim(); })
-        .filter(function (line) { return line.length > 0; });
+        .split(',')
+        .map(function (s) { return s.trim(); })
+        .filter(function (s) { return s.length > 0; })
+        // Acquaintance descriptors: "the <role>" (always lowercased role
+        // per engine) and the literal "a stranger". Case-sensitive on
+        // purpose — a player display name like "The Mountain" stays.
+        .filter(function (s) { return !/^the\s+/.test(s) && s !== 'a stranger'; });
 }
 
 // Per-scene co-located-names cache for sim-NPC ticks.
 //
-// The Salem engine emits a "Here:" block in the user message of fresh
-// perceptions (the chat/send that opens an NPC's tick). The isSimNpc
-// branch in handleDirectChat uses that block to inject "## Your
-// impressions of <name>" into the system prompt via loadPeopleContext.
+// The Salem engine emits a "## Around you" / "huddle: <id> with ..." line
+// in the user message of fresh perceptions (the chat/send that opens an
+// NPC's tick). The isSimNpc branch in handleDirectChat uses that line to
+// inject "## Your impressions of <name>" into the system prompt via
+// loadPeopleContext.
 //
 // On follow-up tool-result chat/sends within the same scene (the model
 // called speak, the engine returned "[OK] You spoke. Continue your
@@ -2624,4 +2644,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames };


### PR DESCRIPTION
## Summary

Stateful Salem NPCs were silently going without per-peer Impressions in their system prompt because `extractCoLocatedNames` still matched v1's `Here:\n  Name` block. v2 engine restructured to a single inline line (`## Around you` → `huddle: <id> with Name1, Name2, the keeper, a stranger`). The old regex matched nothing in v2 → `coLocated = []` → `loadPeopleContext` never called → no \"## Your impressions of X\" sections, even though stateful NPCs have rich `context/people/<peer>` notes accumulated via the dream pipeline.

Net behavior: stateful NPCs meeting familiar peers as if fresh, ignoring established dynamics. Direct evidence on file: `virtual_agent_calls id=7758` (zbbs-ezekiel-crane, 2026-05-13, perception listed Prudence Ward at PW Apothecary, no Impressions block emitted). Filed as `shared/tasks/pending/salem-stateful-va-missing-peer-context`.

## Changes

- **`extractCoLocatedNames`** rewritten to parse v2's `huddle: <id> with <names>` line. Solo states (`(you are the only member)`) and not-in-huddle don't carry `with <names>` and short-circuit to empty.
- **Filter acquaintance descriptors** (`the <role>`, `a stranger`) before they reach `personContextSlug`. Engine acquaintance-gates names at render time (`engine/sim/perception/render.go:renderHuddleMember`), so unacquainted peers arrive as descriptors and have no `context/people/<slug>` to load anyway.
- **Case-sensitive descriptor regex on purpose** — a player named \"The Mountain\" stays; only the lowercase-role pattern the engine emits matches.
- **v1 path dropped entirely.** v1 engine is being deleted post-v2-go-live (`project_salem_v1_deletion`); maintaining a v1 fallback would just rot.
- **Updated comments** on the per-scene cache helpers to reference v2's `## Around you` shape instead of v1's `Here:`.
- **Exported `extractCoLocatedNames`** from the module so the test script can import it.

## Tests

`node/api/scripts/test-extract-co-located-names.js` — 13 cases, all passing:

- Two acquainted peers, single acquainted peer.
- Name with apostrophe / hyphen survives intact.
- Mixed acquainted + role + stranger → drops descriptors.
- All unacquainted → empty.
- Capitalized \"The X\" player name → NOT filtered (case-sensitive descriptor regex).
- Alone in huddle, not in a huddle, no Around-you block → empty.
- Defensive: null / undefined / empty string.
- v1 `Here:` format → empty (pins the deliberate \"v1 unsupported\" scope).

Run: `cd node/api && node scripts/test-extract-co-located-names.js`. Output: `PASS 13 / 13`.

## Out of scope

- Fixing v1 perception parsing (v1 is being deleted; salem v2 boot is imminent).
- Tightening `personContextSlug` for parenthetical annotations (v2 doesn't emit them — the `(inside)`/`(outside)` shape is gone, replaced by the structured `inside:` line).
- Engine-side change to inject per-peer relationships for stateful actors (the existing pattern is: shared-VA gets engine-injected `## What you remember of those here`; stateful gets api-side `## Your impressions of X` loaded from `context/people/*`. This fix restores the latter path; the asymmetry is by design).

— Work