### PR TITLE
LLM-283: drop unmapped action_types from dream distillation

### DIFF
--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -372,10 +372,18 @@ function narrateEvent(event, actorName) {
             // raw-payload format.
             return null;
         default:
-            // Unknown action_type — surface as generic narration so the
-            // line isn't silently lost. Better than dropping; signals
-            // that a new engine action_type needs a real mapping here.
-            return '(' + actorName + ' ' + sanitizeLabel(event.kind) + ')';
+            // A durable action_type with no narration mapping. Do NOT surface it
+            // as generic "(Name kind)" text: loadDayEventsSQL pushes ALL of an
+            // actor's durable rows regardless of type, so generic narration leaks
+            // feed/audit-only beats into NPC dream memory. That is exactly how
+            // gathered (LLM-273) and stayed_open (ZBBS-WORK-387) were already
+            // producing "(Josiah gathered)" noise, and how LLM-283's offered /
+            // declined / countered would too. Drop it from the dream transcript
+            // and log so an unmapped kind surfaces in server logs, not in
+            // production dreams. A beat that SHOULD feed dreams gets an explicit
+            // case above.
+            log('sim-distill-unmapped-kind', { kind: event.kind, speaker: event.speaker });
+            return null;
     }
 }
 

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -212,6 +212,12 @@ function formatLaborReward(p) {
     return parts.slice(0, -1).join(', ') + ' and ' + parts[parts.length - 1];
 }
 
+// Tracks unmapped action_types already logged this process, so the default
+// case's "needs a mapping" signal fires once per kind rather than once per row —
+// a busy day of gathered / stayed_open rows would otherwise spam the log. Reset
+// only on restart; a single line per kind is enough to prompt adding a mapping.
+const loggedUnmappedKinds = new Set();
+
 // Map an engine event to a narration line. Returns the (action) text
 // rendered in parens, or null when the event carries no narrative
 // signal (look_around, done with no state change). Keeping this in
@@ -379,10 +385,14 @@ function narrateEvent(event, actorName) {
             // gathered (LLM-273) and stayed_open (ZBBS-WORK-387) were already
             // producing "(Josiah gathered)" noise, and how LLM-283's offered /
             // declined / countered would too. Drop it from the dream transcript
-            // and log so an unmapped kind surfaces in server logs, not in
-            // production dreams. A beat that SHOULD feed dreams gets an explicit
-            // case above.
-            log('sim-distill-unmapped-kind', { kind: event.kind, speaker: event.speaker });
+            // and log ONCE per kind (loggedUnmappedKinds) so an unmapped kind
+            // surfaces in server logs without spamming a line per row, and never
+            // in production dreams. A beat that SHOULD feed dreams gets an
+            // explicit case above.
+            if (!loggedUnmappedKinds.has(event.kind)) {
+                loggedUnmappedKinds.add(event.kind);
+                log('sim-distill-unmapped-kind', { kind: event.kind });
+            }
             return null;
     }
 }

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -197,8 +197,19 @@ test('labor rewards carry the in-kind goods leg (LLM-225)', () => {
     );
 });
 
-test('an unknown kind falls back to generic narration (never a dropped frame)', () => {
-    assert.equal(narrateEvent({ kind: 'summoned', payload: {} }, ACTOR), '(Ezekiel Crane summoned)');
+test('an unmapped kind is dropped from dreams, not surfaced as generic noise', () => {
+    // LLM-283: loadDayEventsSQL pushes ALL of an actor's durable rows regardless
+    // of type, so the old generic-narration default leaked feed/audit-only beats
+    // into NPC dream memory. Unmapped kinds now drop to null. This covers
+    // LLM-283's negotiation beats, the pre-existing gathered / stayed_open leaks,
+    // and any future durable type until it earns an explicit mapping.
+    assert.equal(narrateEvent({ kind: 'offered', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'declined', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'countered', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'gathered', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'stayed_open', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'summoned', payload: {} }, ACTOR), null);
+    assert.equal(narrateEvent({ kind: 'some_future_beat', payload: {} }, ACTOR), null);
 });
 
 test('pure-perception kinds still render nothing', () => {


### PR DESCRIPTION
## Problem

The salem engine writes durable `agent_action_log` rows for many action types. The daily per-NPC dream push (`loadDayEventsSQL`) selects **all** of an actor's own rows regardless of `action_type`, and the distiller's `narrateEvent` `default` rendered any unmapped kind as generic `(Name kind)` text. So every durable-but-unmapped action type silently leaked generic noise into NPC **dream memory**:

- `gathered` (LLM-273) → `(Josiah Thorne gathered)` — leaking today
- `stayed_open` (ZBBS-WORK-387) → `(Hannah stayed_open)` — leaking today
- LLM-283's `offered`/`declined`/`countered` would have joined them

Surfaced while reviewing the [salem side of LLM-283](https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/734).

## Change

Flip the `default` from generic-narrate to **log-once-and-drop**: an unmapped kind is dropped from the dream transcript (returns `null`, which the transcript loop already skips) and logged once per kind per process so it surfaces in server logs — not in production dreams. A beat that *should* feed dreams still gets an explicit `case`.

This makes "durable but not dream-mapped" inert **by construction**, fixing the two pre-existing leaks and preventing the next one.

## Tests

Rewrote the test that locked the old generic-narration behavior to assert unmapped kinds now return `null` (covers the LLM-283 beats + `gathered`/`stayed_open` + a novel kind). The existing tests already assert every *mapped* type still narrates, guarding against dropping a desired type. 15/15 green.

## Notes

Whether `gathered`/`stayed_open`/haggles *should* earn real dream mappings is a separate opt-in decision (would be follow-up tickets). Companion PR: salem `LLM-283-pay-negotiation-feed-events` (#734).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
