### PR TITLE
LLM-156: add POST /agent/rate-limit (effective per-agent limits)

### DIFF
--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -12,7 +12,7 @@ const sanitize = require('../sanitize');
 const { requireAccess, validateNamespace } = require('../services/namespace-permissions');
 const config = require('../services/config');
 const { apiRoute } = require('../middleware/route-wrapper');
-const { invokeAgent } = require('../services/virtual-agent');
+const { invokeAgent, effectiveRateLimit } = require('../services/virtual-agent');
 const { deleteSessionByToken } = require('../services/sessions');
 const { getVisibleActorIds } = require('../services/actor-visibility');
 // actors service no longer needed — all routes use req.actorId from auth middleware
@@ -945,6 +945,65 @@ router.post('/agent/config', apiRoute('agent', 'agent-config', async (req, res) 
         config_values[row.key] = row.value;
     }
     res.json({ config: config_values });
+}));
+
+// Bounds on a single batch so a caller can't make us resolve an unbounded
+// number (or unbounded-length) of slugs in one request — each is a cached
+// override lookup keyed by the slug.
+const RATE_LIMIT_BATCH_MAX = 200;
+const RATE_LIMIT_SLUG_MAX_LEN = 200;
+
+// POST /agent/rate-limit — return the EFFECTIVE virtual-agent rate-limit
+// config (global config-table defaults merged with each agent's per-agent
+// override) for a batch of agent slugs. The salem-engine fetches this once at
+// startup so it can pace its per-agent tick emission to stay UNDER the limit
+// enforced here, instead of bursting into the cooldown that silently freezes a
+// shared agent's whole NPC pool (LLM-156). Read-only operational config — like
+// /agent/config, any authenticated agent may call it; no admin permission.
+//
+// Window/cooldown are returned in milliseconds (the unit the limiter enforces)
+// so the engine paces against the exact window, never a rounded second.
+//
+// Body:     { agents: string[] }   — VA slugs to resolve (<= RATE_LIMIT_BATCH_MAX)
+// Response: { limits: { "<slug>": { limit, window_ms, cooldown_ms } } }
+router.post('/agent/rate-limit', apiRoute('agent', 'rate-limit', async (req, res) => {
+    if (!req.authenticatedAgent) {
+        return res.status(401).json({
+            error: { code: 'UNAUTHORIZED', message: 'Agent session required' }
+        });
+    }
+    const { agents } = req.body;
+    if (!Array.isArray(agents) || agents.length === 0) {
+        return res.status(400).json({
+            error: { code: 'BAD_REQUEST', message: 'agents must be a non-empty array of agent slugs' }
+        });
+    }
+    if (agents.length > RATE_LIMIT_BATCH_MAX) {
+        return res.status(400).json({
+            error: { code: 'BAD_REQUEST', message: `agents may contain at most ${RATE_LIMIT_BATCH_MAX} slugs` }
+        });
+    }
+    // Validate the whole array up front rather than silently skipping bad
+    // entries — a malformed slug is a client bug worth surfacing, not hiding.
+    for (const slug of agents) {
+        if (typeof slug !== 'string' || slug.length === 0 || slug.length > RATE_LIMIT_SLUG_MAX_LEN) {
+            return res.status(400).json({
+                error: { code: 'BAD_REQUEST', message: `each agent must be a non-empty string of at most ${RATE_LIMIT_SLUG_MAX_LEN} characters` }
+            });
+        }
+    }
+    // Dedupe so a repeated slug doesn't repeat the override lookup.
+    const unique = [...new Set(agents)];
+    const limits = {};
+    for (const slug of unique) {
+        const eff = await effectiveRateLimit(slug);
+        limits[slug] = {
+            limit: eff.limit,
+            window_ms: eff.windowMs,
+            cooldown_ms: eff.cooldownMs,
+        };
+    }
+    res.json({ limits });
 }));
 
 // POST /agent/tick — invoke the authenticated agent's LLM with a perception

--- a/node/api/src/services/virtual-agent-rate-limit.js
+++ b/node/api/src/services/virtual-agent-rate-limit.js
@@ -1,0 +1,25 @@
+// Pure rate-limit config merge (LLM-156), split out of virtual-agent.js so it
+// can be unit-tested without loading the whole virtual-agent stack — that
+// module registers a system handler at load time and pulls in the DB/provider
+// chain. virtual-agent.js's effectiveRateLimit() supplies the live globals plus
+// the agent's per-agent overrides and delegates the precedence to this merge.
+
+// mergeRateLimit layers an agent's per-agent overrides on top of the global
+// defaults. Each override field is independent — an agent may override just the
+// limit and inherit the global window/cooldown. Returns a fresh object; the
+// caller-supplied globals are not mutated.
+function mergeRateLimit(globals, overrides) {
+    const out = {
+        limit: globals.limit,
+        windowMs: globals.windowMs,
+        cooldownMs: globals.cooldownMs,
+    };
+    if (overrides) {
+        if (overrides.limit != null) out.limit = overrides.limit;
+        if (overrides.windowMs != null) out.windowMs = overrides.windowMs;
+        if (overrides.cooldownMs != null) out.cooldownMs = overrides.cooldownMs;
+    }
+    return out;
+}
+
+module.exports = { mergeRateLimit };

--- a/node/api/src/services/virtual-agent-rate-limit.test.js
+++ b/node/api/src/services/virtual-agent-rate-limit.test.js
@@ -1,0 +1,50 @@
+// Tests for mergeRateLimit — the pure global-defaults + per-agent-override
+// merge that effectiveRateLimit() feeds and isRateLimited() enforces (LLM-156).
+// Run with: node --test (from node/api). Uses the built-in node:test runner +
+// node:assert, matching dream.test.js / sim-conversation-distiller.test.js.
+//
+// Lives in its own pure module so the test loads neither the DB pool nor the
+// virtual-agent stack (which registers a system handler at module load).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { mergeRateLimit } = require('./virtual-agent-rate-limit');
+
+const GLOBALS = { limit: 10, windowMs: 60000, cooldownMs: 300000 };
+
+test('no overrides returns the globals unchanged', () => {
+    assert.deepEqual(mergeRateLimit(GLOBALS, null), GLOBALS);
+});
+
+test('a full override replaces every field', () => {
+    const overrides = { limit: 30, windowMs: 60000, cooldownMs: 60000 };
+    assert.deepEqual(mergeRateLimit(GLOBALS, overrides), {
+        limit: 30,
+        windowMs: 60000,
+        cooldownMs: 60000,
+    });
+});
+
+test('each override field is independent — a limit-only override inherits window + cooldown', () => {
+    const overrides = { limit: 40, windowMs: null, cooldownMs: null };
+    assert.deepEqual(mergeRateLimit(GLOBALS, overrides), {
+        limit: 40,
+        windowMs: 60000,
+        cooldownMs: 300000,
+    });
+});
+
+test('a null override field falls through to the global (not coerced to 0)', () => {
+    const overrides = { limit: null, windowMs: null, cooldownMs: 90000 };
+    assert.deepEqual(mergeRateLimit(GLOBALS, overrides), {
+        limit: 10,
+        windowMs: 60000,
+        cooldownMs: 90000,
+    });
+});
+
+test('does not mutate the caller-supplied globals object', () => {
+    const globals = { limit: 10, windowMs: 60000, cooldownMs: 300000 };
+    mergeRateLimit(globals, { limit: 99, windowMs: 1, cooldownMs: 2 });
+    assert.deepEqual(globals, { limit: 10, windowMs: 60000, cooldownMs: 300000 });
+});

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -15,6 +15,7 @@ const config = require('./config');
 const { requireByName } = require('./actors');
 const { canonicalSpeakerId, renderSpeakerLabel, escapeRegExp } = require('./virtual-agent-labels');
 const { personContextSlug } = require('./people-slug');
+const { mergeRateLimit } = require('./virtual-agent-rate-limit');
 
 const MIN_ACTIVITY_MS = 3000;
 
@@ -232,6 +233,21 @@ async function getRateLimitOverrides(agentName) {
     return overrides;
 }
 
+// effectiveRateLimit resolves the rate-limit config the limiter actually
+// enforces for an agent: the global config-table defaults with the agent's
+// per-agent override applied. Returned in ms (window/cooldown) to match the
+// limiter's internal units. Shared by isRateLimited (enforcement) and the
+// /agent/rate-limit route (LLM-156) so the engine paces against the EXACT
+// numbers enforced here, never a drifting second copy of the merge.
+async function effectiveRateLimit(agentName) {
+    const globals = {
+        limit: parseInt(config.get('virtual_agent_rate_limit')),
+        windowMs: parseInt(config.get('virtual_agent_rate_window_seconds')) * 1000,
+        cooldownMs: parseInt(config.get('virtual_agent_cooldown_seconds')) * 1000,
+    };
+    return mergeRateLimit(globals, await getRateLimitOverrides(agentName));
+}
+
 // Check if an agent is rate-limited. Returns true if the call should be blocked.
 //
 // sceneId (optional): the salem per-tick scene id. When this call continues a
@@ -241,18 +257,7 @@ async function getRateLimitOverrides(agentName) {
 // outside sim (human chat, discussions) pass no sceneId and keep per-call
 // counting.
 async function isRateLimited(agentName, sceneId = null) {
-    let limit = parseInt(config.get('virtual_agent_rate_limit'));
-    let windowMs = parseInt(config.get('virtual_agent_rate_window_seconds')) * 1000;
-    let cooldownMs = parseInt(config.get('virtual_agent_cooldown_seconds')) * 1000;
-
-    // Per-agent overrides win when present. Each field is independent —
-    // an agent can override just the limit and inherit the global window.
-    const overrides = await getRateLimitOverrides(agentName);
-    if (overrides) {
-        if (overrides.limit != null) limit = overrides.limit;
-        if (overrides.windowMs != null) windowMs = overrides.windowMs;
-        if (overrides.cooldownMs != null) cooldownMs = overrides.cooldownMs;
-    }
+    const { limit, windowMs, cooldownMs } = await effectiveRateLimit(agentName);
 
     const now = Date.now();
     const cutoffMs = now - windowMs;
@@ -2940,4 +2945,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, effectiveRateLimit, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages };


### PR DESCRIPTION
## What

`POST /agent/rate-limit` — returns the EFFECTIVE per-agent rate-limit config (global config-table defaults merged with each agent's `agent_configuration` override) for a batch of slugs. The salem engine queries it once at startup to pace its per-agent tick emission under the limit enforced here (companion salem PR), instead of bursting a shared VA into its cooldown and freezing the pool.

## Why this shape

- The globals+override merge `isRateLimited` already does is factored into a shared `effectiveRateLimit()`, so the endpoint reports EXACTLY what the limiter enforces — no drifting second copy. The pure `mergeRateLimit()` is split into its own module (`virtual-agent-rate-limit.js`) so it unit-tests without loading the VA/DB stack (virtual-agent.js registers a system handler at load).
- Window/cooldown returned in **ms** — the unit the limiter enforces, so the engine never paces against a rounded second.
- Batch input validated up front (400 on any non-string/empty/over-long element), deduped. Authenticated-only, consistent with `/agent/config` (rate-limit numbers aren't secrets).
- No migration.

Pairs with the salem engine PR for [LLM-156](https://jeffdafoe.atlassian.net/browse/LLM-156). **Deploy this first** (the engine queries it at boot; it fails safe if absent).

## Tests

`mergeRateLimit` precedence unit tests (pure module, `node --test`). The route + resolver are exercised at deploy, per the repo's test convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
