### PR TITLE
ZBBS-WORK-434: spell out relative timestamps in VA history prefixes

### DIFF
--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -1372,19 +1372,28 @@ function isStopUnsupportedError(err) {
     return stopMarkers.some(marker => lower.includes(marker.toLowerCase()));
 }
 
-// Format a timestamp as a compact relative time string.
+// Spell out unit + count, singular at 1 ("1 hour ago", not "1 hours ago").
+function relativeUnit(count, unit) {
+    if (count === 1) return `1 ${unit} ago`;
+    return `${count} ${unit}s ago`;
+}
+
+// Format a timestamp as a relative time string prefixed onto VA chat-history
+// rows. Spelled out rather than compact ([3 hours ago] not [3h]) — weak VA
+// models (llama-3.3-70b) read the words as "this context is stale" more
+// reliably than the dev shorthand.
 function formatRelativeTime(sentAt) {
     const now = Date.now();
     const then = new Date(sentAt).getTime();
     const diffMs = now - then;
     const diffSec = Math.floor(diffMs / 1000);
-    if (diffSec < 60) return '[now]';
+    if (diffSec < 60) return '[just now]';
     const diffMin = Math.floor(diffSec / 60);
-    if (diffMin < 60) return `[${diffMin}m]`;
+    if (diffMin < 60) return `[${relativeUnit(diffMin, 'minute')}]`;
     const diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) return `[${diffHr}h]`;
+    if (diffHr < 24) return `[${relativeUnit(diffHr, 'hour')}]`;
     const diffDay = Math.floor(diffHr / 24);
-    return `[${diffDay}d]`;
+    return `[${relativeUnit(diffDay, 'day')}]`;
 }
 
 function renderDirectChatContext(agent) {


### PR DESCRIPTION
## What

`formatRelativeTime` (`node/api/src/services/virtual-agent.js:1376`) prefixes VA chat-history rows with a relative time. It emitted compact dev shorthand — `[now]` / `[Nm]` / `[Nh]` / `[Nd]`. A weak VA model (llama-3.3-70b) may not read `[3h]` as "this context is stale."

From the 2026-06-12 Prudence visit dig: her prompt carried a 3-hour-old hunger-triage perception prefixed `[3h]` at the top of her message history — easy for the model to treat as current.

## Change

Spell the units out, singular at 1:

| before | after |
|--------|-------|
| `[now]` | `[just now]` |
| `[5m]` | `[5 minutes ago]` (`[1 minute ago]`) |
| `[3h]` | `[3 hours ago]` (`[1 hour ago]`) |
| `[2d]` | `[2 days ago]` (`[1 day ago]`) |

One function, so both call sites are covered:
- active-dialogue `Conversation` block (~line 1530)
- raw-turn history builder (~line 2280)

Both just concatenate the prefix into a display string — no bracket parsing — so the format change is transparent to them.

The adjacent `--- gap: Nh ---` markers are intentionally left as-is (out of scope; the ticket is the per-message timestamp only).

## Verification

- `node --check` clean.
- Functional check of the boundary cases: `0s/30s → [just now]`, `60s/90s → [1 minute ago]`, `1h → [1 hour ago]`, `3h → [3 hours ago]`, `1d → [1 day ago]`, `2d → [2 days ago]`, `30d → [30 days ago]`.

Token cost negligible (~2 tokens × ≤50 history rows vs ~14KB prompts).

— Work