### PR TITLE
ZBBS-HOME-367: indexed lookup hash for API keys / client secrets (MEM-136)

### DIFF
--- a/migrations/MEM-136-api-key-lookup-hash_down.sql
+++ b/migrations/MEM-136-api-key-lookup-hash_down.sql
@@ -1,0 +1,8 @@
+-- MEM-136 reverse: drop the API-key lookup-hash column + partial index.
+-- Safe at any time — the auth code's legacy fallback authenticates rows
+-- without a lookup hash, and pre-MEM-136 code never references the column.
+
+DROP INDEX IF EXISTS idx_agent_api_keys_key_lookup_hash;
+
+ALTER TABLE agent_api_keys
+    DROP COLUMN IF EXISTS key_lookup_hash;

--- a/migrations/MEM-136-api-key-lookup-hash_up.sql
+++ b/migrations/MEM-136-api-key-lookup-hash_up.sql
@@ -1,0 +1,30 @@
+-- MEM-136 — indexed lookup hash for API keys / client secrets (ZBBS-HOME-367).
+--
+-- Symptom: every API-key auth (middleware/auth.js, middleware/mcp-auth.js)
+-- and OAuth client-secret check (routes/oauth.js) PBKDF2-verifies the
+-- presented token against EVERY non-revoked row of agent_api_keys until one
+-- matches — the same O(N * ~50ms) shape MEM-131 removed from sessions.
+-- After ZBBS-HOME-366 made PBKDF2 async this no longer freezes the event
+-- loop, but it still burns one libuv threadpool slot (default pool: 4) per
+-- candidate row per auth, so a growing key fleet degrades all auth latency.
+--
+-- Fix shape (MEM-131 precedent): a deterministic SHA-256 lookup column.
+-- New key inserts populate it; auth does an indexed single-candidate SELECT
+-- then ONE PBKDF2 verify. Backfill is impossible — only the PBKDF2 hash is
+-- stored, the key itself is unrecoverable — so pre-migration rows keep NULL
+-- and authenticate via a bounded legacy scan (key_lookup_hash IS NULL AND
+-- revoked_at IS NULL). Unlike sessions (24h expiry), API keys live forever,
+-- so the legacy path SELF-HEALS instead of waiting out an expiry: a
+-- successful legacy verify has the plaintext in hand and stamps
+-- key_lookup_hash on its row, moving that key to the indexed path from the
+-- next auth onward (services/api-keys.js).
+--
+-- Column nullable so existing rows don't break; index partial to skip the
+-- all-NULL pre-migration fleet.
+
+ALTER TABLE agent_api_keys
+    ADD COLUMN key_lookup_hash TEXT NULL;
+
+CREATE INDEX idx_agent_api_keys_key_lookup_hash
+    ON agent_api_keys (key_lookup_hash)
+ WHERE key_lookup_hash IS NOT NULL;

--- a/node/api/src/middleware/auth.js
+++ b/node/api/src/middleware/auth.js
@@ -1,8 +1,8 @@
 const pool = require('../db');
-const { verify } = require('../services/hashing');
 const { logError } = require('../services/logger');
 const { SESSION_KIND } = require('../constants');
 const { validateSessionToken } = require('../services/sessions');
+const { findApiKeyByToken } = require('../services/api-keys');
 
 // Cache session tokens in memory to avoid DB lookup on every request
 // Key: bearer token, Value: { agent, actorId, expires }
@@ -10,30 +10,20 @@ const sessionCache = new Map();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 // API key auth — accepts a 64-char hex token issued via the admin
-// `agent_api_keys` table. Iterates over non-revoked keys and verifies the hash.
-// Returns { agent, actorId } on match, null otherwise. Updates last_used_at on
-// success (fire-and-forget). Mirrors the path used by mcp-auth.js so a single
-// API key works against both /mcp and /v1.
+// `agent_api_keys` table. Resolves it through the shared indexed lookup
+// (services/api-keys.js, MEM-136 — one PBKDF2 verify, not a per-row scan).
+// Returns { agent, actorId } on match, null otherwise. last_used_at is
+// stamped by the service (fire-and-forget). Mirrors the path used by
+// mcp-auth.js so a single API key works against both /mcp and /v1.
 async function tryApiKeyAuth(token) {
     if (typeof token !== 'string' || !/^[0-9a-f]{64}$/i.test(token)) {
         return null;
     }
-    const keys = await pool.query(
-        `SELECT ac.name AS agent, ak.actor_id, ak.key_hash, ak.key_salt
-         FROM agent_api_keys ak
-         JOIN actors ac ON ac.id = ak.actor_id
-         WHERE ak.revoked_at IS NULL`
-    );
-    for (const row of keys.rows) {
-        if (await verify(token, row.key_salt, row.key_hash)) {
-            pool.query(
-                'UPDATE agent_api_keys SET last_used_at = NOW() WHERE actor_id = $1 AND key_salt = $2',
-                [row.actor_id, row.key_salt]
-            ).catch(() => {});
-            return { agent: row.agent, actorId: row.actor_id };
-        }
+    const row = await findApiKeyByToken(token);
+    if (!row) {
+        return null;
     }
-    return null;
+    return { agent: row.agent, actorId: row.actorId };
 }
 
 // Opportunistic heartbeat — update last_seen on every authenticated agent request

--- a/node/api/src/middleware/auth.js
+++ b/node/api/src/middleware/auth.js
@@ -11,14 +11,12 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 // API key auth — accepts a 64-char hex token issued via the admin
 // `agent_api_keys` table. Resolves it through the shared indexed lookup
-// (services/api-keys.js, MEM-136 — one PBKDF2 verify, not a per-row scan).
+// (services/api-keys.js, MEM-136 — one PBKDF2 verify, not a per-row scan;
+// the 64-hex shape gate lives in the service so all callers share it).
 // Returns { agent, actorId } on match, null otherwise. last_used_at is
 // stamped by the service (fire-and-forget). Mirrors the path used by
 // mcp-auth.js so a single API key works against both /mcp and /v1.
 async function tryApiKeyAuth(token) {
-    if (typeof token !== 'string' || !/^[0-9a-f]{64}$/i.test(token)) {
-        return null;
-    }
     const row = await findApiKeyByToken(token);
     if (!row) {
         return null;

--- a/node/api/src/middleware/mcp-auth.js
+++ b/node/api/src/middleware/mcp-auth.js
@@ -8,9 +8,9 @@
 const crypto = require('crypto');
 const pool = require('../db');
 const config = require('../services/config');
-const { verify } = require('../services/hashing');
 const { broadcast } = require('../services/events');
 const { resolveByName } = require('../services/actors');
+const { findApiKeyByToken } = require('../services/api-keys');
 
 // Opportunistic heartbeat — update last_seen on every authenticated MCP request.
 // Also refreshes active_since if already set, so the activity spinner stays alive
@@ -67,30 +67,17 @@ function tryHmacAuth(token) {
     return match ? agent : null;
 }
 
-// Try to authenticate with an API key from agent_api_keys.
+// Try to authenticate with an API key from agent_api_keys, via the shared
+// indexed lookup (services/api-keys.js, MEM-136 — one PBKDF2 verify, not a
+// per-row scan; last_used_at stamped by the service).
 // Returns { agent, actorId, permissions } on success, null on failure.
 async function tryApiKeyAuth(token) {
-    const keys = await pool.query(
-        `SELECT ac.name AS agent, ak.actor_id, ak.key_hash, ak.key_salt
-         FROM agent_api_keys ak
-         JOIN actors ac ON ac.id = ak.actor_id
-         WHERE ak.revoked_at IS NULL`
-    );
-
-    for (const row of keys.rows) {
-        if (await verify(token, row.key_salt, row.key_hash)) {
-            // Update last_used_at
-            pool.query(
-                'UPDATE agent_api_keys SET last_used_at = NOW() WHERE actor_id = $1 AND key_salt = $2',
-                [row.actor_id, row.key_salt]
-            ).catch(() => {});
-
-            const permissions = await getPermissions(row.actor_id);
-            return { agent: row.agent, actorId: row.actor_id, permissions };
-        }
+    const row = await findApiKeyByToken(token);
+    if (!row) {
+        return null;
     }
-
-    return null;
+    const permissions = await getPermissions(row.actorId);
+    return { agent: row.agent, actorId: row.actorId, permissions };
 }
 
 async function mcpAuth(req, res, next) {

--- a/node/api/src/routes/oauth.js
+++ b/node/api/src/routes/oauth.js
@@ -11,8 +11,8 @@ const { Router } = require('express');
 const crypto = require('crypto');
 const pool = require('../db');
 const config = require('../services/config');
-const { hash, verify } = require('../services/hashing');
 const { logError } = require('../services/logger');
+const { findApiKeyByToken } = require('../services/api-keys');
 
 const router = Router();
 
@@ -44,26 +44,21 @@ function getBaseUrl(req) {
     return `${req.protocol}://${req.get('host')}`;
 }
 
-// Validate a client_id + client_secret pair against agent_api_keys.
+// Validate a client_id + client_secret pair against agent_api_keys, via the
+// shared indexed lookup (services/api-keys.js, MEM-136) scoped to the named
+// actor's keys — one PBKDF2 verify instead of a per-key scan. last_used_at
+// is stamped by the service.
 // Returns the agent name on success, null on failure.
 async function validateClientCredentials(clientId, clientSecret) {
     const { resolveByName } = require('../services/actors');
     const actor = await resolveByName(clientId);
     if (!actor) return null;
 
-    const result = await pool.query(
-        'SELECT id, key_hash, key_salt FROM agent_api_keys WHERE actor_id = $1 AND revoked_at IS NULL',
-        [actor.id]
-    );
-
-    for (const row of result.rows) {
-        if (await verify(clientSecret, row.key_salt, row.key_hash)) {
-            // Track usage
-            pool.query('UPDATE agent_api_keys SET last_used_at = NOW() WHERE id = $1', [row.id]).catch(() => {});
-            return clientId;
-        }
+    const row = await findApiKeyByToken(clientSecret, { actorId: actor.id });
+    if (!row) {
+        return null;
     }
-    return null;
+    return clientId;
 }
 
 // Issue a deterministic HMAC token for an agent.

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const pool = require('../db');
 const config = require('../services/config');
 const generatePassphrase = require('eff-diceware-passphrase');
-const { generateSalt, hash: hashToken, generateKey } = require('../services/hashing');
+const { generateSalt, hash: hashToken, generateKey, tokenLookupHash } = require('../services/hashing');
 const { mailSend } = require('../services/mail');
 const { saveNote } = require('../services/documents');
 const { checkNameAvailability, moderateActorName } = require('../services/actors');
@@ -190,13 +190,15 @@ router.post('/api/register', async (req, res) => {
             [actorId]
         );
 
-        // Generate API key for MCP/OAuth authentication
+        // Generate API key for MCP/OAuth authentication. key_lookup_hash
+        // (MEM-136) is the deterministic SHA-256 index key that lets auth
+        // find this row in one SELECT instead of PBKDF2-scanning the table.
         const apiKey = generateKey();
         const apiKeySalt = generateSalt();
         const apiKeyHash = await hashToken(apiKey, apiKeySalt);
         await client.query(
-            `INSERT INTO agent_api_keys (actor_id, key_hash, key_salt, label) VALUES ($1, $2, $3, 'default')`,
-            [actorId, apiKeyHash, apiKeySalt]
+            `INSERT INTO agent_api_keys (actor_id, key_hash, key_salt, key_lookup_hash, label) VALUES ($1, $2, $3, $4, 'default')`,
+            [actorId, apiKeyHash, apiKeySalt, tokenLookupHash(apiKey)]
         );
 
         await client.query('COMMIT');

--- a/node/api/src/services/api-keys.js
+++ b/node/api/src/services/api-keys.js
@@ -1,0 +1,98 @@
+// Shared API-key lookup — resolves a presented key (bearer token or OAuth
+// client_secret) to its agent_api_keys row via the indexed key_lookup_hash
+// (MEM-136), mirroring services/sessions.js's MEM-131 pattern. Used by the
+// /v1 auth middleware, the /mcp auth middleware, and the OAuth token
+// endpoint so all three share one verification path instead of each
+// carrying its own PBKDF2 scan loop.
+//
+// Fast path: SELECT WHERE key_lookup_hash = sha256(key) returns at most one
+// candidate row, then ONE PBKDF2 verify confirms. O(1) indexed lookup.
+//
+// Legacy fallback: keys issued before MEM-136 have key_lookup_hash NULL and
+// are PBKDF2-verified row by row, bounded to revoked_at IS NULL. Unlike the
+// sessions fallback (which aged out with the 24h expiry), API keys never
+// expire — so a successful legacy verify SELF-HEALS: with the plaintext in
+// hand it stamps key_lookup_hash onto the row, moving that key to the
+// indexed path for every subsequent auth. The fallback population only
+// shrinks (heal, rotation, or revocation) and never grows, since all new
+// keys insert with the hash populated (routes/registration.js).
+
+const pool = require('../db');
+const { verify, tokenLookupHash } = require('./hashing');
+
+// Resolve a presented key to { id, actorId, agent } or null.
+//
+// options.actorId scopes the search to one actor's keys (the OAuth
+// client-credentials case, where client_id names the actor and the secret
+// must belong to it). Without it, the key alone identifies the principal
+// (the bearer-token middlewares).
+//
+// Side effect on success: fire-and-forget last_used_at stamp (and, on a
+// legacy hit, the self-heal key_lookup_hash stamp in the same UPDATE).
+// Failures of these updates are swallowed — they're telemetry/optimization,
+// not authorization, and the next successful auth retries them.
+async function findApiKeyByToken(token, options) {
+    let actorId = null;
+    if (options && options.actorId) {
+        actorId = options.actorId;
+    }
+    const lookupHash = tokenLookupHash(token);
+
+    const fastParams = [lookupHash];
+    let fastWhere = 'ak.key_lookup_hash = $1 AND ak.revoked_at IS NULL';
+    if (actorId !== null) {
+        fastParams.push(actorId);
+        fastWhere += ` AND ak.actor_id = $${fastParams.length}`;
+    }
+    const fast = await pool.query(
+        `SELECT ak.id, ak.actor_id, ak.key_hash, ak.key_salt, ac.name AS agent
+         FROM agent_api_keys ak
+         JOIN actors ac ON ac.id = ak.actor_id
+         WHERE ${fastWhere}
+         LIMIT 1`,
+        fastParams
+    );
+    if (fast.rows.length > 0) {
+        const row = fast.rows[0];
+        if (await verify(token, row.key_salt, row.key_hash)) {
+            pool.query(
+                'UPDATE agent_api_keys SET last_used_at = NOW() WHERE id = $1',
+                [row.id]
+            ).catch(() => {});
+            return { id: row.id, actorId: row.actor_id, agent: row.agent };
+        }
+        // Lookup-hash matched but PBKDF2 verify failed (256-bit collision,
+        // vanishingly unlikely) — fail closed rather than fall through to
+        // the legacy scan, same posture as validateSessionToken.
+        return null;
+    }
+
+    // Legacy fallback for keys issued before MEM-136 (key_lookup_hash NULL).
+    const legacyParams = [];
+    let legacyWhere = 'ak.key_lookup_hash IS NULL AND ak.revoked_at IS NULL';
+    if (actorId !== null) {
+        legacyParams.push(actorId);
+        legacyWhere += ` AND ak.actor_id = $${legacyParams.length}`;
+    }
+    const legacy = await pool.query(
+        `SELECT ak.id, ak.actor_id, ak.key_hash, ak.key_salt, ac.name AS agent
+         FROM agent_api_keys ak
+         JOIN actors ac ON ac.id = ak.actor_id
+         WHERE ${legacyWhere}`,
+        legacyParams
+    );
+    for (const row of legacy.rows) {
+        if (await verify(token, row.key_salt, row.key_hash)) {
+            // Self-heal: this key's plaintext is in hand exactly here, so
+            // stamp its lookup hash — next auth takes the indexed path.
+            pool.query(
+                'UPDATE agent_api_keys SET key_lookup_hash = $1, last_used_at = NOW() WHERE id = $2',
+                [lookupHash, row.id]
+            ).catch(() => {});
+            return { id: row.id, actorId: row.actor_id, agent: row.agent };
+        }
+    }
+    return null;
+}
+
+module.exports = { findApiKeyByToken };

--- a/node/api/src/services/api-keys.js
+++ b/node/api/src/services/api-keys.js
@@ -32,6 +32,15 @@ const { verify, tokenLookupHash } = require('./hashing');
 // Failures of these updates are swallowed — they're telemetry/optimization,
 // not authorization, and the next successful auth retries them.
 async function findApiKeyByToken(token, options) {
+    // Shape gate (code_review R1): every key generateKey() has ever issued
+    // is 64 hex chars, so anything else can be rejected before hashing —
+    // and, more importantly, before the legacy PBKDF2 fallback below.
+    // Centralized here so all three callers get it (mcp-auth and oauth had
+    // no local check; mcp-auth in particular used to PBKDF2-scan the table
+    // for ANY non-HMAC bearer string).
+    if (typeof token !== 'string' || !/^[0-9a-f]{64}$/i.test(token)) {
+        return null;
+    }
     let actorId = null;
     if (options && options.actorId) {
         actorId = options.actorId;
@@ -81,6 +90,16 @@ async function findApiKeyByToken(token, options) {
          WHERE ${legacyWhere}`,
         legacyParams
     );
+    // Residual scan visibility (code_review R1): a well-formed-but-invalid
+    // key that misses the fast path PBKDF2-scans whatever legacy rows
+    // remain — self-heal only shrinks that population via SUCCESSFUL auths,
+    // so dormant pre-MEM-136 keys keep this path alive until rotated or
+    // revoked. Log the scan so the remaining fleet is observable in prod;
+    // the follow-up (drop the fallback once the NULL population is zero)
+    // is tracked in shared/tasks/pending.
+    if (legacy.rows.length > 0) {
+        console.warn(`api-keys: legacy fallback scanning ${legacy.rows.length} pre-MEM-136 row(s) (self-heals on successful auth)`);
+    }
     for (const row of legacy.rows) {
         if (await verify(token, row.key_salt, row.key_hash)) {
             // Self-heal: this key's plaintext is in hand exactly here, so


### PR DESCRIPTION
API-key auth (`/v1` middleware, `/mcp` middleware) and OAuth client-secret validation each PBKDF2-verified the presented token against **every** non-revoked `agent_api_keys` row — the same O(N × ~50ms) shape MEM-131 removed from sessions. Async PBKDF2 (HOME-366) keeps it off the event loop, but each candidate row still burns a libuv threadpool slot (default pool: 4).

**MEM-136** adds `agent_api_keys.key_lookup_hash` (deterministic SHA-256) + partial index, mirroring `sessions.token_lookup_hash`. New `services/api-keys.js findApiKeyByToken()` does the indexed single-candidate SELECT → one PBKDF2 verify → fail-closed on lookup-hash collision; all three former scan loops delegate to it (oauth scoped by the client_id actor).

**Deliberate divergence from the sessions pattern:** API keys never expire, so instead of waiting out an expiry the legacy path **self-heals** — a successful legacy verify has the plaintext in hand and stamps `key_lookup_hash` onto its row, moving that key to the indexed path from the next auth onward. New keys insert with the hash populated (registration.js — the only INSERT site).

code_review round 1, both findings applied: the 64-hex shape gate centralized in the service (mcp-auth/oauth previously had no shape check at all — mcp-auth would PBKDF2-scan on any non-HMAC bearer string), and the residual legacy-fallback scan now logs its row count. The remaining tail — dormant pre-MEM-136 keys keeping the fallback scannable by well-formed invalid tokens — is tracked as ZBBS-WORK-390 (`shared/tasks/pending/zbbs-work-390-drop-api-key-legacy-fallback`): drop the fallback once `key_lookup_hash IS NULL AND revoked_at IS NULL` counts zero.

Verified: `node --check` on all touched files; no test suite exists for this middleware. Migration is additive (nullable column + partial index), down migration included.

Ticket: `shared/tasks/pending/zbbs-home-367-api-key-indexed-lookup-hash` (filed by home from the 05-31 incident reviews, picked up by work).

— Work