### PR TITLE
fix(virtual-agent): tighten extractCoLocatedNames regex to clear ReDoS warning [ZBBS-WORK-350]

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -953,7 +953,15 @@ function extractCoLocatedNames(perceptionText) {
     // and correctly short-circuit. Pre-WORK-348 the engine also rendered an
     // opaque huddle id (`huddle: h1 with ...`); that id has been dropped
     // because the LLM never used it.
-    const match = perceptionText.match(/^huddle:\s+with\s+(.+)$/m);
+    //
+    // Literal single-space anchor on purpose (ZBBS-WORK-350). The engine
+    // emits `huddle: with %s\n` — exactly one space between every token —
+    // so `\s+` was over-defensive and tripped CodeQL js/polynomial-redos
+    // (overlap between `\s+` and `(.+)`, both consuming whitespace, could
+    // pathologically backtrack on adversarial input). The character classes
+    // here are now disjoint: only `(.+)` is unbounded, no other repetition
+    // can overlap it.
+    const match = perceptionText.match(/^huddle: with (.+)$/m);
     if (!match) return [];
     return match[1]
         .split(',')


### PR DESCRIPTION
## Summary

Clears CodeQL alert #112 (`js/polynomial-redos`) on `extractCoLocatedNames`.

Previous: `/^huddle:\s+with\s+(.+)$/m` — overlapping unbounded whitespace classes (`\s+` twice + `(.+)` which also consumes whitespace) could pathologically backtrack on adversarial input. CodeQL flag was correct in principle even though real-world exposure is ~zero (input is salem-engine-generated, not user text).

New: `/^huddle: with (.+)$/m` — literal single-space anchor. The engine emits `fmt.Fprintf(b, \"huddle: with %s\n\", ...)` — exactly one space between every token, no variation — so `\s+` was over-defensive. Disjoint character classes now: only `(.+)` is unbounded, no other repetition can overlap it.

## Tests

Test fixtures unchanged (every fixture already uses single spaces matching the engine's emit format). All 14 cases still pass.

Added an inline comment at the regex site explaining the literal-space choice so a future defensive `\s+` reinstatement doesn't silently re-trip the warning.

## Coordination

Companion to [ZBBS-WORK-348](https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/271) + [ZBBS-WORK-349](https://github.com/jeffdafoe/llm-memory-api/pull/208). The engine-side literal-space contract that 348 established (`huddle: with %s`) is what makes this tightening safe.

— Work