### PR TITLE
MEM-133: lean sim-NPC history — ephemeral_context field + tool-call salience fix

### DIFF
--- a/node/api/scripts/test-build-tool-use-messages.js
+++ b/node/api/scripts/test-build-tool-use-messages.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Standalone test for buildToolUseMessages (virtual-agent.js) — focused on the
+// MEM-133 relative-time grounding: engine perceptions get a [age] prefix and a
+// "--- gap: Nh ---" marker after a long pause, mirroring the companion path the
+// sim tool-use branch had dropped. Also pins the role mapping + salience content.
+//
+// Run: node scripts/test-build-tool-use-messages.js   (exits 0 pass / 1 fail)
+
+const Module = require('module');
+const origRequire = Module.prototype.require;
+const stubExports = {};
+Module.prototype.require = function (id) {
+    if (id === '../db' || id === './db') return { query: async () => ({ rows: [] }) };
+    if (/\/(notes|chat|mail|api-spend|metering|conversations|llm-clients|system-handler)$/.test(id)) {
+        return new Proxy(stubExports, { get: function () { return function () { return Promise.resolve(null); }; } });
+    }
+    return origRequire.apply(this, arguments);
+};
+
+const { buildToolUseMessages } = require('../src/services/virtual-agent');
+
+let passed = 0, failed = 0;
+const failures = [];
+function check(label, cond) {
+    if (cond) { passed++; } else { failed++; failures.push('  FAIL [' + label + ']'); }
+}
+
+const NOW = Date.now();
+const agoISO = (mins) => new Date(NOW - mins * 60000).toISOString();
+const NPC = 'zbbs-john-ellis';
+
+// 3h-ago perception -> assistant pay_with_item -> [ok] -> 5m-ago perception
+// (the ~2.9h gap between the tool row and the 2nd perception trips the marker).
+const history = [
+    { from_agent: 'salem-engine', message: '# Your turn\n## You\nstarving', sent_at: agoISO(180) },
+    { from_agent: NPC, message: '', tool_calls: [{ id: 't1', name: 'pay_with_item', input: { item: 'Cheese', seller: 'Hannah', consume_now: true } }], sent_at: agoISO(179) },
+    { from_agent: 'salem-engine', message: '[ok]', tool_call_id: 't1', sent_at: agoISO(179) },
+    { from_agent: 'salem-engine', message: '# Your turn\n## You\nstill starving', sent_at: agoISO(5) },
+];
+const msgs = buildToolUseMessages(history, NPC);
+
+check('4 messages', msgs.length === 4);
+// 1st perception: [3h] prefix, no gap (first row).
+check('msg0 is user', msgs[0].role === 'user');
+check('msg0 prefixed with [3h]', msgs[0].content.startsWith('[3h]\n# Your turn'));
+check('msg0 has no gap marker (first row)', !msgs[0].content.includes('gap:'));
+// assistant: salience paraphrase, NO time prefix.
+check('msg1 is assistant', msgs[1].role === 'assistant');
+check('msg1 content is the offer paraphrase', msgs[1].content === '(I offered to buy Cheese from Hannah to eat now)');
+check('msg1 carries the tool_call', Array.isArray(msgs[1].tool_calls) && msgs[1].tool_calls[0].function.name === 'pay_with_item');
+check('msg1 NOT time-prefixed', !msgs[1].content.startsWith('['));
+// tool result: untouched.
+check('msg2 is tool', msgs[2].role === 'tool' && msgs[2].tool_call_id === 't1' && msgs[2].content === '[ok]');
+// 2nd perception: gap marker (~3h) + [5m].
+check('msg3 is user', msgs[3].role === 'user');
+check('msg3 has the gap marker', msgs[3].content.startsWith('--- gap: 3h ---\n[5m]\n# Your turn'));
+
+// A perception with no sent_at -> no prefix (graceful).
+const noTime = buildToolUseMessages([{ from_agent: 'salem-engine', message: '# Your turn\nno time' }], NPC);
+check('no sent_at -> raw content, no prefix', noTime[0].content === '# Your turn\nno time');
+
+if (failed > 0) {
+    console.log('FAILED ' + failed + ' / ' + (passed + failed));
+    failures.forEach(f => console.log(f));
+    process.exit(1);
+}
+console.log('PASS ' + passed + ' / ' + (passed + failed));
+process.exit(0);

--- a/node/api/scripts/test-paraphrase-tool-call.js
+++ b/node/api/scripts/test-paraphrase-tool-call.js
@@ -49,22 +49,24 @@ function assertEqual(label, got, want) {
 
 // ---------- pay_with_item (the repeat-buying case) ----------
 
+// pay_with_item places an offer ([ok] = offer placed, not completed sale), so
+// the paraphrase reflects the attempt — "offered to buy", not "bought".
 assertEqual(
-    'pay_with_item consume_now=true (bool) → bought + consumed',
+    'pay_with_item consume_now=true (bool) → offer + eat-now',
     paraphraseToolCall('pay_with_item', { qty: 1, item: 'Cheese', amount: 4, seller: 'John Ellis', consume_now: true }),
-    '(I bought Cheese from John Ellis and consumed it)'
+    '(I offered to buy Cheese from John Ellis to eat now)'
 );
 
 assertEqual(
-    'pay_with_item consume_now="true" (Llama-stringified bool) → bought + consumed',
+    'pay_with_item consume_now="true" (Llama-stringified bool) → offer + eat-now',
     paraphraseToolCall('pay_with_item', { item: 'Bread', seller: 'John Ellis', consume_now: 'true' }),
-    '(I bought Bread from John Ellis and consumed it)'
+    '(I offered to buy Bread from John Ellis to eat now)'
 );
 
 assertEqual(
-    'pay_with_item consume_now absent → bought only',
+    'pay_with_item consume_now absent → plain offer',
     paraphraseToolCall('pay_with_item', { item: 'Water', seller: 'Hannah Boggs' }),
-    '(I bought Water from Hannah Boggs)'
+    '(I offered to buy Water from Hannah Boggs)'
 );
 
 assertEqual(

--- a/node/api/scripts/test-paraphrase-tool-call.js
+++ b/node/api/scripts/test-paraphrase-tool-call.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Standalone unit test for paraphraseToolCall (virtual-agent.js).
+//
+// paraphraseToolCall renders a prior assistant tool_call as a first-person line
+// for the replayed assistant `content`, so the NPC's own actions are salient as
+// language in history (the Llama-3.3 salience problem: it can't carry narration
+// alongside a tool call, so content is emitted empty). The bug this fixes: the
+// prior version checked move_to.destination — a field the engine never sends
+// (it sends structure_name / structure_id) — and didn't handle pay_with_item /
+// consume / take_break / stop at all, so those replayed as blank content and the
+// NPC repeated itself (re-buying food turn after turn).
+//
+// Field shapes pinned here are the ACTUAL live engine tool args (verified from
+// virtual_agent_calls on the running village).
+//
+// Run: node scripts/test-paraphrase-tool-call.js
+// Exits 0 on pass, 1 on any failure.
+
+const Module = require('module');
+const origRequire = Module.prototype.require;
+
+// Stub heavy deps so requiring virtual-agent.js doesn't open a DB pool. The
+// function under test is pure; we only need the exported reference.
+const stubExports = {};
+Module.prototype.require = function (id) {
+    if (id === '../db' || id === './db') return { query: async () => ({ rows: [] }) };
+    if (/\/(notes|chat|mail|api-spend|metering|conversations|llm-clients|system-handler)$/.test(id)) {
+        return new Proxy(stubExports, {
+            get: function () { return function () { return Promise.resolve(null); }; }
+        });
+    }
+    return origRequire.apply(this, arguments);
+};
+
+const { paraphraseToolCall } = require('../src/services/virtual-agent');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assertEqual(label, got, want) {
+    if (got === want) {
+        passed++;
+    } else {
+        failed++;
+        failures.push('  FAIL [' + label + ']: got ' + JSON.stringify(got) + ', want ' + JSON.stringify(want));
+    }
+}
+
+// ---------- pay_with_item (the repeat-buying case) ----------
+
+assertEqual(
+    'pay_with_item consume_now=true (bool) → bought + consumed',
+    paraphraseToolCall('pay_with_item', { qty: 1, item: 'Cheese', amount: 4, seller: 'John Ellis', consume_now: true }),
+    '(I bought Cheese from John Ellis and consumed it)'
+);
+
+assertEqual(
+    'pay_with_item consume_now="true" (Llama-stringified bool) → bought + consumed',
+    paraphraseToolCall('pay_with_item', { item: 'Bread', seller: 'John Ellis', consume_now: 'true' }),
+    '(I bought Bread from John Ellis and consumed it)'
+);
+
+assertEqual(
+    'pay_with_item consume_now absent → bought only',
+    paraphraseToolCall('pay_with_item', { item: 'Water', seller: 'Hannah Boggs' }),
+    '(I bought Water from Hannah Boggs)'
+);
+
+assertEqual(
+    'pay_with_item missing item → no paraphrase',
+    paraphraseToolCall('pay_with_item', { seller: 'John Ellis', consume_now: true }),
+    ''
+);
+
+// ---------- move_to (the field-name bug) ----------
+
+assertEqual(
+    'move_to structure_name → named',
+    paraphraseToolCall('move_to', { structure_name: 'Tavern' }),
+    '(I set off toward Tavern)'
+);
+
+assertEqual(
+    'move_to structure_id (opaque UUID) → generic en-route line',
+    paraphraseToolCall('move_to', { structure_id: '019dbcd2-c0b1-7bf9-98c2-0610cfb7f5e9' }),
+    '(I set off walking to a place I could see)'
+);
+
+assertEqual(
+    'move_to with the OLD (wrong) destination field → no paraphrase (regression guard)',
+    paraphraseToolCall('move_to', { destination: 'Tavern' }),
+    ''
+);
+
+// ---------- consume / take_break / stop / speak ----------
+
+assertEqual('consume → consumed', paraphraseToolCall('consume', { qty: 1, item: 'Stew' }), '(I consumed Stew)');
+
+assertEqual(
+    'take_break with reason',
+    paraphraseToolCall('take_break', { reason: 'I am exhausted' }),
+    '(I stopped to take a break: I am exhausted)'
+);
+
+assertEqual('take_break no reason', paraphraseToolCall('take_break', {}), '(I stopped to take a break)');
+
+assertEqual('stop (no args)', paraphraseToolCall('stop', {}), '(I stopped where I was)');
+
+assertEqual(
+    'speak quotes the text (escaped)',
+    paraphraseToolCall('speak', { text: 'Good morrow, "friend".' }),
+    '(I said aloud: "Good morrow, \\"friend\\".")'
+);
+
+// ---------- no-payload / unknown tools → '' ----------
+
+assertEqual('done → empty', paraphraseToolCall('done', {}), '');
+assertEqual('unknown tool → empty', paraphraseToolCall('scene_quote', { item_kind: 'Cheese' }), '');
+assertEqual('null input → empty', paraphraseToolCall('stop', null), '(I stopped where I was)');
+assertEqual('speak with empty text → empty', paraphraseToolCall('speak', { text: '' }), '');
+
+// ---------- Report ----------
+
+if (failed > 0) {
+    console.log('FAILED ' + failed + ' / ' + (passed + failed));
+    failures.forEach(function (f) { console.log(f); });
+    process.exit(1);
+}
+console.log('PASS ' + passed + ' / ' + (passed + failed));
+process.exit(0);

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -50,6 +50,22 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     const toolsOffered = req.body.tools_offered;
     const toolCallResults = req.body.tool_call_results;
     const persistOnly = req.body.persist_only === true;
+
+    // ephemeral_context (lean sim-history): optional per-tick scratch context —
+    // current affordances / world-state the engine wants the model to see on
+    // THIS call only. handleDirectChat attaches it to the current turn; it is
+    // never written to chat_message_texts, so it can't accumulate across the
+    // replayed conversation. Absent = unchanged behavior. Length-capped as a
+    // guard against an absurd payload (the engine's furniture block is a few KB).
+    const ephemeralContext = req.body.ephemeral_context;
+    if (ephemeralContext !== undefined && ephemeralContext !== null) {
+        if (typeof ephemeralContext !== 'string') {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'ephemeral_context must be a string' } });
+        }
+        if (ephemeralContext.length > 65536) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'ephemeral_context exceeds 65536 chars' } });
+        }
+    }
     if (toolCalls !== undefined && toolCalls !== null && !Array.isArray(toolCalls)) {
         return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'tool_calls must be an array' } });
     }
@@ -130,7 +146,7 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     }
 
     const result = await chatSend(from_agent, to_agents, discussionId, message, {
-        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, wait,
+        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, wait, ephemeralContext,
     });
 
     // wait=true: hold the connection open until the VA reply lands inline.

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -59,6 +59,17 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     // guard against an absurd payload (the engine's furniture block is a few KB).
     const ephemeralContext = req.body.ephemeral_context;
     if (ephemeralContext !== undefined && ephemeralContext !== null) {
+        // SECURITY: ephemeral_context is forwarded to the model but NEVER
+        // persisted to chat_message_texts — an unaudited prompt channel. It MUST
+        // be gated to the Salem sim engine (the only legitimate sim-tick caller).
+        // Otherwise any /chat/send caller could smuggle hidden instructions to a
+        // VA behind a benign `message`, invisible to history/audit surfaces.
+        // from_agent is the authenticated principal here (forced to
+        // req.authenticatedAgent above for non-admin sessions), so a normal agent
+        // can't spoof 'salem-engine'. Matches handleDirectChat's isSimChat gate.
+        if (from_agent !== 'salem-engine') {
+            return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'ephemeral_context is only supported for sim engine chat' } });
+        }
         if (typeof ephemeralContext !== 'string') {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'ephemeral_context must be a string' } });
         }

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -83,6 +83,11 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // engine messages that originated from a structure-less cascade
     // (chronicler dispatch, admin trigger, noticeboard generation).
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
+    // ephemeralContext (lean sim-history): per-tick scratch context (current
+    // affordances / world-state) forwarded to handleDirectChat to attach to
+    // the model's current turn. NOT persisted — it never enters rowSpecs, so
+    // only `message` (the durable narrative) hits chat_message_texts.
+    const ephemeralContext = opts && opts.ephemeralContext !== undefined ? opts.ephemeralContext : null;
     // is_error flag (MEM-122): set on retry/error breadcrumb rows so
     // history readers (loadDirectChatHistory, loadChatHistory) filter
     // them out of next-call context. Without this, virtual agents read
@@ -396,7 +401,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     if (dispatches.length === 1) {
                         const d = dispatches[0];
                         pendingReplyPromise = handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                            toolsOffered, isToolResultCall, sceneId, sceneStructure, ackReplyOnInsert: wait,
+                            toolsOffered, isToolResultCall, sceneId, sceneStructure, ackReplyOnInsert: wait, ephemeralContext,
                         });
                         // Swallow rejection for non-wait callers so unhandled-promise
                         // warnings don't appear; wait-mode awaiters get the error.
@@ -407,7 +412,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                         // stays false here.
                         for (const d of dispatches) {
                             handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                                toolsOffered, isToolResultCall, sceneId, sceneStructure,
+                                toolsOffered, isToolResultCall, sceneId, sceneStructure, ephemeralContext,
                             }).catch(() => {});
                         }
                     }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2153,6 +2153,15 @@ function paraphraseToolCall(name, input) {
 function buildToolUseMessages(history, npcAgentName) {
     const messages = [];
     const npcLower = npcAgentName.toLowerCase();
+    // Relative-time grounding for the replayed sim history: prefix each engine
+    // perception with its age ([3h], [now], ...) and mark big inter-tick gaps,
+    // so the model knows WHEN each turn happened — a busy scene vs. one spread
+    // over hours read very differently, and the tool-use path otherwise carries
+    // no time at all. Mirrors the companion buildDirectChatUserMessage path
+    // (which the sim path had dropped). Replay-time annotation computed from
+    // sent_at — NEVER persisted.
+    const GAP_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2h, matching buildDirectChatUserMessage
+    let prevSentAt = null;
     for (const row of history) {
         const fromLower = (row.from_agent || '').toLowerCase();
         if (fromLower === npcLower) {
@@ -2220,7 +2229,26 @@ function buildToolUseMessages(history, npcAgentName) {
                 content: row.message || '',
             });
         } else {
-            messages.push({ role: 'user', content: row.message || '' });
+            // Engine perception (user turn). Prefix with a relative-time marker
+            // and, when there's a long pause since the previous row, a gap line.
+            // Only the perception turns are stamped — the assistant/tool rows of
+            // a tick are the same moment as their perception.
+            let content = row.message || '';
+            if (row.sent_at) {
+                const prefix = [];
+                if (prevSentAt) {
+                    const gap = new Date(row.sent_at).getTime() - new Date(prevSentAt).getTime();
+                    if (gap >= GAP_THRESHOLD_MS) {
+                        prefix.push('--- gap: ' + Math.round(gap / (60 * 60 * 1000)) + 'h ---');
+                    }
+                }
+                prefix.push(formatRelativeTime(row.sent_at));
+                content = prefix.join('\n') + '\n' + content;
+            }
+            messages.push({ role: 'user', content });
+        }
+        if (row.sent_at) {
+            prevSentAt = row.sent_at;
         }
     }
     return messages;
@@ -2838,4 +2866,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages };

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2396,7 +2396,16 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             // future engine rev that surfaces multiple roles for the same
             // person). Without this, loadPeopleContext would emit duplicate
             // "## Your impressions of X" sections.
-            let coLocated = [...new Set(extractCoLocatedNames(messageText))];
+            // Co-located peers live in the "## Around you / huddle:" block.
+            // The engine renders that block into ephemeral_context post-split
+            // (lean sim-history, ZBBS-WORK-364) but into the message pre-split,
+            // so parse both — the durable message no longer carries surroundings
+            // once the engine half lands. ephemeralContext is null for non-sim
+            // callers and pre-split ticks, so this is a no-op there.
+            const coLocatedSource = ephemeralContext
+                ? messageText + '\n' + ephemeralContext
+                : messageText;
+            let coLocated = [...new Set(extractCoLocatedNames(coLocatedSource))];
             if (isToolResultCall) {
                 // Tool-result follow-up — messageText is "[OK] You spoke..."
                 // or similar, never a fresh perception. Fall back to whatever

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2107,9 +2107,16 @@ function paraphraseToolCall(name, input) {
         case 'pay_with_item': {
             if (typeof inp.item !== 'string' || !inp.item) return '';
             const seller = (typeof inp.seller === 'string' && inp.seller) ? ' from ' + inp.seller : '';
-            // Llama stringifies bools, so consume_now may be true or 'true'.
-            const consumed = (inp.consume_now === true || inp.consume_now === 'true') ? ' and consumed it' : '';
-            return '(I bought ' + inp.item + seller + consumed + ')';
+            // pay_with_item places an OFFER the seller must accept — the [ok]
+            // tool result means "offer placed", NOT "purchase completed" (the
+            // offer can later "fall through" if the seller never fulfils it).
+            // Paraphrase the attempt, not a success the history may contradict:
+            // "I bought and consumed cheese" while the NPC stays starving (and a
+            // later perception says the offer fell through) is exactly the
+            // incoherent self-history that degrades the model. Llama stringifies
+            // bools, so consume_now may be true or 'true'.
+            const eatNow = (inp.consume_now === true || inp.consume_now === 'true') ? ' to eat now' : '';
+            return '(I offered to buy ' + inp.item + seller + eatNow + ')';
         }
         case 'consume':
             if (typeof inp.item === 'string' && inp.item) {

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2079,6 +2079,70 @@ function pruneSimHistory(history) {
 // function-tool wrapper here: {id, type: 'function', function: {name,
 // arguments: <JSON string>}}. Anthropic's provider does its own translation
 // upstream, so it's safe to send the same OpenAI shape through invokeAgent.
+// paraphraseToolCall renders a prior assistant tool_call as a brief first-person
+// line for the assistant message `content`, so the action is salient as LANGUAGE
+// when replayed in history rather than buried in tool_calls.arguments JSON. The
+// model (Llama-3.3) can't carry narration alongside a tool call — it emits empty
+// content + a tool_call — so the language-modeling pass treats a replayed action
+// weakly ("a thing in my args") rather than "a thing I did / said". Without this,
+// the NPC has no legible record of its own recent moves and repeats itself (e.g.
+// re-buying the same food turn after turn). Returns '' for tools with no payload
+// worth surfacing (done — no content; look_around — the tool RESULT carries it).
+//
+// Field names mirror the engine's tool arg schemas, verified against live salem
+// tool calls: pay_with_item {item, seller, consume_now}, consume {item},
+// move_to {structure_name | structure_id}, take_break {reason}, speak {text}.
+// (The prior version checked move_to.destination — a field the engine never
+// sends — so move/pay/break all replayed as blank content.)
+function paraphraseToolCall(name, input) {
+    const inp = input || {};
+    switch (name) {
+        case 'speak':
+            // JSON.stringify so embedded quotes / newlines / backslashes in the
+            // spoken text don't mangle the line or terminate the quoted span.
+            if (typeof inp.text === 'string' && inp.text) {
+                return '(I said aloud: ' + JSON.stringify(inp.text) + ')';
+            }
+            return '';
+        case 'pay_with_item': {
+            if (typeof inp.item !== 'string' || !inp.item) return '';
+            const seller = (typeof inp.seller === 'string' && inp.seller) ? ' from ' + inp.seller : '';
+            // Llama stringifies bools, so consume_now may be true or 'true'.
+            const consumed = (inp.consume_now === true || inp.consume_now === 'true') ? ' and consumed it' : '';
+            return '(I bought ' + inp.item + seller + consumed + ')';
+        }
+        case 'consume':
+            if (typeof inp.item === 'string' && inp.item) {
+                return '(I consumed ' + inp.item + ')';
+            }
+            return '';
+        case 'move_to':
+            // structure_id is an opaque UUID — no human-readable name to render,
+            // so surface only that the actor set off (still a useful "I'm en
+            // route" signal). structure_name carries the place name.
+            if (typeof inp.structure_name === 'string' && inp.structure_name) {
+                return '(I set off toward ' + inp.structure_name + ')';
+            }
+            if (typeof inp.structure_id === 'string' && inp.structure_id) {
+                return '(I set off walking to a place I could see)';
+            }
+            return '';
+        case 'take_break': {
+            const reason = (typeof inp.reason === 'string' && inp.reason) ? ': ' + inp.reason : '';
+            return '(I stopped to take a break' + reason + ')';
+        }
+        case 'stop':
+            return '(I stopped where I was)';
+        case 'chore':
+            if (typeof inp.type === 'string' && inp.type) {
+                return '(I ran a chore: ' + inp.type + ')';
+            }
+            return '';
+        default:
+            return '';
+    }
+}
+
 function buildToolUseMessages(history, npcAgentName) {
     const messages = [];
     const npcLower = npcAgentName.toLowerCase();
@@ -2131,18 +2195,9 @@ function buildToolUseMessages(history, npcAgentName) {
                         const input = (typeof tc.input === 'string')
                             ? safeParseJSON(tc.input)
                             : (tc.input || {});
-                        if (tc.name === 'speak' && input && typeof input.text === 'string' && input.text) {
-                            // JSON.stringify so embedded quotes / newlines /
-                            // backslashes in the spoken text don't mangle
-                            // the paraphrase or terminate the quoted span.
-                            lines.push('(I said aloud: ' + JSON.stringify(input.text) + ')');
-                        } else if (tc.name === 'move_to' && input && typeof input.destination === 'string' && input.destination) {
-                            // typeof guard so we don't render `[object Object]`
-                            // if a future engine rev passes a structured
-                            // destination ({type, id}) instead of a string.
-                            lines.push('(I walked to ' + input.destination + ')');
-                        } else if (tc.name === 'chore' && input && typeof input.type === 'string' && input.type) {
-                            lines.push('(I ran a chore: ' + input.type + ')');
+                        const paraphrase = paraphraseToolCall(tc.name, input);
+                        if (paraphrase) {
+                            lines.push(paraphrase);
                         }
                     }
                     if (lines.length > 0) {
@@ -2223,6 +2278,12 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     // lands with NULL scene_structure and the admin chat UI's scene
     // grouping renders the label inconsistently within a scene.
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
+    // ephemeralContext (lean sim-history): per-tick scratch context (current
+    // affordances / world-state) attached to the model's CURRENT turn below.
+    // Never persisted — it only shapes this one provider call, so it can't
+    // accumulate across the replayed conversation. Empty/absent → no-op.
+    const ephemeralContext = (opts && typeof opts.ephemeralContext === 'string' && opts.ephemeralContext.length > 0)
+        ? opts.ephemeralContext : null;
     const isToolUse = Array.isArray(toolsOffered) && toolsOffered.length > 0;
     // isToolResultCall=true means this chat/send is the model's response
     // to a tool result the engine just sent back (e.g. "[OK] You spoke.").
@@ -2409,6 +2470,24 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
                     role: 'user',
                     content: messageText || 'Continue.'
                 }];
+            }
+
+            // Attach ephemeral_context (lean sim-history) to the CURRENT turn,
+            // AFTER history assembly so it never becomes part of the persisted /
+            // replayed conversation — it carries the per-tick affordances /
+            // world-state the model needs to decide NOW. Append to the last user
+            // message when the latest turn is a fresh perception; for a
+            // tool-result follow-up (latest messages are tool results) push it as
+            // a trailing user turn so the model still sees its current options.
+            if (ephemeralContext) {
+                const lastMsg = toolUseMessages[toolUseMessages.length - 1];
+                if (lastMsg && lastMsg.role === 'user') {
+                    lastMsg.content = lastMsg.content
+                        ? lastMsg.content + '\n\n' + ephemeralContext
+                        : ephemeralContext;
+                } else {
+                    toolUseMessages.push({ role: 'user', content: ephemeralContext });
+                }
             }
         }
         const userMessage = isToolUse ? '' : buildDirectChatUserMessage(history, fromAgent, messageText);
@@ -2743,4 +2822,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall };


### PR DESCRIPTION
## Problem

Salem sim-NPC ticks drive the NPC as an ongoing **chat** (the conversation IS the NPC's working memory). The engine sends one perception/tick and forgets; the api reconstructs the conversation each call (`handleDirectChat` → `loadDirectChatHistory` → `buildToolUseMessages`) and replays it. Because the engine re-renders the **full** perception every tick, the static affordance furniture (rest/food lists, structure_ids, roster) accumulates — observed live as **~11 near-identical full perceptions / ~14k input tokens** in a single Ezekiel Crane tick. `pruneSimHistory` only collapses *consecutive* perception rows, so an NPC that acts every tick prunes nothing.

This is the **memory-api half**. The companion engine perception split is ZBBS-WORK-364 in the salem repo. Full design: `shared/tasks/pending/salem-lean-sim-history/design`.

## Changes

### 1. `ephemeral_context` field on `/v1/chat/send`
The engine will split perception into a **durable** `message` (persisted + replayed — needs-tag + `What just happened` events) and the **ephemeral** furniture. `ephemeral_context` is attached to the model's **current turn only** and **never persisted** — it stays a separate field and never enters `rowSpecs`, so only `message` hits `chat_message_texts`. The furniture therefore can't accumulate across the replayed conversation.

- `routes/chat.js` — parse + validate (string, ≤64KB), forward.
- `services/chat.js` — destructure from opts, forward to both `handleDirectChat` call sites.
- `services/virtual-agent.js` — `handleDirectChat` attaches it after history assembly: appended to the last user message (fresh perception) or pushed as a trailing user turn (tool-result follow-up).

**Backward-compatible:** absent field = today's behavior. The general chat store stays format-agnostic — no perception parsing — so human↔VA chat / discussions are byte-for-byte unchanged (they simply don't set the field). This is the key constraint: the raw verbatim-chat capability must be preserved.

### 2. Tool-call salience fix (`buildToolUseMessages`)
Llama-3.3 can't carry narration alongside a tool call (emits empty `content` + `tool_call`), so prior actions are mirrored into the assistant `content` on replay for salience. But the `move_to` branch checked `input.destination` — a field the engine **never sends** (it sends `structure_name`/`structure_id`) — and `pay_with_item`/`consume`/`take_break`/`stop` were unhandled. So **every** assistant turn replayed as blank `content`, leaving the NPC with no legible record of its own moves → it repeats itself (re-buying food turn after turn). New `paraphraseToolCall` helper uses the **actual** engine arg-fields (verified against live `virtual_agent_calls`).

This part improves current behavior immediately — it doesn't depend on the engine change.

## Tests
- `scripts/test-paraphrase-tool-call.js` — 16 cases incl. a regression guard that the old `destination` field now yields nothing. **PASS 16/16.**
- `node --check` clean on all three edited files.

## Notes for review
- Engine half (perception split + sending `ephemeral_context`) lands separately; until then this is inert except for the salience fix.
- Heads-up already mailed to home re: editing `virtual-agent.js`/`chat.js`.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)