### PR TITLE
ZBBS-WORK-395: harden the admin mermaid note-render path against XSS

### DIFF
--- a/node/api/public/admin/notes.js
+++ b/node/api/public/admin/notes.js
@@ -8,6 +8,22 @@ import svgPanZoom from 'svg-pan-zoom';
 // Initialize mermaid — startOnLoad false since we render manually
 mermaid.initialize({
     startOnLoad: false,
+    // securityLevel 'strict' is mermaid 11.x's default, but pin it explicitly:
+    // it is the layer that DOMPurifies mermaid's own SVG output, and a future
+    // "loose" (the common tweak to enable click handlers / HTML labels) would
+    // silently turn the v-html sink below into stored XSS. Note content is
+    // semi-trusted — agents and the dream pipeline (LLM output) author it.
+    // (ZBBS-WORK-395)
+    securityLevel: 'strict',
+    // Render labels as native SVG <text> instead of <foreignObject> + HTML.
+    // This pairs with the app-level DOMPurify SVG pass at the render site:
+    // with htmlLabels on, flowchart labels are HTML-in-SVG, which the SVG
+    // sanitize profile strips (verified: every flowchart label vanished) and
+    // which DOMPurify's namespace rules won't cleanly re-allow. Pure-SVG
+    // output sanitizes losslessly — verified zero element loss on flowchart,
+    // sequence, and adversarial-payload diagrams. (ZBBS-WORK-395)
+    htmlLabels: false,
+    flowchart: { htmlLabels: false },
     theme: 'base',
     themeVariables: {
         background: '#1c1c30',
@@ -289,7 +305,17 @@ function useNotes({ api, showToast, showConfirm, onEvent }) {
                 // mermaid.render needs a unique ID per call
                 const id = 'mermaid-' + Date.now();
                 const { svg } = await mermaid.render(id, diagram);
-                renderedNoteContent.value = svg;
+                // App-level sanitize before the v-html sink, mirroring the
+                // markdown path below — mermaid's internal DOMPurify pass
+                // (securityLevel 'strict') is a single point of failure with
+                // bypass CVEs in its history. The SVG profiles pass mermaid's
+                // pure-SVG output through losslessly BECAUSE htmlLabels is
+                // off in the initialize above (with HTML labels they'd strip
+                // every flowchart label) — keep the two settings together.
+                // (ZBBS-WORK-395)
+                renderedNoteContent.value = DOMPurify.sanitize(svg, {
+                    USE_PROFILES: { svg: true, svgFilters: true },
+                });
                 // Wait for DOM update, then attach pan+zoom
                 await nextTick();
                 initPanZoom();


### PR DESCRIPTION
## Why

The notes viewer's mermaid path is the one `v-html` sink in the admin SPA fed from semi-trusted data (notes come from agents and the dream pipeline's LLM output). Its only sanitization was mermaid's implicit `securityLevel: 'strict'` default — a single point of failure with bypass CVEs in its history, one careless 'loose' tweak away from stored XSS, with no CSP behind it. Full audit in `shared/tasks/pending/zbbs-work-395-admin-mermaid-xss-hardening` (all other render surfaces verified framework-escaped).

## What

In [notes.js](node/api/public/admin/notes.js), three coupled changes:
- **Pin `securityLevel: 'strict'`** so a regression is a visible diff line.
- **`htmlLabels: false`** — labels become native SVG `<text>`. Required for the next piece: verified against the repo's exact dists in headless Firefox that with HTML labels on, the SVG sanitize profile destroys every flowchart label, and re-allowing `foreignObject` still loses its HTML children to DOMPurify's namespace rules.
- **App-level `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })`** before the v-html assignment — belt-and-suspenders matching the markdown path.

Verified lossless on flowchart / sequence / adversarial-payload diagrams (zero element loss, labels intact, payloads inert as escaped text, DOM scan clean of on*/script/javascript:). `vite build:admin` passes. Frontend-only, no migration.

code_review: 1 round, no blocking issues. CSP for the admin app stays deferred (ticket item 3).

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)