### PR TITLE
ZBBS-WORK-396: MCP initialize instructions are pointer-only; payload lives solely in read_instructions

### DIFF
--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -182,9 +182,13 @@ const TOOLS = [
         }
     },
     // --- Instructions tools ---
+    // The "call this at the start of every conversation" line below is load-bearing:
+    // claude.ai drops the `instructions` field from the initialize response
+    // (anthropics/claude-ai-mcp#93), so for those clients this tool description is
+    // the only model-visible nudge to bootstrap. Don't trim it.
     {
         name: 'read_instructions',
-        description: 'Read your startup instructions. Returns the instructions text that was previously saved, or empty if none set.',
+        description: 'Read your startup instructions, context, and identity documents (including your soul document when dream processing is enabled). Call this at the start of every conversation, before anything else.',
         inputSchema: {
             type: 'object',
             properties: {}
@@ -1470,26 +1474,14 @@ const TOOL_HANDLERS = {
 async function createMcpServer(req) {
     const agent = req.mcpAgent;
 
-    // Load agent's startup instructions from DB to return in the initialize response.
-    // This way Claude gets instructions on connect — no tool call needed.
-    let instructions = 'At the start of every conversation, call the read_instructions tool to load your context and instructions. Follow whatever it returns.';
-    try {
-        const result = await pool.query('SELECT startup_instructions FROM agent_configuration WHERE actor_id = $1', [req.mcpActorId]);
-        var agentInst = (result.rows.length > 0 && result.rows[0].startup_instructions) ? result.rows[0].startup_instructions : '';
-        var globalBootstrap = config.get('global_bootstrap') || '';
-        var parts = [];
-        if (globalBootstrap) {
-            parts.push(globalBootstrap);
-        }
-        if (agentInst) {
-            parts.push(agentInst);
-        }
-        if (parts.length > 0) {
-            instructions = parts.join('\n\n');
-        }
-    } catch (err) {
-        // Fall back to generic instructions if DB query fails
-    }
+    // Initialize `instructions` is deliberately just a pointer at read_instructions,
+    // never the payload. Carrying the payload here duplicated it on clients that
+    // honor this field (Claude Code), and an agent's startup_instructions used to
+    // displace this pointer — so those agents were never told to call
+    // read_instructions and silently missed the dream bootstrap + soul, which only
+    // ride the tool. claude.ai drops this field entirely (anthropics/claude-ai-mcp#93);
+    // the read_instructions tool description carries the same pointer for those clients.
+    const instructions = 'At the start of every conversation, call the read_instructions tool to load your context and instructions. Follow whatever it returns.';
 
     const server = new Server(
         { name: 'llm-memory', version: '2.0.0' },


### PR DESCRIPTION
## What

Two changes in `node/api/src/routes/mcp.js`:

1. **`createMcpServer`**: the initialize response's `instructions` field now always sends the one-line pointer ("call the read_instructions tool at the start of every conversation") instead of global_bootstrap + the agent's startup_instructions.
2. **`read_instructions` tool description**: now describes the full payload (instructions, context, soul) and carries the same call-this-first nudge.

## Why

The old initialize block had three defects:

- **Duplication**: clients that honor the field (Claude Code) received the payload at initialize AND again from `read_instructions` — paid in context every session. We only never noticed because work/home have empty startup_instructions.
- **Pointer displacement**: a non-empty `startup_instructions` replaced the fallback pointer, so exactly the agents with instructions set were never told to call `read_instructions` — and silently missed the dream bootstrap + soul, which only ride the tool.
- **claude.ai drops the field entirely** ([anthropics/claude-ai-mcp#93](https://github.com/anthropics/claude-ai-mcp/issues/93), confirmed via [#131](https://github.com/anthropics/claude-ai-mcp/issues/131)): payload delivered via initialize never reached those models at all. Verified empirically against sirius42: her 2.5KB identity doc has ridden initialize since provisioning and never arrived once (api-log shows the connector's ~2h infra refresh cadence, one real session in 7 days, one read_instructions call ever).

End state: payload lives in exactly one place (`read_instructions`, unchanged — bootstrap + startup_instructions + dream bootstrap + soul); the trigger lives in two tiny redundant places (initialize for honoring clients, tool description for claude.ai). The REST pull route `/agent/instructions/read` is untouched.

No migration, no schema change. Syntax-checked with `node --check`.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)