### PR TITLE
MEM-133 / ZBBS-HOME-397: conversation_id grouping for the admin chat viewer

### DIFF
--- a/migrations/MEM-133-conversation-id_down.sql
+++ b/migrations/MEM-133-conversation-id_down.sql
@@ -1,0 +1,4 @@
+-- MEM-133 down: drop conversation_id columns (indexes drop with the columns).
+
+ALTER TABLE chat_message_texts DROP COLUMN conversation_id;
+ALTER TABLE virtual_agent_calls DROP COLUMN conversation_id;

--- a/migrations/MEM-133-conversation-id_up.sql
+++ b/migrations/MEM-133-conversation-id_up.sql
@@ -6,7 +6,7 @@
 -- narrative-beat scene (sim.Scene.ID) instead — STABLE across the ticks AND the
 -- participants of one conversation beat — so the viewer can collapse the whole
 -- exchange back into one conversation (with the per-tick scene_id as the inner
--- sub-group). Threaded from salem via the /v1/chat/send body (ZBBS-HOME-396).
+-- sub-group). Threaded from salem via the /v1/chat/send body (ZBBS-HOME-397).
 --
 -- TEXT, not uuid (unlike scene_id): sim.SceneID is "sc-"+hex, not a UUID.
 -- Nullable — NULL for companion-mode, human chat, and solo (no-huddle) sim ticks,

--- a/migrations/MEM-133-conversation-id_up.sql
+++ b/migrations/MEM-133-conversation-id_up.sql
@@ -1,0 +1,22 @@
+-- MEM-133: conversation_id column on chat_message_texts + virtual_agent_calls.
+--
+-- The admin comms chat viewer groups chat rows by scene_id, but the salem engine
+-- mints a fresh scene_id PER TICK (llm.NewSceneID), so one conversation shatters
+-- into one collapsible group per tick. conversation_id carries the engine's
+-- narrative-beat scene (sim.Scene.ID) instead — STABLE across the ticks AND the
+-- participants of one conversation beat — so the viewer can collapse the whole
+-- exchange back into one conversation (with the per-tick scene_id as the inner
+-- sub-group). Threaded from salem via the /v1/chat/send body (ZBBS-HOME-396).
+--
+-- TEXT, not uuid (unlike scene_id): sim.SceneID is "sc-"+hex, not a UUID.
+-- Nullable — NULL for companion-mode, human chat, and solo (no-huddle) sim ticks,
+-- which then render ungrouped exactly like a NULL scene_id does today.
+--
+-- Mirrors idx_cmt_scene / idx_va_calls_scene: a partial btree index over the
+-- non-null rows for the viewer's group-by and the call-log correlation.
+
+ALTER TABLE chat_message_texts ADD COLUMN conversation_id TEXT;
+CREATE INDEX idx_cmt_conversation ON chat_message_texts (conversation_id) WHERE conversation_id IS NOT NULL;
+
+ALTER TABLE virtual_agent_calls ADD COLUMN conversation_id TEXT;
+CREATE INDEX idx_va_calls_conversation ON virtual_agent_calls (conversation_id) WHERE conversation_id IS NOT NULL;

--- a/node/api/public/admin/chat.js
+++ b/node/api/public/admin/chat.js
@@ -14,7 +14,7 @@ function useChat({ api, showToast, dashboard }) {
     // Companion-mode and any pre-MEM-121 row has neither and renders as a single
     // standalone row exactly as before. Sim-mode rows sharing a conversation
     // collapse into one expandable group — so a whole exchange is one row
-    // (MEM-133 / ZBBS-HOME-396) instead of one group per per-tick scene_id.
+    // (MEM-133 / ZBBS-HOME-397) instead of one group per per-tick scene_id.
     //
     // Ordering: a group occupies the slot of its most recent message,
     // so a fresh tavern conversation lands at the top. Inside the group
@@ -49,7 +49,7 @@ function useChat({ api, showToast, dashboard }) {
         const sceneIndex = new Map(); // group key -> group ref
         const groups = [];
         for (const msg of chatMessages.value) {
-            // Group by conversation_id (MEM-133 / ZBBS-HOME-396) — the engine's
+            // Group by conversation_id (MEM-133 / ZBBS-HOME-397) — the engine's
             // narrative-beat scene, STABLE across the ticks AND participants of
             // one conversation beat — so a whole Josiah↔Moses exchange collapses
             // into ONE group instead of one group per per-tick scene_id. Fall

--- a/node/api/public/admin/chat.js
+++ b/node/api/public/admin/chat.js
@@ -9,12 +9,14 @@ function useChat({ api, showToast, dashboard }) {
     // rows whenever Salem is busy.
     const expandedScenes = ref(new Set());
 
-    // Group chat rows by scene_id for the admin chat list. Companion-mode
-    // and any pre-MEM-121 row has a NULL scene_id and renders as a single
-    // standalone row exactly as before. Sim-mode rows that share a
-    // scene_id collapse into one expandable scene row.
+    // Group chat rows by conversation_id (the engine's narrative-beat scene)
+    // for the admin chat list, falling back to scene_id for rows without one.
+    // Companion-mode and any pre-MEM-121 row has neither and renders as a single
+    // standalone row exactly as before. Sim-mode rows sharing a conversation
+    // collapse into one expandable group — so a whole exchange is one row
+    // (MEM-133 / ZBBS-HOME-396) instead of one group per per-tick scene_id.
     //
-    // Ordering: a scene group occupies the slot of its most recent message,
+    // Ordering: a group occupies the slot of its most recent message,
     // so a fresh tavern conversation lands at the top. Inside the group
     // messages are sub-grouped by participant thread (chronicler ↔ engine,
     // each villager ↔ engine), with each thread rendered chronologically.
@@ -44,14 +46,23 @@ function useChat({ api, showToast, dashboard }) {
         return pair || '(unknown)';
     }
     const chatGroups = computed(() => {
-        const sceneIndex = new Map(); // scene_id -> group ref
+        const sceneIndex = new Map(); // group key -> group ref
         const groups = [];
         for (const msg of chatMessages.value) {
-            if (msg.scene_id) {
-                let group = sceneIndex.get(msg.scene_id);
+            // Group by conversation_id (MEM-133 / ZBBS-HOME-396) — the engine's
+            // narrative-beat scene, STABLE across the ticks AND participants of
+            // one conversation beat — so a whole Josiah↔Moses exchange collapses
+            // into ONE group instead of one group per per-tick scene_id. Fall
+            // back to scene_id for rows without a conversation_id (companion-mode,
+            // pre-MEM-133 history, solo no-huddle ticks) so their behavior is
+            // unchanged. The group's `scene_id` field carries the grouping key,
+            // so the collapse/expand wiring keyed on it keeps working.
+            const groupKey = msg.conversation_id || msg.scene_id;
+            if (groupKey) {
+                let group = sceneIndex.get(groupKey);
                 if (!group) {
-                    group = { type: 'scene', scene_id: msg.scene_id, messages: [] };
-                    sceneIndex.set(msg.scene_id, group);
+                    group = { type: 'scene', scene_id: groupKey, conversation_id: msg.conversation_id || null, messages: [] };
+                    sceneIndex.set(groupKey, group);
                     groups.push(group);
                 }
                 group.messages.push(msg);

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -745,7 +745,7 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
     // For discussion channels, query distinct messages from chat_message_texts
     // to avoid showing duplicate delivery rows
     if (discussionId) {
-        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id, cmt.scene_id${sceneSelect}
+        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id, cmt.scene_id, cmt.conversation_id${sceneSelect}
                    FROM chat_message_texts cmt
                    JOIN actors fa ON fa.id = cmt.from_actor_id`;
         const conditions = ['cmt.discussion_id = $1'];
@@ -762,7 +762,7 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
         res.json({ messages: result.rows });
     } else {
         // Non-discussion: query delivery rows as before
-        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at, cmt.scene_id${sceneSelect}
+        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at, cmt.scene_id, cmt.conversation_id${sceneSelect}
                    FROM chat_messages cm
                    JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
                    JOIN actors fa ON fa.id = cmt.from_actor_id

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -150,6 +150,22 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         }
     }
 
+    // conversation_id (MEM-133 / ZBBS-HOME-396) — the engine's narrative-beat
+    // scene id (sim.Scene.ID, "sc-"+hex), STABLE across the ticks AND the
+    // participants of one conversation beat. Threaded so the admin chat viewer
+    // groups a whole exchange under one conversation instead of one group per
+    // per-tick scene_id. Unlike scene_id this is NOT a UUID (TEXT column).
+    // NULL for companion-mode, human chat, and solo (no-huddle) sim ticks.
+    let conversationId = req.body.conversation_id;
+    if (conversationId !== undefined && conversationId !== null) {
+        if (typeof conversationId !== 'string' || conversationId.length > 64) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'conversation_id must be a string up to 64 chars' } });
+        }
+        if (conversationId.trim() === '') {
+            conversationId = null;
+        }
+    }
+
     const wait = req.body.wait === true;
 
     if (persistOnly && wait) {
@@ -157,7 +173,7 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     }
 
     const result = await chatSend(from_agent, to_agents, discussionId, message, {
-        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, wait, ephemeralContext,
+        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, conversationId, wait, ephemeralContext,
     });
 
     // wait=true: hold the connection open until the VA reply lands inline.

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -150,7 +150,7 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         }
     }
 
-    // conversation_id (MEM-133 / ZBBS-HOME-396) — the engine's narrative-beat
+    // conversation_id (MEM-133 / ZBBS-HOME-397) — the engine's narrative-beat
     // scene id (sim.Scene.ID, "sc-"+hex), STABLE across the ticks AND the
     // participants of one conversation beat. Threaded so the admin chat viewer
     // groups a whole exchange under one conversation instead of one group per

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -161,7 +161,11 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         if (typeof conversationId !== 'string' || conversationId.length > 64) {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'conversation_id must be a string up to 64 chars' } });
         }
-        if (conversationId.trim() === '') {
+        // Trim before storing so " sc-abc " can't split grouping from "sc-abc"
+        // (the engine sends a clean omitempty id, but be defensive about other
+        // clients). Whitespace-only normalizes to NULL, like scene_structure.
+        conversationId = conversationId.trim();
+        if (conversationId === '') {
             conversationId = null;
         }
     }

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -83,7 +83,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // engine messages that originated from a structure-less cascade
     // (chronicler dispatch, admin trigger, noticeboard generation).
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
-    // conversationId (MEM-133 / ZBBS-HOME-396): the engine's narrative-beat scene
+    // conversationId (MEM-133 / ZBBS-HOME-397): the engine's narrative-beat scene
     // id — the STABLE grouping key (across the ticks AND participants of one
     // conversation beat) the admin chat viewer collapses a whole exchange under,
     // distinct from the per-tick sceneId. NULL outside grouped sim ticks.

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -83,6 +83,11 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // engine messages that originated from a structure-less cascade
     // (chronicler dispatch, admin trigger, noticeboard generation).
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
+    // conversationId (MEM-133 / ZBBS-HOME-396): the engine's narrative-beat scene
+    // id — the STABLE grouping key (across the ticks AND participants of one
+    // conversation beat) the admin chat viewer collapses a whole exchange under,
+    // distinct from the per-tick sceneId. NULL outside grouped sim ticks.
+    const conversationId = opts && opts.conversationId !== undefined ? opts.conversationId : null;
     // ephemeralContext (lean sim-history): per-tick scratch context (current
     // affordances / world-state) forwarded to handleDirectChat to attach to
     // the model's current turn. NOT persisted — it never enters rowSpecs, so
@@ -209,7 +214,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
         for (const [idx, spec] of rowSpecs.entries()) {
             const textResult = await client.query(
                 `INSERT INTO chat_message_texts
-                    (message, from_actor_id, discussion_id, sent_at, tool_calls, tool_call_id, tools_offered, scene_id, scene_structure, is_error)
+                    (message, from_actor_id, discussion_id, sent_at, tool_calls, tool_call_id, tools_offered, scene_id, scene_structure, is_error, conversation_id)
                  VALUES (
                     $1, $2, $3, NOW(), $4, $5, $6, $7,
                     COALESCE($8, CASE
@@ -220,7 +225,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                              ORDER BY id ASC LIMIT 1
                         )
                     END),
-                    $9
+                    $9, $10
                  )
                  RETURNING id, sent_at`,
                 [
@@ -241,6 +246,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     sceneId,
                     sceneStructure,
                     isError,
+                    conversationId,
                 ]
             );
             insertedTexts.push({
@@ -321,6 +327,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                 message: t.message,
                 discussion_id: discussionId || null,
                 scene_id: sceneId,
+                conversation_id: conversationId,
                 sent_at: t.sent_at
             });
         }
@@ -401,7 +408,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     if (dispatches.length === 1) {
                         const d = dispatches[0];
                         pendingReplyPromise = handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                            toolsOffered, isToolResultCall, sceneId, sceneStructure, ackReplyOnInsert: wait, ephemeralContext,
+                            toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, ackReplyOnInsert: wait, ephemeralContext,
                         });
                         // Swallow rejection for non-wait callers so unhandled-promise
                         // warnings don't appear; wait-mode awaiters get the error.
@@ -412,7 +419,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                         // stays false here.
                         for (const d of dispatches) {
                             handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                                toolsOffered, isToolResultCall, sceneId, sceneStructure, ephemeralContext,
+                                toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, ephemeralContext,
                             }).catch(() => {});
                         }
                     }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -739,8 +739,8 @@ async function logCall(options) {
              (actor_id, context, context_id, provider, model, system_prompt, user_message,
               response, status, status_code, error_message,
               input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-              cost, duration_ms, usage_id, scene_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+              cost, duration_ms, usage_id, scene_id, conversation_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
             [
                 options.actorId,
                 options.context || null,
@@ -761,6 +761,7 @@ async function logCall(options) {
                 options.durationMs || null,
                 options.usageId || null,
                 options.sceneId || null,
+                options.conversationId || null,
             ]
         );
     } catch (err) {
@@ -2358,6 +2359,11 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     // lands with NULL scene_structure and the admin chat UI's scene
     // grouping renders the label inconsistently within a scene.
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
+    // conversationId (MEM-133 / ZBBS-HOME-396): forwarded from the original
+    // /chat/send so the VA's reply row AND this call's log entry carry the same
+    // narrative-beat grouping id as the perception that prompted them — keeping
+    // the whole exchange in one conversation in the admin viewer.
+    const conversationId = opts && opts.conversationId !== undefined ? opts.conversationId : null;
     // ephemeralContext (lean sim-history): per-tick scratch context (current
     // affordances / world-state) attached to the model's CURRENT turn below.
     // Never persisted — it only shapes this one provider call, so it can't
@@ -2614,7 +2620,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (await isRateLimited(agent.agent, rateLimitSceneId)) {
             logVA('direct-chat-rate-limited', { agent: virtualAgentName, from: fromAgent });
             await chatSend(virtualAgentName, [fromAgent], null,
-                '[Error] Rate limited — too many API calls. Please wait before trying again.', { sceneId, isError: true });
+                '[Error] Rate limited — too many API calls. Please wait before trying again.', { sceneId, conversationId, isError: true });
             return null;
         }
 
@@ -2623,7 +2629,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (costCheck.limited) {
             logVA('direct-chat-over-cost-limit', { agent: virtualAgentName, from: fromAgent, reason: costCheck.reason });
             await chatSend(virtualAgentName, [fromAgent], null,
-                `[Error] ${costCheck.reason}`, { sceneId, isError: true });
+                `[Error] ${costCheck.reason}`, { sceneId, conversationId, isError: true });
             return null;
         }
 
@@ -2642,7 +2648,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             withActivityIndicator(agent.agent, () => providerFn(systemPrompt, userMessage, providerCallOpts)),
             async (err, retryInfo) => {
                 await chatSend(virtualAgentName, [fromAgent], null,
-                    `[Retrying] Initial attempt failed: ${err.message}. Retrying ${retryInfo.retriesRemaining} more time(s) over the next ~${formatDuration(retryInfo.totalSeconds)}.`, { sceneId, isError: true });
+                    `[Retrying] Initial attempt failed: ${err.message}. Retrying ${retryInfo.retriesRemaining} more time(s) over the next ~${formatDuration(retryInfo.totalSeconds)}.`, { sceneId, conversationId, isError: true });
             }
         );
         const response = providerResult.text || '';
@@ -2670,7 +2676,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             actorId: agent.actor_id, agentName: agent.agent, context: 'chat',
             provider: agent.provider, model: agent.model,
             systemPrompt, userMessage: loggedUserMessage, response: loggedResponse, usage, cost: chatCost,
-            durationMs: chatDurationMs, usageId: chatUsageId, sceneId,
+            durationMs: chatDurationMs, usageId: chatUsageId, sceneId, conversationId,
         }).catch(() => {});
 
         // Send response as direct chat back to the sender. Tool-use replies
@@ -2686,7 +2692,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         // so the row doesn't sit unacked forever (which is what made the
         // collapsed-scene unacked indicator permanently lit for every
         // Salem scene — every NPC→engine reply was unacked).
-        const replyOpts = { sceneId, sceneStructure };
+        const replyOpts = { sceneId, sceneStructure, conversationId };
         if (replyToolCalls.length > 0) replyOpts.toolCalls = replyToolCalls;
         if (opts && opts.ackReplyOnInsert) replyOpts.ackOnInsert = true;
         await chatSend(agent.agent, [fromAgent], null, response, replyOpts);
@@ -2737,7 +2743,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             provider: agent ? agent.provider : 'unknown', model: agent ? agent.model : 'unknown',
             systemPrompt: typeof systemPrompt !== 'undefined' ? systemPrompt : null,
             userMessage: typeof loggedUserMessage !== 'undefined' ? loggedUserMessage : messageText,
-            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId, sceneId,
+            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId, sceneId, conversationId,
         }).catch(() => {});
         logError('virtual-agent', 'direct-chat-error', {
             agent: virtualAgentName,
@@ -2749,7 +2755,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         // Send error feedback to the caller so they know it failed
         try {
             await chatSend(virtualAgentName, [fromAgent], null,
-                `[Error] ${virtualAgentName} is unavailable (${err.message}).`, { sceneId, isError: true });
+                `[Error] ${virtualAgentName} is unavailable (${err.message}).`, { sceneId, conversationId, isError: true });
         } catch (sendErr) {
             logVA('error-feedback-failed', { agent: virtualAgentName, error: sendErr.message });
         }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2359,7 +2359,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     // lands with NULL scene_structure and the admin chat UI's scene
     // grouping renders the label inconsistently within a scene.
     const sceneStructure = opts && opts.sceneStructure !== undefined ? opts.sceneStructure : null;
-    // conversationId (MEM-133 / ZBBS-HOME-396): forwarded from the original
+    // conversationId (MEM-133 / ZBBS-HOME-397): forwarded from the original
     // /chat/send so the VA's reply row AND this call's log entry carry the same
     // narrative-beat grouping id as the perception that prompted them — keeping
     // the whole exchange in one conversation in the admin viewer.


### PR DESCRIPTION
## Problem
The admin comms chat viewer groups chat rows by `scene_id`, but the salem engine mints a fresh `scene_id` per tick, so one conversation shatters into one collapsible group per tick.

## Fix
The engine now also sends a `conversation_id` — its narrative-beat `sim.Scene.ID`, stable across the ticks AND participants of one conversation beat (paired salem PR #360). This stamps it on the chat rows and groups the viewer by it, restoring whole-conversation grouping.

- **MEM-133 migration**: nullable `conversation_id TEXT` + partial index on `chat_message_texts` and `virtual_agent_calls`. TEXT not uuid (`sim.SceneID` is `"sc-"+hex`).
- `/v1/chat/send`: accept + validate (trimmed, ≤64) + thread `conversation_id` onto the INSERT, the WS broadcast, and the VA-reply dispatch.
- `virtual-agent.js`: VA reply row, call-log insert, and error breadcrumbs carry it.
- admin chat-list SELECTs it; **admin frontend groups by it**, falling back to `scene_id` for rows without one (companion-mode, pre-MEM-133 history, solo ticks). Per-participant thread sub-grouping kept.

`scene_id` untouched (it keeps per-tick threading, rate-limiting, shared-VA persona isolation). Purely additive. Migration round-trips clean; vite build green; code_review'd clean (GPT-5.5, trim fix applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)