### PR TITLE
LLM-237: split parallel tool_calls at replay time + fast retry cadence for deterministic 4xx

### DIFF
--- a/node/api/scripts/test-build-tool-use-messages.js
+++ b/node/api/scripts/test-build-tool-use-messages.js
@@ -42,7 +42,9 @@ const msgs = buildToolUseMessages(history, NPC);
 check('4 messages', msgs.length === 4);
 // 1st perception: [3h] prefix, no gap (first row).
 check('msg0 is user', msgs[0].role === 'user');
-check('msg0 prefixed with [3h]', msgs[0].content.startsWith('[3h]\n# Your turn'));
+// WORK-434 spelled out relative timestamps ([3h] → [3 hours ago]); these
+// expectations were stale until LLM-237 touched this file.
+check('msg0 prefixed with [3 hours ago]', msgs[0].content.startsWith('[3 hours ago]\n# Your turn'));
 check('msg0 has no gap marker (first row)', !msgs[0].content.includes('gap:'));
 // assistant: salience paraphrase, NO time prefix.
 check('msg1 is assistant', msgs[1].role === 'assistant');
@@ -53,7 +55,7 @@ check('msg1 NOT time-prefixed', !msgs[1].content.startsWith('['));
 check('msg2 is tool', msgs[2].role === 'tool' && msgs[2].tool_call_id === 't1' && msgs[2].content === '[ok]');
 // 2nd perception: gap marker (~3h) + [5m].
 check('msg3 is user', msgs[3].role === 'user');
-check('msg3 has the gap marker', msgs[3].content.startsWith('--- gap: 3h ---\n[5m]\n# Your turn'));
+check('msg3 has the gap marker', msgs[3].content.startsWith('--- gap: 3h ---\n[5 minutes ago]\n# Your turn'));
 
 // A perception with no sent_at -> no prefix (graceful).
 const noTime = buildToolUseMessages([{ from_agent: 'salem-engine', message: '# Your turn\nno time' }], NPC);
@@ -70,6 +72,64 @@ const rejected = buildToolUseMessages([
 ], NPC);
 check('rejected quote-take: bought paraphrase', rejected[1].content === '(I bought Meat from John Ellis and ate it on the spot)');
 check('rejected quote-take: [error] result directly follows', rejected[2].role === 'tool' && rejected[2].tool_call_id === 't9' && rejected[2].content === '[error: quote expired]');
+
+// LLM-237: a parallel-tool-call turn (Llama's normal speak+done shape) is
+// split at replay time into one assistant message per call, each directly
+// followed by its id-matched tool result — vLLM-based OpenRouter upstreams
+// 400 any request whose history has an assistant message with >1 tool_calls.
+const parallel = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(10) },
+    { from_agent: NPC, message: '', tool_calls: [
+        { id: 'p1', name: 'speak', input: { text: 'Fresh bread today!' } },
+        { id: 'p2', name: 'done', input: {} },
+    ], sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[ok] You said: "Fresh bread today!"', tool_call_id: 'p1', sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[done]', tool_call_id: 'p2', sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '# Your turn again', sent_at: agoISO(8) },
+], NPC);
+check('parallel: 6 messages (1 user + 2 assistant/tool pairs + 1 user)', parallel.length === 6);
+check('parallel: piece 1 is assistant with ONLY the speak call',
+    parallel[1].role === 'assistant' && parallel[1].tool_calls.length === 1 && parallel[1].tool_calls[0].function.name === 'speak');
+check('parallel: piece 1 carries the speak paraphrase', parallel[1].content === '(I said aloud: "Fresh bread today!")');
+check('parallel: speak result directly follows its piece',
+    parallel[2].role === 'tool' && parallel[2].tool_call_id === 'p1');
+check('parallel: piece 2 is assistant with ONLY the done call',
+    parallel[3].role === 'assistant' && parallel[3].tool_calls.length === 1 && parallel[3].tool_calls[0].function.name === 'done');
+check('parallel: done has no paraphrase (empty content)', parallel[3].content === '');
+check('parallel: done result directly follows its piece',
+    parallel[4].role === 'tool' && parallel[4].tool_call_id === 'p2' && parallel[4].content === '[done]');
+check('parallel: trailing perception intact', parallel[5].role === 'user' && parallel[5].content.includes('# Your turn again'));
+
+// Model-authored text on a parallel turn stays on the FIRST piece only —
+// later pieces get their own paraphrase (or empty), never a duplicate.
+const parallelText = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(10) },
+    { from_agent: NPC, message: 'Let me think on that.', tool_calls: [
+        { id: 'q1', name: 'speak', input: { text: 'Aye.' } },
+        { id: 'q2', name: 'done', input: {} },
+    ], sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[ok]', tool_call_id: 'q1', sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[done]', tool_call_id: 'q2', sent_at: agoISO(9) },
+], NPC);
+check('parallel+text: model text on first piece', parallelText[1].content === 'Let me think on that.');
+check('parallel+text: second piece empty, not duplicated', parallelText[3].content === '');
+
+// A missing tool result (generation raced the engine's result writes) gets a
+// synthesized neutral "[ok]" so no split piece carries a dangling tool_call.
+const missingResult = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(10) },
+    { from_agent: NPC, message: '', tool_calls: [
+        { id: 'm1', name: 'speak', input: { text: 'Hm.' } },
+        { id: 'm2', name: 'done', input: {} },
+    ], sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[ok]', tool_call_id: 'm1', sent_at: agoISO(9) },
+], NPC);
+check('missing result: still fully paired (5 messages)', missingResult.length === 5);
+check('missing result: synthesized [ok] for the unanswered call',
+    missingResult[4].role === 'tool' && missingResult[4].tool_call_id === 'm2' && missingResult[4].content === '[ok]');
+
+// Single-call turns are untouched by the split (shape identical to before).
+check('single-call turn untouched', msgs[1].tool_calls.length === 1 && msgs[2].role === 'tool');
 
 if (failed > 0) {
     console.log('FAILED ' + failed + ' / ' + (passed + failed));

--- a/node/api/scripts/test-build-tool-use-messages.js
+++ b/node/api/scripts/test-build-tool-use-messages.js
@@ -115,7 +115,8 @@ check('parallel+text: model text on first piece', parallelText[1].content === 'L
 check('parallel+text: second piece empty, not duplicated', parallelText[3].content === '');
 
 // A missing tool result (generation raced the engine's result writes) gets a
-// synthesized neutral "[ok]" so no split piece carries a dangling tool_call.
+// synthesized neutral, non-affirming result so no split piece carries a
+// dangling tool_call.
 const missingResult = buildToolUseMessages([
     { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(10) },
     { from_agent: NPC, message: '', tool_calls: [
@@ -125,11 +126,27 @@ const missingResult = buildToolUseMessages([
     { from_agent: 'salem-engine', message: '[ok]', tool_call_id: 'm1', sent_at: agoISO(9) },
 ], NPC);
 check('missing result: still fully paired (5 messages)', missingResult.length === 5);
-check('missing result: synthesized [ok] for the unanswered call',
-    missingResult[4].role === 'tool' && missingResult[4].tool_call_id === 'm2' && missingResult[4].content === '[ok]');
+check('missing result: synthesized placeholder for the unanswered call',
+    missingResult[4].role === 'tool' && missingResult[4].tool_call_id === 'm2' && missingResult[4].content === '[no result recorded]');
 
 // Single-call turns are untouched by the split (shape identical to before).
 check('single-call turn untouched', msgs[1].tool_calls.length === 1 && msgs[2].role === 'tool');
+
+// Stored tool_call input may be a JSON STRING (provider-dependent), not an
+// object. The OpenAI-shape conversion passes strings through unchanged, so
+// the salience mirror (which now parses function.arguments) must produce the
+// same paraphrase as it did when it read the neutral row directly.
+const stringInput = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(10) },
+    { from_agent: NPC, message: '', tool_calls: [
+        { id: 's1', name: 'speak', input: '{"text":"Fresh bread today!"}' },
+    ], sent_at: agoISO(9) },
+    { from_agent: 'salem-engine', message: '[ok]', tool_call_id: 's1', sent_at: agoISO(9) },
+], NPC);
+check('string input: paraphrase survives the OpenAI-shape round trip',
+    stringInput[1].content === '(I said aloud: "Fresh bread today!")');
+check('string input: arguments not double-encoded',
+    stringInput[1].tool_calls[0].function.arguments === '{"text":"Fresh bread today!"}');
 
 if (failed > 0) {
     console.log('FAILED ' + failed + ' / ' + (passed + failed));

--- a/node/api/src/services/providers/anthropic.js
+++ b/node/api/src/services/providers/anthropic.js
@@ -329,7 +329,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             const errorText = await response.text();
             logProvider('api-error', { provider: 'anthropic', model, status: response.status, error: errorText });
-            throw new Error(`Anthropic API error ${response.status}: ${errorText}`);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            const apiError = new Error(`Anthropic API error ${response.status}: ${errorText}`);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         const data = await response.json();

--- a/node/api/src/services/providers/google.js
+++ b/node/api/src/services/providers/google.js
@@ -335,7 +335,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             const errorText = await response.text();
             logProvider('api-error', { provider: 'google', model, status: response.status, error: errorText });
-            throw new Error(`Gemini API error ${response.status}: ${errorText}`);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            const apiError = new Error(`Gemini API error ${response.status}: ${errorText}`);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         const data = await response.json();

--- a/node/api/src/services/providers/openai.js
+++ b/node/api/src/services/providers/openai.js
@@ -337,7 +337,11 @@ async function callResponses(model, apiKey, conf, fullMessages, opts) {
     if (!response.ok) {
         const errorText = await response.text();
         logProvider('api-error', { provider: 'openai', model, endpoint: 'responses', status: response.status, error: errorText });
-        throw new Error(`OpenAI API error ${response.status}: ${errorText}`);
+        // status rides on the error so retryWithBackoff can pick a
+        // cadence by error class (deterministic 4xx vs outage/429).
+        const apiError = new Error(`OpenAI API error ${response.status}: ${errorText}`);
+        apiError.status = response.status;
+        throw apiError;
     }
 
     const data = await response.json();
@@ -511,7 +515,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             const errorText = await response.text();
             logProvider('api-error', { provider: 'openai', model, status: response.status, error: errorText });
-            throw new Error(`OpenAI API error ${response.status}: ${errorText}`);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            const apiError = new Error(`OpenAI API error ${response.status}: ${errorText}`);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         const data = await response.json();

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -212,7 +212,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             var errorText = await response.text();
             logProvider('api-error', { provider: 'openrouter', model, status: response.status, error: errorText });
-            throw new Error('OpenRouter API error ' + response.status + ': ' + errorText);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            var apiError = new Error('OpenRouter API error ' + response.status + ': ' + errorText);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         var data = await response.json();

--- a/node/api/src/services/providers/perplexity.js
+++ b/node/api/src/services/providers/perplexity.js
@@ -179,7 +179,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             const errorText = await response.text();
             logProvider('api-error', { provider: 'perplexity', model, status: response.status, error: errorText });
-            throw new Error(`Perplexity API error ${response.status}: ${errorText}`);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            const apiError = new Error(`Perplexity API error ${response.status}: ${errorText}`);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         const data = await response.json();

--- a/node/api/src/services/providers/xai.js
+++ b/node/api/src/services/providers/xai.js
@@ -258,7 +258,11 @@ function createCall(model, apiKey, configuration) {
         if (!response.ok) {
             const errorText = await response.text();
             logProvider('api-error', { provider: 'xai', model, status: response.status, error: errorText });
-            throw new Error(`xAI API error ${response.status}: ${errorText}`);
+            // status rides on the error so retryWithBackoff can pick a
+            // cadence by error class (deterministic 4xx vs outage/429).
+            const apiError = new Error(`xAI API error ${response.status}: ${errorText}`);
+            apiError.status = response.status;
+            throw apiError;
         }
 
         const data = await response.json();

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -103,11 +103,35 @@ async function setAgentStatus(agentName, status) {
 // Optional onFirstFailure(err, retryInfo) callback fires once after the first
 // attempt fails, before the backoff sleep — lets callers send immediate feedback
 // (e.g. "retrying, please wait") so the sender isn't left in the dark.
+// Parse a comma-separated seconds cadence ("60,600,3600") into millisecond
+// delays, falling back to the default when the config value is missing or
+// yields no usable numbers (a garbage setting must not become a NaN sleep).
+function parseBackoffCadence(str, fallback) {
+    const parsed = String(str || fallback)
+        .split(',')
+        .map(s => parseInt(s.trim(), 10) * 1000)
+        .filter(n => Number.isFinite(n) && n >= 0);
+    if (parsed.length > 0) {
+        return parsed;
+    }
+    return String(fallback).split(',').map(s => parseInt(s.trim(), 10) * 1000);
+}
+
+// Sum the delays a retry run would actually sleep: retryCount draws from the
+// cadence, clamped to its last entry when the cadence is shorter than the
+// retry count (mirrors the delay lookup in retryWithBackoff).
+function totalDelayMsForCadence(cadence, retryCount) {
+    let total = 0;
+    for (let n = 0; n < retryCount; n++) {
+        total += cadence[Math.min(n, cadence.length - 1)];
+    }
+    return total;
+}
+
 async function retryWithBackoff(agentName, fn, onFirstFailure) {
     // Retry count is derived from the backoff cadence — each entry = one retry.
     // e.g. "300,600,3600" means 3 retries at 5m, 10m, 1h intervals.
-    const backoffStr = config.get('virtual_agent_retry_backoff') || '60,600,3600';
-    const backoffs = backoffStr.split(',').map(s => parseInt(s.trim()) * 1000);
+    const backoffs = parseBackoffCadence(config.get('virtual_agent_retry_backoff'), '60,600,3600');
     // Deterministic client errors (4xx, except 429) retry on a much shorter
     // cadence. The main cadence is sized for provider outages and rate
     // limits; a 4xx means the provider REJECTED the request, and for
@@ -116,8 +140,7 @@ async function retryWithBackoff(agentName, fn, onFirstFailure) {
     // usually succeeds and a 5-minute wait is pure NPC dead air. 429 stays
     // on the slow cadence — retrying a rate limit quickly makes it worse.
     // Providers attach the HTTP status to thrown API errors as err.status.
-    const clientErrorStr = config.get('virtual_agent_retry_backoff_client_error') || '5,15,60';
-    const clientErrorBackoffs = clientErrorStr.split(',').map(s => parseInt(s.trim()) * 1000);
+    const clientErrorBackoffs = parseBackoffCadence(config.get('virtual_agent_retry_backoff_client_error'), '5,15,60');
 
     let lastError;
     for (let attempt = 0; attempt <= backoffs.length; attempt++) {
@@ -141,9 +164,14 @@ async function retryWithBackoff(agentName, fn, onFirstFailure) {
                 const delay = cadence[Math.min(attempt, cadence.length - 1)];
                 logVA('retry-backoff', { agent: agentName, attempt: attempt + 1, retries: backoffs.length, delayMs: delay, error: err.message });
 
-                // Notify caller on first failure so they can send feedback to the sender
+                // Notify caller on first failure so they can send feedback
+                // to the sender. Total wait sums the delays the run would
+                // ACTUALLY sleep — backoffs.length draws from the chosen
+                // cadence with last-entry clamping — not the cadence's raw
+                // entries, which under-reports when the cadence is shorter
+                // than the retry count.
                 if (attempt === 0 && onFirstFailure) {
-                    const totalSeconds = Math.ceil(cadence.reduce((a, b) => a + b, 0) / 1000);
+                    const totalSeconds = Math.ceil(totalDelayMsForCadence(cadence, backoffs.length) / 1000);
                     try {
                         await onFirstFailure(err, { retriesRemaining: backoffs.length, totalSeconds });
                     } catch (cbErr) {
@@ -2310,9 +2338,9 @@ function buildToolUseMessages(history, npcAgentName) {
 // The engine writes a tool-result row for every tool_call id (including
 // "[done]" and "[skipped: post_terminal]"), so id-matched interleaving is
 // normally lossless. If a result is missing (e.g. a generation triggered
-// while later results were still in flight), a neutral "[ok]" result is
-// synthesized so no piece carries a dangling tool_call — strict providers
-// reject unanswered tool_calls too.
+// while later results were still in flight), a neutral "[no result
+// recorded]" result is synthesized so no piece carries a dangling
+// tool_call — strict providers reject unanswered tool_calls too.
 function splitParallelToolCallTurns(messages) {
     const out = [];
     let i = 0;
@@ -2350,7 +2378,10 @@ function splitParallelToolCallTurns(messages) {
                 out.push(result);
                 resultsById.delete(toolCall.id);
             } else {
-                out.push({ role: 'tool', tool_call_id: toolCall.id, content: '[ok]' });
+                // Neutral, non-affirming placeholder — "[ok]" could falsely
+                // confirm an action whose real result arrives only in the
+                // next generation's history.
+                out.push({ role: 'tool', tool_call_id: toolCall.id, content: '[no result recorded]' });
             }
         });
 

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -108,6 +108,16 @@ async function retryWithBackoff(agentName, fn, onFirstFailure) {
     // e.g. "300,600,3600" means 3 retries at 5m, 10m, 1h intervals.
     const backoffStr = config.get('virtual_agent_retry_backoff') || '60,600,3600';
     const backoffs = backoffStr.split(',').map(s => parseInt(s.trim()) * 1000);
+    // Deterministic client errors (4xx, except 429) retry on a much shorter
+    // cadence. The main cadence is sized for provider outages and rate
+    // limits; a 4xx means the provider REJECTED the request, and for
+    // OpenRouter that is often a routing lottery (e.g. landing on a strict
+    // single-tool-call upstream — LLM-237) where an immediate re-roll
+    // usually succeeds and a 5-minute wait is pure NPC dead air. 429 stays
+    // on the slow cadence — retrying a rate limit quickly makes it worse.
+    // Providers attach the HTTP status to thrown API errors as err.status.
+    const clientErrorStr = config.get('virtual_agent_retry_backoff_client_error') || '5,15,60';
+    const clientErrorBackoffs = clientErrorStr.split(',').map(s => parseInt(s.trim()) * 1000);
 
     let lastError;
     for (let attempt = 0; attempt <= backoffs.length; attempt++) {
@@ -121,12 +131,19 @@ async function retryWithBackoff(agentName, fn, onFirstFailure) {
             lastError = err;
             if (attempt < backoffs.length) {
                 await setAgentStatus(agentName, 'degraded');
-                const delay = backoffs[attempt];
+                // Pick the cadence per-failure: a run can start as a 400 and
+                // later hit a 429, so each sleep matches the error it follows.
+                // The retry COUNT always comes from the main cadence length.
+                let cadence = backoffs;
+                if (typeof err.status === 'number' && err.status >= 400 && err.status < 500 && err.status !== 429) {
+                    cadence = clientErrorBackoffs;
+                }
+                const delay = cadence[Math.min(attempt, cadence.length - 1)];
                 logVA('retry-backoff', { agent: agentName, attempt: attempt + 1, retries: backoffs.length, delayMs: delay, error: err.message });
 
                 // Notify caller on first failure so they can send feedback to the sender
                 if (attempt === 0 && onFirstFailure) {
-                    const totalSeconds = Math.ceil(backoffs.reduce((a, b) => a + b, 0) / 1000);
+                    const totalSeconds = Math.ceil(cadence.reduce((a, b) => a + b, 0) / 1000);
                     try {
                         await onFirstFailure(err, { retriesRemaining: backoffs.length, totalSeconds });
                     } catch (cbErr) {
@@ -2234,41 +2251,6 @@ function buildToolUseMessages(history, npcAgentName) {
                         },
                     };
                 });
-                // Salience: prior speak/move_to/chore tool_calls carry
-                // semantically-meaningful payloads (the spoken text, the
-                // destination, the chore type). When this row was emitted
-                // the model had it as a fresh decision; when REPLAYED in
-                // history, the payload sits inside tool_calls.arguments
-                // JSON, which the language-modeling pass treats as "an
-                // action I took" rather than "speech I said" / "place I
-                // walked to". That makes it weak as a "do not repeat
-                // yourself" signal — observed empirically as NPC
-                // tavernkeepers re-greeting the same person across
-                // adjacent turns with near-identical phrasing.
-                //
-                // Mirror the payload into `content` as a brief
-                // first-person paraphrase. tool_calls structure is
-                // preserved (protocol-correct, paired with tool results
-                // by tool_call_id); content adds the natural-language
-                // copy so prior speeches/moves are salient as language
-                // alongside other agents' speech in the perception's
-                // "Recent:" block. Skip look_around (tool result IS the
-                // information) and done (no payload worth surfacing).
-                if (!msg.content) {
-                    const lines = [];
-                    for (const tc of raw) {
-                        const input = (typeof tc.input === 'string')
-                            ? safeParseJSON(tc.input)
-                            : (tc.input || {});
-                        const paraphrase = paraphraseToolCall(tc.name, input);
-                        if (paraphrase) {
-                            lines.push(paraphrase);
-                        }
-                    }
-                    if (lines.length > 0) {
-                        msg.content = lines.join('\n');
-                    }
-                }
             }
             messages.push(msg);
         } else if (row.tool_call_id) {
@@ -2300,6 +2282,127 @@ function buildToolUseMessages(history, npcAgentName) {
             prevSentAt = row.sent_at;
         }
     }
+    // Two replay-time post-passes (order matters): split parallel tool_calls
+    // into single-call pieces first, then mirror each call's payload into its
+    // piece's content. Both operate on the OpenAI-shape messages, not the
+    // stored rows — nothing is persisted.
+    return mirrorToolCallSalience(splitParallelToolCallTurns(messages));
+}
+
+// Split a replayed assistant turn carrying MULTIPLE tool_calls into one
+// assistant message per call, each immediately followed by its own tool
+// result (matched by tool_call_id).
+//
+// Why: Llama-3.3 legitimately emits parallel tool calls — speak + done in
+// one turn is the engine tick protocol's normal shape — and providers that
+// support that serve the generating request fine. But OpenRouter routes
+// EVERY request independently across upstream providers, and several
+// vLLM-based upstreams (Nebius, AkashML, WandB) reject any request whose
+// message history contains an assistant message with more than one
+// tool_call: "This model only supports single tool-calls at once!". When
+// the remaining upstreams are rate-limited, OpenRouter exhausts the list
+// and returns a hard 400 — so one permissive provider's response poisons
+// the replayed history for every follow-up request that routes strictly
+// (LLM-237: observed live as minutes of NPC dead air while the call sat in
+// retry backoff). Splitting at replay time keeps the stored row faithful
+// while making the outbound request renderable by every upstream.
+//
+// The engine writes a tool-result row for every tool_call id (including
+// "[done]" and "[skipped: post_terminal]"), so id-matched interleaving is
+// normally lossless. If a result is missing (e.g. a generation triggered
+// while later results were still in flight), a neutral "[ok]" result is
+// synthesized so no piece carries a dangling tool_call — strict providers
+// reject unanswered tool_calls too.
+function splitParallelToolCallTurns(messages) {
+    const out = [];
+    let i = 0;
+    while (i < messages.length) {
+        const msg = messages[i];
+        const isParallelTurn = msg.role === 'assistant'
+            && Array.isArray(msg.tool_calls)
+            && msg.tool_calls.length > 1;
+        if (!isParallelTurn) {
+            out.push(msg);
+            i++;
+            continue;
+        }
+
+        // Collect the run of tool results that follows this turn, keyed by
+        // the tool_call id each one answers.
+        const resultsById = new Map();
+        let j = i + 1;
+        while (j < messages.length && messages[j].role === 'tool') {
+            resultsById.set(messages[j].tool_call_id, messages[j]);
+            j++;
+        }
+
+        msg.tool_calls.forEach(function (toolCall, index) {
+            const piece = { role: 'assistant', content: '', tool_calls: [toolCall] };
+            if (index === 0) {
+                // Model-authored text (rare — Llama usually emits empty
+                // content alongside tool calls) belongs to the turn as a
+                // whole; keep it on the first piece only.
+                piece.content = msg.content || '';
+            }
+            out.push(piece);
+            const result = resultsById.get(toolCall.id);
+            if (result) {
+                out.push(result);
+                resultsById.delete(toolCall.id);
+            } else {
+                out.push({ role: 'tool', tool_call_id: toolCall.id, content: '[ok]' });
+            }
+        });
+
+        // Defensive: a trailing tool result answering none of this turn's
+        // calls shouldn't exist, but keep it rather than silently dropping
+        // history. Map preserves insertion order.
+        for (const leftover of resultsById.values()) {
+            out.push(leftover);
+        }
+
+        i = j;
+    }
+    return out;
+}
+
+// Salience: prior speak/move_to/chore tool_calls carry semantically-
+// meaningful payloads (the spoken text, the destination, the chore type).
+// When the row was emitted the model had it as a fresh decision; when
+// REPLAYED in history, the payload sits inside tool_calls.arguments JSON,
+// which the language-modeling pass treats as "an action I took" rather than
+// "speech I said" / "place I walked to". That makes it weak as a "do not
+// repeat yourself" signal — observed empirically as NPC tavernkeepers
+// re-greeting the same person across adjacent turns with near-identical
+// phrasing.
+//
+// Mirror the payload into `content` as a brief first-person paraphrase.
+// tool_calls structure is preserved (protocol-correct, paired with tool
+// results by tool_call_id); content adds the natural-language copy so prior
+// speeches/moves are salient as language alongside other agents' speech in
+// the perception's "Recent:" block. Skip look_around (tool result IS the
+// information) and done (no payload worth surfacing). Runs AFTER
+// splitParallelToolCallTurns so each split piece gets the paraphrase of its
+// own call; model-authored content is never overwritten.
+function mirrorToolCallSalience(messages) {
+    for (const msg of messages) {
+        if (msg.role !== 'assistant' || !Array.isArray(msg.tool_calls) || msg.content) {
+            continue;
+        }
+        const lines = [];
+        for (const toolCall of msg.tool_calls) {
+            const paraphrase = paraphraseToolCall(
+                toolCall.function.name,
+                safeParseJSON(toolCall.function.arguments)
+            );
+            if (paraphrase) {
+                lines.push(paraphrase);
+            }
+        }
+        if (lines.length > 0) {
+            msg.content = lines.join('\n');
+        }
+    }
     return messages;
 }
 
@@ -2329,7 +2432,9 @@ function safeParseJSON(s) {
 // role: user (a perception/text from engine→VA, never a tool_result —
 // tool_results are role: tool in OpenAI shape). Tool-use protocol
 // completeness inside the kept window is preserved by buildToolUseMessages
-// itself (each row maps 1:1, no slicing); this only handles the boundary.
+// itself (rows map to messages with no slicing; the parallel-tool-call
+// split keeps every call paired with its result); this only handles the
+// boundary.
 function trimHeadToUserMessage(messages) {
     let firstUser = 0;
     while (firstUser < messages.length && messages[firstUser].role !== 'user') {


### PR DESCRIPTION
## Problem

Live incident (huddle `hud-b698da5b`, 2026-07-03 14:16–14:27 UTC): two OpenRouter 400s for `zbbs-josiah-thorne`, each parking the NPC in a 5-minute retry backoff — minutes of dead air mid-negotiation with Patience Walker.

Llama-3.3 emits parallel tool calls per turn (`speak`+`done`, `accept_pay`+`speak`+`done` — the engine tick protocol's normal shape). `buildToolUseMessages` replayed that assistant row as ONE message with `tool_calls: [N]`, and several vLLM-based OpenRouter upstreams (Nebius, AkashML, WandB) reject any request whose history contains an assistant message with more than one tool_call ("This model only supports single tool-calls at once!"). With the remaining upstreams rate-limited, OpenRouter exhausts its list and returns a hard 400 — a provider-routing lottery where one permissive provider's response poisons the history for every follow-up request.

## Fix

**1. Replay-time split** (`virtual-agent.js`): `splitParallelToolCallTurns` turns a multi-tool-call assistant turn into one assistant message per call, each directly followed by its id-matched `role:tool` result (verified in prod that the engine writes a result row for every tool_call id, including `[done]` and `[skipped: post_terminal]`). A defensively-missing result gets a synthesized `[no result recorded]` so no piece carries a dangling tool_call. The salience paraphrase mirroring moves to a per-piece post-pass (`mirrorToolCallSalience`). Nothing is persisted — stored rows stay faithful.

**2. Fast retry for deterministic 4xx**: all providers attach `err.status` to thrown API errors; `retryWithBackoff` uses a short cadence for 4xx-except-429 (config `virtual_agent_retry_backoff_client_error`, default `5,15,60`s) instead of the outage cadence. 429 stays slow. Cadence configs are parse-hardened against garbage values.

## Testing

`test-build-tool-use-messages.js` extended: split pairing, first-piece model text, missing-result synthesis, stored-string input round-trip, single-call untouched — 29/29. Two expectations stale since WORK-434's `[3h]` → `[3 hours ago]` format change fixed. All other standalone suites green (20, 14, 636, 56, 12).

Reviewed by code_review: totalSeconds under-report + cadence hardening + non-affirming placeholder applied; string-input double-encode concern refuted with pinned tests.

Jira: LLM-237

🤖 Generated with [Claude Code](https://claude.com/claude-code)