### PR TITLE
ZBBS-WORK-391: until param on /v1/sim/raw-turns (walk-back cursor)

### DIFF
--- a/node/api/src/routes/sim.js
+++ b/node/api/src/routes/sim.js
@@ -66,6 +66,12 @@ router.post('/sim/conversation-day', apiRoute('sim', 'conversation_day', async (
 //              shared "salem-vendor"/"salem-visitor"); 1:1 for a stateful NPC,
 //              many-to-one for a shared VA
 //   since    — ISO timestamp lower bound on created_at
+//   until    — EXCLUSIVE upper bound on created_at (strictly earlier-than).
+//              The route returns the newest rows first with no offset
+//              pagination, so without this an older episode buried behind 50+
+//              newer turns is unreachable. Exclusive so it works as a cursor:
+//              pass the oldest row's created_at verbatim to fetch the next
+//              page back without repeating the boundary row.
 //   status   — 'success' | 'error'
 //   limit    — default 5, capped at 50 (each turn carries ~5k+14k chars of
 //              prompt, so the default stays small; raise it deliberately)
@@ -116,6 +122,15 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
         }
         conditions.push(`c.created_at >= $${idx++}`);
         params.push(since.toISOString());
+    }
+
+    if (body.until !== undefined && body.until !== null && body.until !== '') {
+        const until = new Date(body.until);
+        if (Number.isNaN(until.getTime())) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'until must be a valid timestamp' } });
+        }
+        conditions.push(`c.created_at < $${idx++}`);
+        params.push(until.toISOString());
     }
 
     if (body.status !== undefined && body.status !== null && body.status !== '') {


### PR DESCRIPTION
POST /v1/sim/raw-turns returns newest-first with no offset pagination, so an older episode buried behind 50+ newer turns is unreachable — hit this live investigating the Prudence over-buy (the 06-07 Ellis Farm episode sat behind a wall of newer turns).

Adds `until`: an **exclusive** `created_at` upper bound mirroring the existing `since` block (bound parameter, validated timestamp). Exclusive so it works as a cursor — pass the oldest row's `created_at` verbatim to fetch the next page back without repeating the boundary row. Reviewed by code_review alongside salem #390 (which ships the matching umbilical `/turns` passthrough); the inclusive-bound nit from that round is what made this exclusive.

— Work