### PR TITLE
LLM-213: narrate solicited_work/hired in the sim dream distiller

### DIFF
--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -43,8 +43,9 @@
 // emitted 'speak' / 'pay' / 'move_to' / 'act' / 'chore' / 'object_refresh';
 // the v2 rewrite renamed the verbs and added a few, so narrateEvent also
 // handles 'spoke' / 'paid' / 'walked' / 'delivered' / 'consumed' /
-// 'took_break' (ZBBS-WORK-376) / 'labored' (LLM-162). Unknown kinds get a
-// generic narration so a new engine action_type doesn't silently drop frames.
+// 'took_break' (ZBBS-WORK-376) / 'labored' (LLM-162) / 'solicited_work' /
+// 'hired' (LLM-213). Unknown kinds get a generic narration so a new engine
+// action_type doesn't silently drop frames.
 
 const pool = require('../db');
 const { saveNote } = require('./documents');
@@ -290,6 +291,26 @@ function narrateEvent(event, actorName) {
             // || 'someone' has to come last so it catches that case too.
             const employer = sanitizeLabel(p.employer || p.recipient || '') || 'someone';
             return '(earned ' + formatCoins(p.amount) + ' working for ' + employer + ')';
+        }
+        case 'solicited_work': {
+            // LLM-213: a worker offered to work for the employer (solicit_work
+            // minted a live pending offer). Worker-side row. payload: { employer,
+            // amount, duration_min }. The offer-time counterpart to the settle-
+            // time 'labored' line; no coins move yet, so the beat is the ARRANGEMENT
+            // (who, how much asked). duration is audit-only, left out of narration.
+            // Same post-sanitize '|| someone' fallback as 'labored' so a blank/
+            // unsafe employer still renders a clean line.
+            const employer = sanitizeLabel(p.employer || p.recipient || '') || 'someone';
+            return '(offered to work for ' + employer + ' for ' + formatCoins(p.amount) + ')';
+        }
+        case 'hired': {
+            // LLM-213: an employer took a worker on (accept_work flipped the offer
+            // to Working). Employer-side row. payload: { worker, amount,
+            // duration_min }. No coins move at accept — the reward settles at
+            // completion ('labored') — but the arrangement is the beat the dream
+            // memory needs.
+            const worker = sanitizeLabel(p.worker || p.recipient || '') || 'someone';
+            return '(hired ' + worker + ' for ' + formatCoins(p.amount) + ')';
         }
         case 'enter_huddle':
             // Membership marker (ZBBS-094). The engine writes one of

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -86,6 +86,30 @@ test('labored renders the reward earned and the employer (LLM-162)', () => {
     );
 });
 
+test('solicited_work renders the offer to the employer for the reward (LLM-213)', () => {
+    assert.equal(
+        narrateEvent({ kind: 'solicited_work', payload: { employer: 'Hannah', amount: 4, duration_min: 240 } }, ACTOR),
+        '(offered to work for Hannah for 4 coins)'
+    );
+    // amount 1 singularizes; a missing employer degrades to "someone".
+    assert.equal(
+        narrateEvent({ kind: 'solicited_work', payload: { amount: 1 } }, ACTOR),
+        '(offered to work for someone for 1 coin)'
+    );
+});
+
+test('hired renders the worker taken on and the reward (LLM-213)', () => {
+    assert.equal(
+        narrateEvent({ kind: 'hired', payload: { worker: 'Hannah', amount: 4, duration_min: 240 } }, ACTOR),
+        '(hired Hannah for 4 coins)'
+    );
+    // a missing worker degrades to "someone".
+    assert.equal(
+        narrateEvent({ kind: 'hired', payload: { amount: 6 } }, ACTOR),
+        '(hired someone for 6 coins)'
+    );
+});
+
 test('an unknown kind falls back to generic narration (never a dropped frame)', () => {
     assert.equal(narrateEvent({ kind: 'summoned', payload: {} }, ACTOR), '(Ezekiel Crane summoned)');
 });


### PR DESCRIPTION
Companion to salem-engine [PR #678](https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/678) (LLM-213), which adds two durable `agent_action_log` action_types for the labor conversational beats — `solicited_work` (a worker's `solicit_work`) and `hired` (an employer's `accept_work`).

## Why this half
`LoadDayEvents` forwards an actor's own rows to the daily sim-conversation push with **no action_type filter**, so the new rows reach `narrateEvent` — where they'd hit the generic `default` fallback (`(Anne Walker solicited_work)`), dropping the employer/worker + reward the row exists to carry. Flagged by code_review on the engine PR.

## Change
Two `narrateEvent` cases, mirroring the settle-time `labored` line:
- `solicited_work` (worker side): `(offered to work for <employer> for N coins)` — payload `{ employer, amount, duration_min }`.
- `hired` (employer side): `(hired <worker> for N coins)` — payload `{ worker, amount, duration_min }`.

Same post-sanitize `|| 'someone'` fallback as `labored`; `duration_min` is audit-only, left out of narration.

## Tests
Added for both cases (incl. singularized "1 coin" + missing-counterparty degrade). `narrateEvent` unit suite green (`node --test`).

— Work
