### PR TITLE
Security #2 follow-up: implicit created-by sight + delegation-bound visibility/save

### DIFF
--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -232,7 +232,7 @@
                                     <td><button class="btn btn-ghost btn-compact btn-danger" @click="removeVisibilityGrant(idx)" title="Remove">&times;</button></td>
                                 </tr>
                                 <tr v-if="actorVisibilityGrants.length === 0">
-                                    <td colspan="3" class="ts">No grants — can only see self.</td>
+                                    <td colspan="3" class="ts">No grants — can only see self and agents they created.</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1620,21 +1620,12 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
             );
         }
 
-        // Grant the creator visibility to the new agent (so they can see it in the UI).
-        // Skip if the creator already has wildcard visibility (sees everything).
-        const creatorVis = await client.query(
-            'SELECT target_actor_id FROM actor_visibility_configuration WHERE actor_id = $1 AND target_actor_id IS NULL',
-            [req.actorId]
-        );
-        if (creatorVis.rows.length === 0) {
-            await client.query(
-                'INSERT INTO actor_visibility_configuration (actor_id, target_actor_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-                [req.actorId, actorId]
-            );
-        }
+        // No explicit visibility grant needed: the creator sees this agent
+        // implicitly via created_by (services/actor-visibility.js).
 
         await client.query('COMMIT');
-        // Clear visibility cache so the new grant takes effect immediately
+        // Clear visibility cache so the creator's implicit sight of the new
+        // agent takes effect immediately
         const { clearCache: clearVisCache } = require('../services/actor-visibility');
         clearVisCache(req.actorId);
     } catch (txErr) {
@@ -2332,6 +2323,28 @@ router.post('/admin/actors/visibility/save', requirePerm('agents', 'write'), adm
         const existCheck = await pool.query('SELECT id FROM actors WHERE id = ANY($1)', [deduped]);
         if (existCheck.rows.length !== deduped.length) {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'One or more target actors do not exist' } });
+        }
+    }
+
+    // Delegation bound — you can only share sight you already have.
+    // Without this, ownership alone would let any signup with agents:write
+    // re-grant ITSELF wildcard visibility and undo the default-deny flip.
+    // Superadmins (callerVisible === null) skip the bound.
+    const callerVisible = await getVisibleActorIds(req.actorId);
+    if (callerVisible !== null) {
+        if (wildcard) {
+            // Wildcard for the target requires the caller to hold wildcard
+            // itself (realm-wide sight is not something self/created
+            // ownership confers).
+            const callerWildcard = await pool.query(
+                'SELECT 1 FROM actor_visibility_configuration WHERE actor_id = $1 AND target_actor_id IS NULL',
+                [req.actorId]
+            );
+            if (callerWildcard.rows.length === 0) {
+                return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Granting wildcard visibility requires wildcard visibility yourself' } });
+            }
+        } else if (deduped.some(g => !callerVisible.has(g))) {
+            return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'You can only grant visibility of actors you can see yourself' } });
         }
     }
 

--- a/node/api/src/services/actor-visibility.js
+++ b/node/api/src/services/actor-visibility.js
@@ -5,9 +5,12 @@
 //   2. Realm scoping — actors only see others that share at least one realm.
 //   3. Explicit grants — within a realm, visibility comes from
 //      actor_visibility_configuration (wildcard or per-actor grants).
-// Default-deny: an actor with no grant rows sees only itself. Visibility
-// beyond self is opt-in — trusted agents get a wildcard row.
-// Implicit: every actor can always see themselves.
+// Default-deny: an actor with no grant rows sees only itself and the actors
+// it created. Visibility beyond that is opt-in — trusted agents get a
+// wildcard row.
+// Implicit: every actor can always see itself AND actors it created
+// (created_by) — those are its own resources; a signup must be able to see
+// and manage its agents without any grant rows.
 
 const pool = require('../db');
 const { hasPermission } = require('./admin-permissions');
@@ -49,8 +52,15 @@ async function loadVisibility(actorId) {
         return null;
     }
 
-    // First get realm peers — this is the outer boundary
+    // First get realm peers — this is the outer boundary for grants
     const realmPeers = await loadRealmPeers(actorId);
+
+    // Actors you created are implicitly visible, like self — they're your
+    // resources. Not bounded by realm: you see what you made, period.
+    const created = await pool.query(
+        'SELECT id FROM actors WHERE created_by = $1',
+        [actorId]
+    );
 
     // Then check explicit visibility grants
     const result = await pool.query(
@@ -61,22 +71,29 @@ async function loadVisibility(actorId) {
     // Check for wildcard (NULL target) — sees all agents within their realm(s)
     for (const row of result.rows) {
         if (row.target_actor_id === null) {
+            for (const c of created.rows) {
+                realmPeers.add(c.id);
+            }
             return realmPeers;
         }
     }
 
-    // No explicit grants and no wildcard — default-deny: see only yourself.
+    const ids = new Set();
+    ids.add(actorId);
+    for (const c of created.rows) {
+        ids.add(c.id);
+    }
+
+    // No explicit grants and no wildcard — default-deny: self + created only.
     // A fresh signup starts blind to the rest of its realm; visibility is
     // granted deliberately (wildcard row for trusted agents, per-actor rows
     // otherwise). This used to default to all realm peers, which let any
     // open-registration signup enumerate the whole roster.
     if (result.rows.length === 0) {
-        return new Set([actorId]);
+        return ids;
     }
 
     // Explicit grants exist — intersect with realm peers
-    const ids = new Set();
-    ids.add(actorId);
     for (const row of result.rows) {
         if (realmPeers.has(row.target_actor_id)) {
             ids.add(row.target_actor_id);

--- a/node/api/src/services/actor-visibility.js
+++ b/node/api/src/services/actor-visibility.js
@@ -68,13 +68,15 @@ async function loadVisibility(actorId) {
         [actorId]
     );
 
-    // Check for wildcard (NULL target) — sees all agents within their realm(s)
+    // Check for wildcard (NULL target) — sees all agents within their realm(s).
+    // Copy rather than mutate realmPeers, in case loadRealmPeers is ever cached.
     for (const row of result.rows) {
         if (row.target_actor_id === null) {
+            const ids = new Set(realmPeers);
             for (const c of created.rows) {
-                realmPeers.add(c.id);
+                ids.add(c.id);
             }
-            return realmPeers;
+            return ids;
         }
     }
 


### PR DESCRIPTION
Follow-up to #224. Jeff asked the right question — "agents can't just turn those back on, can they?" — and for visibility the answer was yes:

**The hole:** `/admin/actors/visibility/save` is gated by `requireOwnership`, which allows **self**. The route wrote whatever it was told, unbounded. So any signup (default grant includes `agents:write`) could POST `{actor_id: <itself>, wildcard: true}` and re-grant itself realm-wide sight — a one-call self-service undo of #224's default-deny flip. (`admin_permissions` and namespace permissions were already superadmin-only and NOT affected — this was visibility-specific.)

**The inverse problem found alongside it:** post-#224, a signup with zero visibility rows couldn't see agents it *created* — its own agents vanished from its dashboard. `/admin/actors/create` worked around this with an explicit creator→agent grant insert, but self-registered signups creating agents had no such path.

## Changes

**`services/actor-visibility.js` — implicit created-by sight.** `loadVisibility` now includes actors where `created_by = viewer` in every non-superadmin path, like self. They're the viewer's own resources (consistent with the ownership model from the 05-21 fixes). Not realm-bounded — you see what you made.

**`routes/admin.js` — delegation bound on `visibility/save`.** You can only share sight you already have: `wildcard: true` requires the caller to hold wildcard itself (or `*:*`); per-actor grants must be ⊆ `getVisibleActorIds(caller)`. The legitimate case still works — an owner granting its agents sight of each other is within bounds, since created agents are in the owner's visible set.

**`routes/admin.js` — `/admin/actors/create`** drops the now-redundant explicit creator-grant insert (the post-COMMIT `clearVisibilityCache(req.actorId)` stays, now serving the implicit sight). Existing auto-grant rows in prod remain valid, just superfluous — no migration needed.

**UI label** updated: zero-grant actors "can only see self and agents they created".

## Accepted residual (flagging, not fixing here)
A wildcard-holding caller (trusted: jeff/wendy/work/home) could create an agent with realms it doesn't hold itself and wildcard it, indirectly seeing another realm through that agent's eyes. Only reachable by already-trusted actors; realms-on-create validation is a separate design question.

## Verification
- `node --check` clean on both JS files; `npm run build:admin` clean.
- Attack paths traced: self-wildcard → 403; self-grant of unseen actor → 403; agent-without-admin-perms can't reach the route at all (`requirePerm('agents','write')`).

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)