### PR TITLE
LLM-162: dream distiller narrates the labored action_type

### DIFF
--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -43,8 +43,8 @@
 // emitted 'speak' / 'pay' / 'move_to' / 'act' / 'chore' / 'object_refresh';
 // the v2 rewrite renamed the verbs and added a few, so narrateEvent also
 // handles 'spoke' / 'paid' / 'walked' / 'delivered' / 'consumed' /
-// 'took_break' (ZBBS-WORK-376). Unknown kinds get a generic narration so a
-// new engine action_type doesn't silently drop frames.
+// 'took_break' (ZBBS-WORK-376) / 'labored' (LLM-162). Unknown kinds get a
+// generic narration so a new engine action_type doesn't silently drop frames.
 
 const pool = require('../db');
 const { saveNote } = require('./documents');
@@ -276,6 +276,20 @@ function narrateEvent(event, actorName) {
             // rendered as a narration aside when present.
             const reason = sanitizeNarration(p.reason || '');
             return reason ? '(stepped away, ' + reason + ')' : '(stepped away)';
+        }
+        case 'labored': {
+            // LLM-162: a completed solicit_work labor contract (settle-at-
+            // completion). Worker-side row — the worker EARNED the reward
+            // working for the employer. payload: { employer, amount,
+            // duration_min }. The counterpart to the buyer-side 'paid' line;
+            // duration is audit-only (recorded in agent_action_log) and left
+            // out of the narration — the economic fact (who paid, how much) is
+            // what the dream memory needs.
+            // Fall back AFTER sanitizing: a blank/unsafe employer string
+            // sanitizes to '' and would otherwise render "working for " — the
+            // || 'someone' has to come last so it catches that case too.
+            const employer = sanitizeLabel(p.employer || p.recipient || '') || 'someone';
+            return '(earned ' + formatCoins(p.amount) + ' working for ' + employer + ')';
         }
         case 'enter_huddle':
             // Membership marker (ZBBS-094). The engine writes one of

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -74,6 +74,18 @@ test('took_break renders the reason as an aside, or a bare line without one', ()
     assert.equal(narrateEvent({ kind: 'took_break', payload: {} }, ACTOR), '(stepped away)');
 });
 
+test('labored renders the reward earned and the employer (LLM-162)', () => {
+    assert.equal(
+        narrateEvent({ kind: 'labored', payload: { employer: 'Hannah', amount: 5, duration_min: 30 } }, ACTOR),
+        '(earned 5 coins working for Hannah)'
+    );
+    // amount 1 singularizes; a missing employer degrades to "someone".
+    assert.equal(
+        narrateEvent({ kind: 'labored', payload: { amount: 1 } }, ACTOR),
+        '(earned 1 coin working for someone)'
+    );
+});
+
 test('an unknown kind falls back to generic narration (never a dropped frame)', () => {
     assert.equal(narrateEvent({ kind: 'summoned', payload: {} }, ACTOR), '(Ezekiel Crane summoned)');
 });


### PR DESCRIPTION
## Summary
Companion to the salem engine change for Jira LLM-162. The engine now writes a worker-side `labored` `agent_action_log` row on a completed LLM-26 labor contract. This adds the `narrateEvent` case in `sim-conversation-distiller.js` so the dream distillation pipeline renders `(earned N coins working for X)` instead of the generic `(<name> labored)` fallback.

The `|| 'someone'` fallback runs **after** `sanitizeLabel` so a blank/unsafe employer string degrades cleanly instead of rendering `working for ` (per code_review).

## Companion PR
Engine side: jeffdafoe/llm-memory-plugin-salem-1692#631.

## Tests
`labored` distiller case (full + singular-coin / missing-employer degrade). All 12 distiller tests green.

## Review
code_review (GPT-5.4): no blocking issues; the post-sanitization fallback applied per its one minor suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)