### PR TITLE
ZBBS-WORK-388: allowlist plugins:administer + access, UI administer column

### DIFF
--- a/node/api/public/admin/actors-config.js
+++ b/node/api/public/admin/actors-config.js
@@ -57,7 +57,8 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
         { id: 'actors', label: 'Actors', actions: ['read', 'write'], hint: 'Actor management: permissions, visibility, passwords, create/edit actors' },
         { id: 'templates', label: 'Templates', actions: ['read', 'write', 'delete'], hint: 'Welcome and onboarding message templates' },
         { id: 'logs', label: 'Logs', actions: ['read'], hint: 'API request logs and error logs' },
-        { id: 'access', label: 'Access', actions: ['read', 'write'], hint: 'Access requests from the landing page' }
+        { id: 'access', label: 'Access', actions: ['read', 'write'], hint: 'Access requests from the landing page' },
+        { id: 'plugins', label: 'Plugins', actions: ['administer'], hint: 'Village-operator capability: salem umbilical control surface, sim ingestion' }
     ];
 
     // Virtual agent access state
@@ -493,11 +494,23 @@ function useActorsConfig({ api, showToast, showConfirm, agentsModule, user, perm
         const row = actorAdminPerms.value[resourceIndex];
         if (!row) return;
         const has = row.granted.includes(action);
+        // Non-hierarchical actions (e.g. plugins:administer) aren't in the rank
+        // ladder — they toggle independently, implying and implied by nothing.
+        const hierarchy = { read: 1, write: 2, delete: 3 };
+        if (!hierarchy[action]) {
+            if (has) {
+                row.granted = row.granted.filter(a => a !== action);
+            } else {
+                row.granted = [...row.granted, action];
+            }
+            return;
+        }
         if (has) {
             // Remove this action and any lower-ranked actions that become orphaned
+            // (keep non-hierarchical grants — they're outside the ladder)
             const rank = { read: 1, write: 2, delete: 3 };
             const removedRank = rank[action];
-            row.granted = row.granted.filter(a => rank[a] < removedRank);
+            row.granted = row.granted.filter(a => !rank[a] || rank[a] < removedRank);
         } else {
             // Add this action and any implied lower actions
             const rank = { read: 1, write: 2, delete: 3 };

--- a/node/api/public/admin/views/actor-dialogs.html
+++ b/node/api/public/admin/views/actor-dialogs.html
@@ -414,6 +414,7 @@
                                     <th style="text-align: center;">Read</th>
                                     <th style="text-align: center;">Write</th>
                                     <th style="text-align: center;">Delete</th>
+                                    <th style="text-align: center;">Administer</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -429,6 +430,10 @@
                                     </td>
                                     <td style="text-align: center;">
                                         <input v-if="row.actions.includes('delete')" type="checkbox" :checked="adminPermChecked(idx, 'delete')" @change="toggleAdminPerm(idx, 'delete')">
+                                        <span v-else class="ts">—</span>
+                                    </td>
+                                    <td style="text-align: center;">
+                                        <input v-if="row.actions.includes('administer')" type="checkbox" :checked="adminPermChecked(idx, 'administer')" @change="toggleAdminPerm(idx, 'administer')">
                                         <span v-else class="ts">—</span>
                                     </td>
                                 </tr>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -2436,7 +2436,17 @@ const ADMIN_PERM_ALLOWLIST = {
     config: ['read', 'write'],
     actors: ['read', 'write'],
     templates: ['read', 'write', 'delete'],
-    logs: ['read']
+    logs: ['read'],
+    // Access-requests + invite-codes routes (below). The dashboard has always offered
+    // this pair, but the routes landed a week after this allowlist (701cd32 vs c0b0716)
+    // and the entry was never added — so granting it silently no-opped.
+    access: ['read', 'write'],
+    // Village-operator capability — consumed by the salem umbilical's requireOperator
+    // (via /auth/verify's permission map) and /sim/raw-turns, not by any /admin route.
+    // It must still be in this allowlist: admin-permissions/save is replace-all and
+    // silently drops any row that fails isValidAdminPerm, so without this entry every
+    // dashboard permissions save would revoke a holder's operator access.
+    plugins: ['administer']
 };
 
 function isValidAdminPerm(resource, action) {


### PR DESCRIPTION
## What

`ADMIN_PERM_ALLOWLIST` (routes/admin.js) was missing two real capabilities, and `admin-permissions/save` is replace-all that silently drops any row failing `isValidAdminPerm` — so for both, granting silently no-opped and a dashboard permissions save on an existing holder silently revoked the row.

1. **`plugins:administer`** — the village-operator capability (salem umbilical `requireOperator` via /auth/verify's permission map, plus `/sim/raw-turns`). Server-side allowlist entry, plus the dashboard half: a Plugins row in `adminResources` and an Administer column in the actor-config grid (the table hardcoded read/write/delete). `toggleAdminPerm` gets a branch for non-hierarchical actions — they toggle independently of the read<write<delete ladder (and the ladder's remove-filter now preserves out-of-ladder grants on mixed rows).
2. **`access:read/write`** — gates the access-requests + invite-codes routes. The UI has offered this pair since those routes landed (701cd32, 2026-03-22), but the allowlist predates them (c0b0716, 2026-03-14) and was never updated — only `*:*` holders could use the Access view. One-line allowlist entry; the UI side already worked.

## Why now

Found during the HOME-418 / agent-admin-parity work (2026-06-10): work+home's explicit `plugins:administer` rows are gone (superseded by `*:*`), so nothing currently depends on this — but it blocks ever granting village-operator capability narrowly, and the access half affects any future non-superadmin admin user.

## Validation

`node --check` on admin.js; `npm run build:admin` green. No test infrastructure exists in this repo (no test script, no test files), so no test added — flagging the deviation from the ticket sketch rather than standing up a framework for this.

Ticket: `shared/tasks/pending/zbbs-work-388-admin-perm-allowlist-plugins`

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)