### PR TITLE
fix(virtual-agent): drop huddle-id from extractCoLocatedNames regex [ZBBS-WORK-349]

### DIFF
--- a/node/api/scripts/test-extract-co-located-names.js
+++ b/node/api/scripts/test-extract-co-located-names.js
@@ -55,14 +55,14 @@ function assertEqual(label, got, want) {
     }
 }
 
-// ---------- v2 happy paths ----------
+// ---------- v2 happy paths (post-WORK-348: no debug ids in lines) ----------
 
 assertEqual(
     'two acquainted peers',
     extractCoLocatedNames(
         '## Around you\n' +
-        'inside: Tavern [tavern]\n' +
-        'huddle: h1 with Prudence Ward, Josiah Thorne\n' +
+        'inside: Tavern\n' +
+        'huddle: with Prudence Ward, Josiah Thorne\n' +
         'atmosphere: quiet\n'
     ),
     ['Prudence Ward', 'Josiah Thorne']
@@ -72,15 +72,15 @@ assertEqual(
     'single acquainted peer',
     extractCoLocatedNames(
         '## Around you\n' +
-        'inside: Apothecary [pw_apothecary]\n' +
-        'huddle: h2 with Prudence Ward\n'
+        'inside: Apothecary\n' +
+        'huddle: with Prudence Ward\n'
     ),
     ['Prudence Ward']
 );
 
 assertEqual(
     'name with apostrophe + hyphen survives intact',
-    extractCoLocatedNames('huddle: h1 with Mary O\'Brien, Jean-Luc Picard\n'),
+    extractCoLocatedNames('huddle: with Mary O\'Brien, Jean-Luc Picard\n'),
     ["Mary O'Brien", 'Jean-Luc Picard']
 );
 
@@ -88,19 +88,19 @@ assertEqual(
 
 assertEqual(
     'mixed acquainted + role + stranger drops descriptors',
-    extractCoLocatedNames('huddle: h1 with Prudence Ward, the keeper, a stranger\n'),
+    extractCoLocatedNames('huddle: with Prudence Ward, the keeper, a stranger\n'),
     ['Prudence Ward']
 );
 
 assertEqual(
     'all unacquainted yields empty',
-    extractCoLocatedNames('huddle: h1 with the keeper, the blacksmith, a stranger\n'),
+    extractCoLocatedNames('huddle: with the keeper, the blacksmith, a stranger\n'),
     []
 );
 
 assertEqual(
     'capitalized "The X" player name is NOT filtered',
-    extractCoLocatedNames('huddle: h1 with The Mountain, Sansa Stark\n'),
+    extractCoLocatedNames('huddle: with The Mountain, Sansa Stark\n'),
     ['The Mountain', 'Sansa Stark']
 );
 
@@ -110,8 +110,8 @@ assertEqual(
     'alone in huddle (you are the only member)',
     extractCoLocatedNames(
         '## Around you\n' +
-        'inside: Tavern [tavern]\n' +
-        'huddle: h1 (you are the only member)\n'
+        'inside: Tavern\n' +
+        'huddle: (you are the only member)\n'
     ),
     []
 );
@@ -123,6 +123,16 @@ assertEqual(
         'inside: outdoors\n' +
         'huddle: not in a huddle\n'
     ),
+    []
+);
+
+// Regression guard: the pre-WORK-348 format with a leading huddle id
+// MUST NOT match — the new parser is anchored on `huddle: with` exactly.
+// If the engine ever re-introduced a huddle id between the label and
+// "with", this would silently break, and this test pins that contract.
+assertEqual(
+    'pre-WORK-348 "huddle: h1 with ..." does NOT match (id-anchored parser is gone)',
+    extractCoLocatedNames('huddle: h1 with Prudence Ward, Josiah Thorne\n'),
     []
 );
 

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -928,7 +928,7 @@ async function loadPeopleContext(agentName, counterparts) {
 // Parse co-located people from a Salem engine perception (v2 format).
 //
 // The v2 engine's "## Around you" block lists co-huddle peers inline on a
-// single "huddle:" line: `huddle: <id> with Name1, Name2, the keeper, a stranger`.
+// single "huddle:" line: `huddle: with Name1, Name2, the keeper, a stranger`.
 // Solo / not-in-huddle states have fixed suffixes ("(you are the only
 // member)", "not in a huddle") that don't match the `with <names>` pattern
 // and short-circuit to an empty list.
@@ -947,10 +947,13 @@ async function loadPeopleContext(agentName, counterparts) {
 // — not a person — and would otherwise cause Impressions to be empty).
 function extractCoLocatedNames(perceptionText) {
     if (!perceptionText) return [];
-    // Anchor on the huddle line specifically (not the broader "## Around
-    // you" header) so the "(you are the only member)" / "not in a huddle"
-    // suffixes don't accidentally match — those don't carry "with <names>".
-    const match = perceptionText.match(/^huddle:\s+\S+\s+with\s+(.+)$/m);
+    // Anchor on `huddle: with <names>` — the "with" keyword is the engine's
+    // structural marker that names follow. Solo (`huddle: (you are the only
+    // member)`) and no-huddle (`huddle: not in a huddle`) don't carry "with"
+    // and correctly short-circuit. Pre-WORK-348 the engine also rendered an
+    // opaque huddle id (`huddle: h1 with ...`); that id has been dropped
+    // because the LLM never used it.
+    const match = perceptionText.match(/^huddle:\s+with\s+(.+)$/m);
     if (!match) return [];
     return match[1]
         .split(',')


### PR DESCRIPTION
## Summary

Companion to engine [ZBBS-WORK-348](https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/271) which drops the opaque `HuddleID` from the rendered `huddle:` line in salem-engine's perception. The parser was anchored on `huddle: <id> with <names>`; with the id gone the line is now just `huddle: with <names>`.

## Changes

- Regex `/^huddle:\s+\S+\s+with\s+(.+)$/m` → `/^huddle:\s+with\s+(.+)$/m`. The `\S+\s+` id-skip is unneeded now.
- Test fixtures updated to drop both the huddle id (`h1`) and the structure id bracket (`[tavern]`) from `inside:` lines — matches the post-WORK-348 engine output.
- **New regression guard**: pre-WORK-348 format `huddle: h1 with ...` MUST NOT match. Pins the contract — if the engine ever re-leaked the id, the parser would silently start dropping names from the Impressions list, and this test catches it.

## Tests

`node/api/scripts/test-extract-co-located-names.js` — 14 cases (was 13), all passing. Output: `PASS 14 / 14`.

## Coordination

Ship in the same deploy cycle as engine [ZBBS-WORK-348](https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/271). Salem v2 hasn't booted live yet (login-curtain bug is the gating blocker, home's plate), so brief mid-deploy mismatch is non-fatal — no live NPCs to drop Impressions on.

— Work