### PR TITLE
ZBBS-WORK-394: request_log takes the last X-Forwarded-For hop, not the first

### DIFF
--- a/node/api/src/middleware/request-log.js
+++ b/node/api/src/middleware/request-log.js
@@ -57,8 +57,22 @@ function requestLog(req, res, next) {
             return;
         }
 
-        // Get client IP (respect X-Forwarded-For from nginx)
-        const ip = req.headers['x-forwarded-for']?.split(',')[0]?.trim() || req.ip || null;
+        // Get client IP from the LAST X-Forwarded-For hop. nginx appends the
+        // address it actually saw after any client-supplied entries
+        // ($proxy_add_x_forwarded_for), so earlier entries are spoofable —
+        // scanners send "X-Forwarded-For: 127.0.0.1" probing for localhost
+        // trust, and taking the first entry let that spoof into the log
+        // (observed 2026-06-10). We sit exactly one trusted proxy deep, so
+        // the last entry is always the real peer nginx connected from.
+        let ip = null;
+        const xff = req.headers['x-forwarded-for'];
+        if (xff) {
+            const hops = xff.split(',');
+            ip = hops[hops.length - 1].trim() || null;
+        }
+        if (!ip) {
+            ip = req.ip || null;
+        }
 
         // Capture response length: Content-Length header, or body in end(), or accumulated write() bytes
         let responseLength = res.getHeader('content-length') ? parseInt(res.getHeader('content-length'), 10) : null;


### PR DESCRIPTION
## Problem

The Recent API Activity panel logged today's ~1,640-request scanner wordlist burst as source `127.0.0.1` — the scanner sent `X-Forwarded-For: 127.0.0.1` (localhost-trust probe) and the middleware takes the first XFF entry, which is client-controlled. nginx (`$proxy_add_x_forwarded_for`) appends the address it actually saw *after* client-supplied entries, so the last hop is the trustworthy one in our exactly-one-proxy deployment.

Display-integrity only — verified nothing in the app makes trust decisions off this field.

## Fix

Take the last XFF hop; junk/missing header falls back to `req.ip`. Spoofed list → real IP; single hop → unchanged; direct local connection → socket address.

code_review: no blocking issues. Its optional array-header guard was deliberately skipped — Node joins duplicate headers into a single string for all non-`set-cookie` headers, so string-or-undefined is the platform contract.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)