### PR TITLE
MEM-135 / Security #2: visibility default-deny + roster surface filtering

### DIFF
--- a/migrations/MEM-135-visibility-default-deny_down.sql
+++ b/migrations/MEM-135-visibility-default-deny_down.sql
@@ -1,0 +1,7 @@
+-- MEM-135 rollback: remove the trusted-agent wildcard visibility rows.
+-- jeff's wildcard row predates this migration (seeded by MEM-059) and is
+-- deliberately left in place.
+
+DELETE FROM actor_visibility_configuration
+ WHERE target_actor_id IS NULL
+   AND actor_id IN (SELECT id FROM actors WHERE name IN ('wendy', 'work', 'home'));

--- a/migrations/MEM-135-visibility-default-deny_up.sql
+++ b/migrations/MEM-135-visibility-default-deny_up.sql
@@ -1,0 +1,15 @@
+-- MEM-135: visibility default flips to self-only (default-deny).
+-- The code change makes an actor with zero actor_visibility_configuration
+-- rows see only itself (previously: all realm peers). Trusted agents that
+-- relied on the open default get explicit wildcard rows here so they keep
+-- their realm-wide view. Superadmins (*:*) bypass visibility in code and
+-- need no row, but the rows are harmless belt-and-braces for them.
+-- Idempotent: ON CONFLICT DO NOTHING (jeff was already seeded by MEM-059;
+-- the partial unique index idx_avc_wildcard catches duplicate wildcards).
+--
+-- MUST run BEFORE the MEM-135 code deploys, or work/home go roster-blind
+-- until it does.
+
+INSERT INTO actor_visibility_configuration (actor_id, target_actor_id)
+SELECT id, NULL FROM actors WHERE name IN ('jeff', 'wendy', 'work', 'home')
+ON CONFLICT DO NOTHING;

--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -204,14 +204,14 @@
                             <div class="agent-card-description">Which other agents this actor can see when checking who's online</div>
                         </div>
                         <span class="agent-card-state" :class="actorHasWildcardVis ? 'agent-card-state--accent' : ''">
-                            {{ actorHasWildcardVis ? 'All agents' : (actorVisibilityGrants.length + ' grant' + (actorVisibilityGrants.length !== 1 ? 's' : '')) }}
+                            {{ actorHasWildcardVis ? 'All realm peers' : (actorVisibilityGrants.length + ' grant' + (actorVisibilityGrants.length !== 1 ? 's' : '')) }}
                         </span>
                     </div>
 
                     <div class="setting-row" style="margin-bottom: 12px;">
                         <div class="setting-row-text">
-                            <div class="setting-row-title">See all agents</div>
-                            <div class="setting-row-description">Wildcard visibility — can see every registered agent</div>
+                            <div class="setting-row-title">See whole realm</div>
+                            <div class="setting-row-description">Wildcard visibility — can see all agents sharing a realm with this actor</div>
                         </div>
                         <input type="checkbox" v-model="actorHasWildcardVis">
                     </div>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -2143,8 +2143,8 @@ function parseActorId(raw, res) {
 
 // POST /admin/actors/list — list all actors (for the Actors config tab)
 router.post('/admin/actors/list', requirePerm('agents', 'read'), adminRoute('actors-list', async (req, res) => {
-    const result = await pool.query(
-        `SELECT a.id, a.name, a.created_at, a.visible_to_others, a.created_by,
+    const visibleIds = await getVisibleActorIds(req.actorId);
+    let sql = `SELECT a.id, a.name, a.created_at, a.visible_to_others, a.created_by,
                 (ac.actor_id IS NOT NULL) AS is_agent,
                 (a.password_hash IS NOT NULL) AS is_user,
                 a.realms,
@@ -2155,9 +2155,14 @@ router.post('/admin/actors/list', requirePerm('agents', 'read'), adminRoute('act
          FROM actors a
          LEFT JOIN agent_configuration ac ON ac.actor_id = a.id
          LEFT JOIN agent_status s ON s.actor_id = a.id
-         LEFT JOIN actors creator ON creator.id = a.created_by
-         ORDER BY a.name`
-    );
+         LEFT JOIN actors creator ON creator.id = a.created_by`;
+    const params = [];
+    if (visibleIds !== null) {
+        sql += ' WHERE a.id = ANY($1)';
+        params.push(Array.from(visibleIds));
+    }
+    sql += ' ORDER BY a.name';
+    const result = await pool.query(sql, params);
 
     // Pre-fetch OpenRouter catalog if any actor uses it
     if (result.rows.some(r => r.provider === 'openrouter')) {

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -14,6 +14,7 @@ const config = require('../services/config');
 const { apiRoute } = require('../middleware/route-wrapper');
 const { invokeAgent } = require('../services/virtual-agent');
 const { deleteSessionByToken } = require('../services/sessions');
+const { getVisibleActorIds } = require('../services/actor-visibility');
 // actors service no longer needed — all routes use req.actorId from auth middleware
 
 const router = Router();
@@ -248,10 +249,14 @@ router.post('/agent/status', apiRoute('agent', 'status', async (req, res) => {
     // Use authenticated identity only — never trust req.body.agent
     const actorId = req.actorId;
 
+    // Visibility filter — the roster only shows actors the caller has been
+    // granted sight of (same rules as the /admin/* routes; null = superadmin,
+    // no filtering). Without this, any API key could enumerate every agent.
+    const visibleIds = await getVisibleActorIds(actorId);
+
     // Single query: join agent_status view with per-sender unread counts for
     // both chat and mail, so the caller sees everything at once.
-    const result = await pool.query(
-        `SELECT
+    let rosterSql = `SELECT
             a.agent,
             a.status,
             a.last_seen,
@@ -277,10 +282,14 @@ router.post('/agent/status', apiRoute('agent', 'status', async (req, res) => {
             JOIN actors fa ON fa.id = ml.from_actor_id
             WHERE ml.to_actor_id = $1 AND ml.acked_at IS NULL AND ml.deleted_at IS NULL
             GROUP BY fa.name
-        ) m ON m.from_agent = a.agent
-        ORDER BY a.agent`,
-        [actorId]
-    );
+        ) m ON m.from_agent = a.agent`;
+    const rosterParams = [actorId];
+    if (visibleIds !== null) {
+        rosterSql += ' WHERE a.actor_id = ANY($2)';
+        rosterParams.push(Array.from(visibleIds));
+    }
+    rosterSql += ' ORDER BY a.agent';
+    const result = await pool.query(rosterSql, rosterParams);
 
     // Get active subsystems per agent from non-expired sessions
     const sessionsResult = await pool.query(

--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -26,6 +26,7 @@ const { broadcast } = require('../services/events');
 const { requireByName, resolveByName } = require('../services/actors');
 const { requireAccess, hasAccess, getReadableNamespaces, validateNamespace } = require('../services/namespace-permissions');
 const { hasNoteAccess, listSharesByOwner, listSharedDocuments } = require('../services/note-permissions');
+const { getVisibleActorIds } = require('../services/actor-visibility');
 const sanitize = require('../sanitize');
 
 const router = Router();
@@ -1207,8 +1208,13 @@ const TOOL_HANDLERS = {
     // --- Agent ---
     async agent_status(args, agent, namespace, actorId) {
         const queryAgent = validateIdentity(args.agent, agent, 'agent');
-        const result = await pool.query(
-            `SELECT
+
+        // Visibility filter — same rules as /agent/status and the /admin/*
+        // routes (null = superadmin, no filtering). This is the surface an
+        // agent session actually calls, so it must not leak the full roster.
+        const visibleIds = await getVisibleActorIds(actorId);
+
+        let rosterSql = `SELECT
                 a.agent,
                 a.status,
                 a.last_seen,
@@ -1232,10 +1238,14 @@ const TOOL_HANDLERS = {
                 FROM mail ml
                 WHERE ml.to_actor_id = $1 AND ml.acked_at IS NULL AND ml.deleted_at IS NULL
                 GROUP BY ml.from_actor_id
-            ) m ON m.from_actor_id = a.actor_id
-            ORDER BY CASE a.status WHEN 'online' THEN 0 WHEN 'available' THEN 1 WHEN 'degraded' THEN 2 WHEN 'offline' THEN 3 ELSE 4 END, a.last_seen DESC NULLS LAST`,
-            [actorId]
-        );
+            ) m ON m.from_actor_id = a.actor_id`;
+        const rosterParams = [actorId];
+        if (visibleIds !== null) {
+            rosterSql += ' WHERE a.actor_id = ANY($2)';
+            rosterParams.push(Array.from(visibleIds));
+        }
+        rosterSql += ` ORDER BY CASE a.status WHEN 'online' THEN 0 WHEN 'available' THEN 1 WHEN 'degraded' THEN 2 WHEN 'offline' THEN 3 ELSE 4 END, a.last_seen DESC NULLS LAST`;
+        const result = await pool.query(rosterSql, rosterParams);
 
         const lines = result.rows.map(a => {
             const parts = [`${a.agent}: ${a.status}`];

--- a/node/api/src/services/actor-visibility.js
+++ b/node/api/src/services/actor-visibility.js
@@ -1,11 +1,16 @@
-// Actor visibility — controls which actors a logged-in admin UI user can see.
-// Two layers of filtering:
-//   1. Realm scoping — actors only see others that share at least one realm.
-//   2. Explicit grants — within a realm, visibility can be further restricted
-//      via actor_visibility_configuration (wildcard or per-actor grants).
+// Actor visibility — controls which actors a viewer can see, on the admin UI
+// routes and the agent-facing roster surfaces (/agent/status, MCP agent_status).
+// Three layers:
+//   1. Superadmin (*:*) — unfiltered, sees everything across realms.
+//   2. Realm scoping — actors only see others that share at least one realm.
+//   3. Explicit grants — within a realm, visibility comes from
+//      actor_visibility_configuration (wildcard or per-actor grants).
+// Default-deny: an actor with no grant rows sees only itself. Visibility
+// beyond self is opt-in — trusted agents get a wildcard row.
 // Implicit: every actor can always see themselves.
 
 const pool = require('../db');
+const { hasPermission } = require('./admin-permissions');
 
 // Cache: actorId -> { visibleIds: Set<number> | null, expires }
 // null visibleIds means no filtering needed (see everything in realm)
@@ -36,8 +41,14 @@ async function loadRealmPeers(actorId) {
 }
 
 // Load visibility grants for an actor from the database.
-// Returns null (wildcard — see everything in realm) or a Set of visible actor IDs.
+// Returns null (superadmin — no filtering) or a Set of visible actor IDs.
 async function loadVisibility(actorId) {
+    // Superadmins (*:*) bypass visibility entirely — they see all actors,
+    // across realms. Everyone else is bounded by realm + grants below.
+    if (await hasPermission(actorId, '*', '*')) {
+        return null;
+    }
+
     // First get realm peers — this is the outer boundary
     const realmPeers = await loadRealmPeers(actorId);
 
@@ -54,11 +65,13 @@ async function loadVisibility(actorId) {
         }
     }
 
-    // No explicit grants and no wildcard — default to seeing all realm peers.
-    // The explicit grant system is for restricting within a realm, not for
-    // granting access. If you have no grants, you see your whole realm.
+    // No explicit grants and no wildcard — default-deny: see only yourself.
+    // A fresh signup starts blind to the rest of its realm; visibility is
+    // granted deliberately (wildcard row for trusted agents, per-actor rows
+    // otherwise). This used to default to all realm peers, which let any
+    // open-registration signup enumerate the whole roster.
     if (result.rows.length === 0) {
-        return realmPeers;
+        return new Set([actorId]);
     }
 
     // Explicit grants exist — intersect with realm peers
@@ -73,7 +86,8 @@ async function loadVisibility(actorId) {
 }
 
 // Get visible actor IDs for an actor (cached).
-// Returns Set<number> of visible actor IDs.
+// Returns Set<number> of visible actor IDs, or null when no filtering
+// applies (superadmin). Callers treat null as "skip the WHERE clause".
 async function getVisibleActorIds(actorId) {
     if (!isValidActorId(actorId)) {
         return new Set(); // fail closed — see nothing
@@ -99,6 +113,10 @@ async function canSee(viewerActorId, targetActorId) {
     }
 
     const visibleIds = await getVisibleActorIds(viewerActorId);
+    // null = unfiltered (superadmin)
+    if (visibleIds === null) {
+        return true;
+    }
     return visibleIds.has(targetActorId);
 }
 

--- a/node/api/src/services/actor-visibility.js
+++ b/node/api/src/services/actor-visibility.js
@@ -13,7 +13,7 @@ const pool = require('../db');
 const { hasPermission } = require('./admin-permissions');
 
 // Cache: actorId -> { visibleIds: Set<number> | null, expires }
-// null visibleIds means no filtering needed (see everything in realm)
+// null visibleIds means no filtering needed (superadmin; cross-realm)
 const cache = new Map();
 const CACHE_TTL_MS = 2 * 60 * 1000;
 


### PR DESCRIPTION
Closes security hole #2 (read-side disclosure): any open-registration signup could enumerate the full actor roster and read comms it had no part in, because `getVisibleActorIds` defaulted to **all realm peers** when an actor had zero `actor_visibility_configuration` rows, and three roster surfaces bypassed visibility entirely.

## Changes

**`services/actor-visibility.js`**
- Empty-config default flipped: zero rows now means **self-only** (default-deny). Previously it returned all realm peers — and the admin panel already claimed "can only see self", so the UI label and backend now agree.
- Superadmin (`*:*`) bypass: `loadVisibility` returns `null` (no filtering, cross-realm). Every `/admin/*` call site already branches on `visibleIds !== null` — that branch was dead code until now; `services/logger.js` documents the same null contract.
- `canSee` handles the new null return (superadmin sees everyone).

**Roster surfaces that bypassed visibility (now filtered):**
- `/v1/agent/status` (`routes/agent.js`) — returned the full roster to any API key.
- MCP `agent_status` tool (`routes/mcp.js`) — separate query, same leak; this is the path agent sessions actually call (verified live 2026-06-09: an `llm-memory`-realm key saw `salem`-realm NPCs).
- `/admin/actors/list` (`routes/admin.js`) — had no visibility filter at all (the "all 43 actors" finding in the empirical test).

**`migrations/MEM-135-*`** — seeds wildcard visibility rows for jeff/wendy/work/home (idempotent, `ON CONFLICT DO NOTHING`; jeff already seeded by MEM-059). **Must run before this code deploys** or work/home go roster-blind until it does.

**Admin UI** (`actor-dialogs.html`) — wildcard copy corrected: it claimed "can see every registered agent" but a wildcard row only grants realm peers.

## What does NOT change
- Mail/chat send + receive — visibility is never consulted there. sirius42 → claude-general keeps working; only *discovery* tightens.
- salem-engine — doesn't call any status/admin surface (verified by grep).
- VA trigger gating (`canAccessVirtualAgent`) — untouched, separate check (#1, already shipped).
- Notes — namespace-permissions already default-deny.

## Verification
- `node --check` clean on all four JS files; `npm run build:admin` clean.
- Pre-existing null-handling at every `getVisibleActorIds` call site reviewed (dashboard, api-log/error-log via logger.js, agents list, discussions, chat, mail).

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)