### PR TITLE
Security: narrow VA-access admin branch (#1) + superadmin-gate dream consolidate (#3)

### DIFF
--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1999,6 +1999,12 @@ router.post('/admin/agents/call-detail', requirePerm('agents', 'read'), adminRou
 // Default (no filters, dry_run=false): processes every (agent, person)
 // pair across all agents in dream_mode IN ('sim', 'companion').
 router.post('/admin/dream/consolidate-people', requirePerm('agents', 'write'), adminRoute('dream-consolidate-people', async (req, res) => {
+    // Dream consolidation is a global, cross-actor operation — superadmin only.
+    // agents:write alone isn't enough (every self-signup is granted it), so gate
+    // on the *:* permission, matching actors/admin-permissions/save.
+    if (!await hasPermission(req.actorId, '*', '*')) {
+        return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Dream consolidation requires superadmin' } });
+    }
     const agentFilterRaw = req.body.agent;
     const personFilterRaw = req.body.person_slug;
     const dryRun = !!req.body.dry_run;

--- a/node/api/src/services/actors.js
+++ b/node/api/src/services/actors.js
@@ -87,11 +87,11 @@ function clearCache() {
 // Access is governed solely by the per-agent ACL — realm is NOT consulted here.
 // Granted if any of:
 //   1. The actor is the creator (owner) of the virtual agent
-//   2. The actor has an admin_permissions row (admin)
+//   2. The actor is a superadmin (holds the *:* admin permission)
 //   3. There's a virtual_agent_access row with grantee_actor_id = NULL (public)
 //   4. There's a virtual_agent_access row with grantee_actor_id = actor's id
 //
-// Default-deny: a VA with no ACL rows is reachable only by its owner and admins.
+// Default-deny: a VA with no ACL rows is reachable only by its owner and superadmins.
 // Realms are a tenant-isolation boundary, NOT an access grant — sharing a realm
 // does not confer access. "Who can use" comes entirely from the access ACL (the
 // admin virtual-agent-access dialogue). Previously a realm-overlap clause granted
@@ -103,8 +103,11 @@ async function canAccessVirtualAgent(actorId, virtualAgentId) {
             -- Creator/owner check
             SELECT 1 FROM actors WHERE id = $2 AND created_by = $1
             UNION ALL
-            -- Admin check
-            SELECT 1 FROM admin_permissions WHERE actor_id = $1
+            -- Superadmin check. A bare admin_permissions row is NOT sufficient:
+            -- every self-signup is granted admin_permissions at registration, so
+            -- matching any row would let any account trigger any VA. Only the *:*
+            -- grant bypasses the per-VA ACL below.
+            SELECT 1 FROM admin_permissions WHERE actor_id = $1 AND resource = '*' AND action = '*'
             UNION ALL
             -- ACL check (public or explicit grant)
             SELECT 1 FROM virtual_agent_access


### PR DESCRIPTION
## Summary

Two security fixes from the llm-memory-api review pile (`shared/tasks/pending/llm-memory-security-review`), both pure code and verified safe against a live audit. No DB changes are required for these to be safe to deploy.

### #1 — narrow `canAccessVirtualAgent` admin branch to superadmin (`services/actors.js`)

The VA-access check OR'd `SELECT 1 FROM admin_permissions WHERE actor_id = $1` ahead of the per-VA ACL. Every self-signup is granted `admin_permissions` rows at registration, so **any account could trigger (and bill) any virtual agent regardless of its ACL.** Narrowed to the `*:*` superadmin grant.

**Why it's safe** (2026-06-09 admin audit): every intended trigger relationship already holds an explicit `virtual_agent_access` grant, so the post-fix predicate (owner / `*:*` / public / explicit) stays TRUE for all of them:
- sirius42 / home / work → claude-general (claude-general has **no** public row; its grants are exactly these three)
- salem-engine → all 7 salem NPCs
- home / work (+ wendy, jeff) → the utility VAs (code_review, search-general, designer, design_review, openai-general, search-twitter-x, test-gemini)

Narrowing branch 2 breaks none of them — it only removes the drive-by access that was the hole.

### #3 — superadmin-gate `/admin/dream/consolidate-people` (`routes/admin.js`)

Was `requirePerm('agents','write')` only. Every self-signup has `agents:write`, so any UI-authenticated signup could trigger a global, cross-actor dream consolidation. Added an inline `*:*` check, matching the existing `actors/admin-permissions/save` pattern (same idiom already at three other call sites in this file).

## Related (not in this PR)

- **Permission data cleanup already applied** (via admin session, logged, reversible): 3 salem NPCs (`zbbs-ezekiel-crane`, `zbbs-prudence-ward`, `zbbs-josiah-thorne`) held the full default-signup permission set; stripped to `(none)` to match `zbbs-john-ellis`.
- **Deferred for separate review:** other `agents:write` admin routes (`agents/instructions/save`, `agents/expertise/save`, `agents/update`, `agents/reset-passphrase`) should be checked for ownership-scoping. Not touched here.
- **Still open (design + DB):** #2 (read-side disclosure — flip the all-realm-peers visibility default to deny + route `/agent/status` through `getVisibleActorIds`) and #4 (registration defaults / `open_registration`).

## Test

- `node --check` passes on both files.
- No automated test/lint suite in this package; changes are minimal and the #3 idiom matches three existing call sites.

Home to review before deploy, please — you own the deploy and the rest of the pile.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
