### PR TITLE
ZBBS-HOME-415: per-row reference id (chat_message_texts.id) in admin chat viewer

### DIFF
--- a/node/api/public/admin/chat.js
+++ b/node/api/public/admin/chat.js
@@ -191,10 +191,26 @@ function useChat({ api, showToast, dashboard }) {
         selectedMessage.value = null;
     }
 
+    // Copy a row's reference id (chat_message_texts.id) to the clipboard
+    // (ZBBS-HOME-415). The id is the handle for pointing Claude at a
+    // specific row ("look at row 51421"), so click-to-copy beats
+    // select-and-drag on a 5-6 digit number. navigator.clipboard needs a
+    // secure context, which the admin always has (https); the catch is
+    // for the rare denial (e.g. permissions policy) so the click never
+    // throws unhandled.
+    async function copyRefId(id) {
+        try {
+            await navigator.clipboard.writeText(String(id));
+            showToast('ID ' + id + ' copied');
+        } catch (err) {
+            showToast('Copy failed: ' + err.message, 'error');
+        }
+    }
+
     return {
         chatMessages, selectedMessage,
         chatGroups, expandedScenes, toggleScene, isSceneExpanded,
-        loadChat, deleteChat, closeDialogs,
+        loadChat, deleteChat, closeDialogs, copyRefId,
     };
 }
 

--- a/node/api/public/admin/chat.js
+++ b/node/api/public/admin/chat.js
@@ -199,11 +199,23 @@ function useChat({ api, showToast, dashboard }) {
     // for the rare denial (e.g. permissions policy) so the click never
     // throws unhandled.
     async function copyRefId(id) {
+        // Defensive: a malformed/legacy row without a text_id would
+        // otherwise copy the literal string "undefined".
+        if (id === null || id === undefined || id === '') {
+            showToast('No reference ID for this row', 'error');
+            return;
+        }
         try {
+            // clipboard can be absent despite https (iframe permissions
+            // policy, older browser) — without this check the failure is
+            // a confusing "Cannot read properties of undefined".
+            if (!navigator.clipboard?.writeText) {
+                throw new Error('clipboard unavailable');
+            }
             await navigator.clipboard.writeText(String(id));
             showToast('ID ' + id + ' copied');
         } catch (err) {
-            showToast('Copy failed: ' + err.message, 'error');
+            showToast('Copy failed: ' + (err?.message || String(err)), 'error');
         }
     }
 

--- a/node/api/public/admin/style.css
+++ b/node/api/public/admin/style.css
@@ -718,6 +718,20 @@ tbody tr:last-child td { border-bottom: none; }
 .col-agent { width: 10em; }
 .col-channel { width: 8em; }
 .col-time { width: 11em; }
+.col-ref-id { width: 4.5em; }
+
+/* Per-row reference id (ZBBS-HOME-415): chat_message_texts.id rendered as
+   a small monospace chip so the admin can cite an exact row ("look at row
+   51421") instead of screenshotting. Click-to-copy via copyRefId();
+   user-select: all keeps one-click manual selection as a fallback. */
+.ref-id {
+    font-size: 11px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text-muted);
+    cursor: copy;
+    user-select: all;
+}
+.ref-id:hover { color: var(--text-primary); }
 
 /* ═══════════════════════════════════════════════════════════════════
    Sub-tabs

--- a/node/api/public/admin/views/comms.html
+++ b/node/api/public/admin/views/comms.html
@@ -71,6 +71,7 @@
             <table class="fixed-table">
                 <colgroup>
                     <col class="col-icon">
+                    <col class="col-ref-id">
                     <col class="col-agent">
                     <col class="col-agent">
                     <col class="col-channel">
@@ -80,6 +81,7 @@
                 <thead>
                     <tr>
                         <th></th>
+                        <th>ID</th>
                         <th>From</th>
                         <th>To</th>
                         <th>Channel</th>
@@ -92,6 +94,10 @@
                         <!-- Companion-mode and pre-MEM-121 rows render unchanged. -->
                         <tr v-if="group.type === 'msg'" @click="selectedMessage = group.msg" class="clickable">
                             <td class="icon-cell"><i :class="group.msg.acked_at ? 'icon-check acked-icon' : 'icon-circle unacked-icon'"></i></td>
+                            <!-- Reference id = chat_message_texts.id (ZBBS-HOME-415), the
+                                 content-row id a query can SELECT by — NOT the delivery-row
+                                 id. @click.stop so copying doesn't also open the modal. -->
+                            <td><code class="ref-id" title="chat_message_texts.id — click to copy" @click.stop="copyRefId(group.msg.text_id)">{{ group.msg.text_id }}</code></td>
                             <td>{{ group.msg.from_agent }}</td>
                             <td>{{ group.msg.to_agent }}</td>
                             <td>{{ group.msg.channel || '—' }}</td>
@@ -116,6 +122,10 @@
                                 <i :class="isSceneExpanded(group.scene_id) ? 'icon-chevron-down' : 'icon-chevron-right'"></i>
                                 <i v-if="group.hasUnacked" class="icon-circle unacked-icon scene-ack-marker"></i>
                             </td>
+                            <!-- A scene header aggregates many messages, so it has no
+                                 single reference id — the scene_id chip in the summary
+                                 cell is its handle. Empty cell keeps the columns aligned. -->
+                            <td></td>
                             <td colspan="3" class="scene-participants">{{ group.participants.join(', ') }}</td>
                             <td class="message-cell"><span class="scene-summary">Scene<template v-if="group.location"> · {{ group.location }}</template> · {{ group.messages.length }} messages · <code class="scene-id">{{ group.scene_id }}</code></span></td>
                             <td class="time-cell">{{ formatDate(group.latest_at) }}</td>
@@ -133,11 +143,13 @@
                                     <td class="icon-cell">
                                         <i v-if="thread.hasUnacked" class="icon-circle unacked-icon"></i>
                                     </td>
+                                    <td></td>
                                     <td colspan="4" class="scene-thread-label">{{ thread.participant }} <span class="scene-thread-count">· {{ thread.messages.length }}</span></td>
                                     <td class="time-cell">{{ formatDate(thread.earliest_at) }}</td>
                                 </tr>
                                 <tr v-for="msg in thread.messages" :key="'scene-msg-' + msg.id" @click="selectedMessage = msg" class="clickable scene-child">
                                     <td class="icon-cell"><i :class="msg.acked_at ? 'icon-check acked-icon' : 'icon-circle unacked-icon'"></i></td>
+                                    <td><code class="ref-id" title="chat_message_texts.id — click to copy" @click.stop="copyRefId(msg.text_id)">{{ msg.text_id }}</code></td>
                                     <td>{{ msg.from_agent }}</td>
                                     <td>{{ msg.to_agent }}</td>
                                     <td>{{ msg.channel || '—' }}</td>

--- a/node/api/public/admin/views/misc-dialogs.html
+++ b/node/api/public/admin/views/misc-dialogs.html
@@ -48,7 +48,10 @@
                     <div v-else class="chat-transcript" ref="chatTranscriptEl">
                         <div v-for="msg in discussionChat" :key="msg.id" class="chat-bubble">
                             <div class="chat-meta">
-                                <strong :style="{ color: agentColor(msg.from_agent) }">{{ msg.from_agent }}</strong>
+                                <!-- chat-meta is flex space-between, so the ref-id chip is
+                                     grouped with the sender name to stay on the left edge
+                                     instead of floating to the middle as a third child. -->
+                                <span><strong :style="{ color: agentColor(msg.from_agent) }">{{ msg.from_agent }}</strong> <code class="ref-id" title="chat_message_texts.id — click to copy" @click="copyRefId(msg.text_id)">{{ msg.text_id }}</code></span>
                                 <span class="chat-time">{{ formatDate(msg.sent_at) }}</span>
                             </div>
                             <div class="chat-text">{{ msg.message }}</div>
@@ -82,6 +85,7 @@
             </p>
             <p class="ts" style="margin-bottom: 12px;">{{ formatDate(selectedMessage.sent_at) }}
                 <span v-if="selectedMessage.channel"> | Channel: {{ selectedMessage.channel }}</span>
+                <span v-if="selectedMessage.text_id"> | ID: <code class="ref-id" title="chat_message_texts.id — click to copy" @click="copyRefId(selectedMessage.text_id)">{{ selectedMessage.text_id }}</code></span>
             </p>
             <div class="mail-body">
                 <template v-if="selectedMessage.message">{{ selectedMessage.message }}</template>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -745,7 +745,7 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
     // For discussion channels, query distinct messages from chat_message_texts
     // to avoid showing duplicate delivery rows
     if (discussionId) {
-        let sql = `SELECT cmt.id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id, cmt.scene_id, cmt.conversation_id${sceneSelect}
+        let sql = `SELECT cmt.id, cmt.id AS text_id, fa.name AS from_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cmt.discussion_id, cmt.scene_id, cmt.conversation_id${sceneSelect}
                    FROM chat_message_texts cmt
                    JOIN actors fa ON fa.id = cmt.from_actor_id`;
         const conditions = ['cmt.discussion_id = $1'];
@@ -761,8 +761,17 @@ router.post('/admin/chat', requirePerm('comms', 'read'), adminRoute('chat-list',
         const result = await pool.query(sql, params);
         res.json({ messages: result.rows });
     } else {
-        // Non-discussion: query delivery rows as before
-        let sql = `SELECT cm.id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at, cmt.scene_id, cmt.conversation_id${sceneSelect}
+        // Non-discussion: query delivery rows as before. Two ids ride along
+        // (ZBBS-HOME-415): cm.id is the per-recipient DELIVERY row (what
+        // delete operates on — one utterance to a multi-actor huddle fans
+        // out to several of these), while text_id is the CONTENT row
+        // (chat_message_texts.id — one per utterance, the id you can
+        // SELECT by directly). The viewer displays text_id as the row's
+        // reference id so an id read off the screen round-trips to a
+        // single content row. The discussion branch above queries
+        // chat_message_texts directly, so its text_id is the same value
+        // as its id — aliased anyway so the frontend reads one field.
+        let sql = `SELECT cm.id, cmt.id AS text_id, fa.name AS from_agent, ta.name AS to_agent, cmt.message, cmt.tool_calls, cmt.sent_at, cm.acked_at, cmt.scene_id, cmt.conversation_id${sceneSelect}
                    FROM chat_messages cm
                    JOIN chat_message_texts cmt ON cmt.id = cm.message_text_id
                    JOIN actors fa ON fa.id = cmt.from_actor_id


### PR DESCRIPTION
Every chat row in the admin Communications → Chat viewer now shows a small monospace, click-to-copy reference ID, so a specific row can be cited directly ("look at row 51421") instead of screenshotted. Rows can arrive dozens per second from the agentic tool loop, so timestamps don't disambiguate.

**Which id:** `chat_message_texts.id` — the content row, one per utterance, the id a `SELECT ... WHERE id = N` round-trips to. NOT `chat_messages.id` (delivery row, fans out per recipient in multi-actor huddles). Both branches of `POST /admin/chat` alias it `text_id`; the non-discussion branch keeps `cm.id` as `id` for the existing delete semantics and row keys.

**Surfaces:** chat table (new narrow ID column; chips on plain + scene-child rows, spacer cells on scene/thread headers), chat-message detail modal meta line, discussion-transcript bubbles. Deliberately not the dashboard live-discussion panel (real-time view, not the reference viewer).

**Copy:** `copyRefId()` — clipboard + toast, guarded for missing `text_id` / absent clipboard (code_review round 1); `user-select: all` as manual fallback.

Verified: backend `node --check`, ESM check on chat.js, `vite build` of the admin SPA green. Read-side/display only — no migration, no schema change.

Ticket: `shared/tasks/pending/zbbs-home-415-admin-chat-row-reference-ids` (filed by home, picked up by work).

— Work