### PR TITLE
LLM-236: store + surface in-world actor identity on virtual_agent_calls

### DIFF
--- a/migrations/MEM-139-va-sim-actor-identity_down.sql
+++ b/migrations/MEM-139-va-sim-actor-identity_down.sql
@@ -1,0 +1,4 @@
+-- MEM-139 down: drop the sim_actor columns (the partial index drops with the column).
+
+ALTER TABLE virtual_agent_calls DROP COLUMN sim_actor_id;
+ALTER TABLE virtual_agent_calls DROP COLUMN sim_actor_name;

--- a/migrations/MEM-139-va-sim-actor-identity_up.sql
+++ b/migrations/MEM-139-va-sim-actor-identity_up.sql
@@ -1,0 +1,32 @@
+-- MEM-139: sim_actor_id / sim_actor_name columns on virtual_agent_calls.
+--
+-- Attribution for shared switchboard-VA turns (LLM-236). The salem engine backs
+-- MANY in-world actors (Anne / Patience / Silence Walker ...) with ONE shared VA
+-- agent (salem-vendor / salem-visitor), so virtual_agent_calls.actor_id — which
+-- is the VA agent, not the character — collapses every character onto one
+-- row-owner. Which actor a turn was FOR was only recoverable by parsing the
+-- perception text in user_message, which made huddle forensics slow (the
+-- motivating case: a 122-turn Inn huddle where 66 turns were salem-vendor across
+-- three interleaved actors).
+--
+-- The engine already knows the deliberating actor, so it now stamps the actor's
+-- id + display name on the /v1/chat/send body; memory_api stores them here and
+-- surfaces them on /v1/sim/raw-turns (which the salem umbilical's /turns proxy
+-- relays). Persistent 1:1 VAs (zbbs-<name>) stamp it too, so filtering by
+-- in-world actor is uniform across shared and stateful NPCs.
+--
+-- sim_actor_id is TEXT, not uuid: it is the salem ENGINE actor id (from its own
+-- zbbs database), opaque to memory_api and never joined here — TEXT sidesteps the
+-- uuid-cast 500 an ill-formed value would otherwise raise (the same reason
+-- conversation_id is TEXT, MEM-133). sim_actor_name mirrors scene_structure's
+-- VARCHAR(100) (zbbs display names are bounded there). Both NULL for
+-- companion-mode / human chat and for village-level cascades (atmosphere /
+-- noticeboard / narration expansion) that act on behalf of no single actor.
+--
+-- The partial index mirrors idx_va_calls_scene: a btree over the non-null rows
+-- for the /sim/raw-turns sim_actor filter (huddle forensics: "every turn this
+-- character took").
+
+ALTER TABLE virtual_agent_calls ADD COLUMN sim_actor_id TEXT;
+ALTER TABLE virtual_agent_calls ADD COLUMN sim_actor_name VARCHAR(100);
+CREATE INDEX idx_va_calls_sim_actor ON virtual_agent_calls (sim_actor_id) WHERE sim_actor_id IS NOT NULL;

--- a/node/api/public/admin/views/agent-dialog.html
+++ b/node/api/public/admin/views/agent-dialog.html
@@ -301,6 +301,7 @@
         <div class="call-detail-body">
             <div class="call-detail-meta">
                 <span><strong>{{ callDetail.context || '-' }}</strong></span>
+                <span v-if="callDetail.sim_actor_name || callDetail.sim_actor_id" class="ts" title="in-world actor this turn was made on behalf of (LLM-236)">as {{ callDetail.sim_actor_name || callDetail.sim_actor_id }}</span>
                 <span class="ts">{{ callDetail.provider }} / {{ callDetail.model }}</span>
                 <span :class="callDetail.status === 'error' ? 'badge badge-error' : 'badge badge-online'" style="font-size: 11px;">{{ callDetail.status }}</span>
                 <span class="ts" v-if="callDetail.duration_ms">{{ callDetail.duration_ms }}ms</span>

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1971,6 +1971,7 @@ router.post('/admin/agents/call-detail', requirePerm('agents', 'read'), adminRou
     }
     const result = await pool.query(
         `SELECT c.id, ac.name AS agent, c.context, c.context_id, c.provider, c.model,
+                c.sim_actor_id, c.sim_actor_name,
                 c.system_prompt, c.user_message, c.response,
                 c.status, c.status_code, c.error_message,
                 c.input_tokens, c.output_tokens, c.cache_read_tokens, c.cache_write_tokens,

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -170,6 +170,37 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
         }
     }
 
+    // sim_actor_id / sim_actor_name (MEM-139 / LLM-236) — the in-world actor a
+    // shared-VA (salem-vendor) turn is made ON BEHALF OF. The row's actor_id is
+    // the switchboard VA (many characters, one agent), so without these the only
+    // way to attribute a turn to a character was parsing the perception text.
+    // The engine stamps the deliberating actor; memory_api stores both on the
+    // virtual_agent_calls row. sim_actor_id is the salem engine actor id — an
+    // opaque TEXT key here, never cast to uuid (like conversation_id). Both are
+    // omitted (omitempty) by the engine for village-level cascades and are NULL
+    // for companion-mode / human chat. Whitespace-only normalizes to NULL, like
+    // scene_structure / conversation_id.
+    let simActorId = req.body.sim_actor_id;
+    if (simActorId !== undefined && simActorId !== null) {
+        if (typeof simActorId !== 'string' || simActorId.length > 100) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_id must be a string up to 100 chars' } });
+        }
+        simActorId = simActorId.trim();
+        if (simActorId === '') {
+            simActorId = null;
+        }
+    }
+    let simActorName = req.body.sim_actor_name;
+    if (simActorName !== undefined && simActorName !== null) {
+        if (typeof simActorName !== 'string' || simActorName.length > 100) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_name must be a string up to 100 chars' } });
+        }
+        simActorName = simActorName.trim();
+        if (simActorName === '') {
+            simActorName = null;
+        }
+    }
+
     const wait = req.body.wait === true;
 
     if (persistOnly && wait) {
@@ -177,7 +208,7 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     }
 
     const result = await chatSend(from_agent, to_agents, discussionId, message, {
-        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, conversationId, wait, ephemeralContext,
+        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, conversationId, simActorId, simActorName, wait, ephemeralContext,
     });
 
     // wait=true: hold the connection open until the VA reply lands inline.

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -180,22 +180,30 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     // omitted (omitempty) by the engine for village-level cascades and are NULL
     // for companion-mode / human chat. Whitespace-only normalizes to NULL, like
     // scene_structure / conversation_id.
+    // Trim BEFORE the length check so padding can't count against the cap for a
+    // value that fits once trimmed (the stored value is the trimmed one).
     let simActorId = req.body.sim_actor_id;
     if (simActorId !== undefined && simActorId !== null) {
-        if (typeof simActorId !== 'string' || simActorId.length > 100) {
+        if (typeof simActorId !== 'string') {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_id must be a string up to 100 chars' } });
         }
         simActorId = simActorId.trim();
+        if (simActorId.length > 100) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_id must be a string up to 100 chars' } });
+        }
         if (simActorId === '') {
             simActorId = null;
         }
     }
     let simActorName = req.body.sim_actor_name;
     if (simActorName !== undefined && simActorName !== null) {
-        if (typeof simActorName !== 'string' || simActorName.length > 100) {
+        if (typeof simActorName !== 'string') {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_name must be a string up to 100 chars' } });
         }
         simActorName = simActorName.trim();
+        if (simActorName.length > 100) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor_name must be a string up to 100 chars' } });
+        }
         if (simActorName === '') {
             simActorName = null;
         }

--- a/node/api/src/routes/sim.js
+++ b/node/api/src/routes/sim.js
@@ -170,14 +170,21 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
         // no format cast. It's a bounding filter (indexed by idx_va_calls_sim_actor):
         // "every turn this in-world character took," which for a shared-VA NPC is
         // the attribution the agent-name filter can't give (salem-vendor backs
-        // many characters). Length-bounded like `agent` / `conversation`; the value
-        // is a bound parameter, so there's no injection risk either way.
-        if (body.sim_actor.length > 200) {
+        // many characters). Trim + cap 100 to MATCH the write path (chat.js stores
+        // a trimmed value <=100), so a padded filter like " alice " still hits the
+        // stored "alice" and a value that could never have been written is rejected;
+        // the value is a bound parameter, so there's no injection risk either way.
+        const simActor = body.sim_actor.trim();
+        if (simActor.length > 100) {
             return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor is too long' } });
         }
-        conditions.push(`c.sim_actor_id = $${idx++}`);
-        params.push(body.sim_actor);
-        hasBoundingFilter = true;
+        // Whitespace-only trims to empty — treat as no filter rather than a
+        // guaranteed-no-match condition on ''.
+        if (simActor !== '') {
+            conditions.push(`c.sim_actor_id = $${idx++}`);
+            params.push(simActor);
+            hasBoundingFilter = true;
+        }
     }
 
     if (body.since !== undefined && body.since !== null && body.since !== '') {

--- a/node/api/src/routes/sim.js
+++ b/node/api/src/routes/sim.js
@@ -71,6 +71,12 @@ router.post('/sim/conversation-day', apiRoute('sim', 'conversation_day', async (
 //              "every turn in this huddle's conversation" filter (ZBBS-WORK-431),
 //              stable across the huddle's ticks and participants. TEXT, not a UUID
 //              like scene_id, so no format validation — just a length bound.
+//   sim_actor — the salem ENGINE actor id (MEM-139/LLM-236) the turn was made
+//              ON BEHALF OF. For a shared-VA NPC this is the attribution the
+//              `agent` filter can't give — `agent=salem-vendor` returns every
+//              character that VA backs, `sim_actor=<id>` returns just this one.
+//              TEXT (engine actor id), indexed (idx_va_calls_sim_actor), so it's
+//              a bounding filter like the three above.
 //   since    — ISO timestamp lower bound on created_at
 //   until    — EXCLUSIVE upper bound on created_at (strictly earlier-than).
 //              The route returns the newest rows first with no offset
@@ -79,8 +85,8 @@ router.post('/sim/conversation-day', apiRoute('sim', 'conversation_day', async (
 //              pass the oldest row's created_at verbatim to fetch the next
 //              page back without repeating the boundary row.
 //   status   — 'success' | 'error'
-//   limit    — when a bounding filter (scene_id / conversation / agent) is set,
-//              the result is bounded and indexed, so it returns the FULL set by
+//   limit    — when a bounding filter (scene_id / conversation / agent / sim_actor)
+//              is set, the result is bounded and indexed, so it returns the FULL set by
 //              default (capped at 500) — the point of those filters is "give me
 //              this conversation," not a 5-row tail of it. With NO bounding
 //              filter the result is a tail of the whole retention window and
@@ -108,10 +114,11 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
     const conditions = [];
     const params = [];
     let idx = 1;
-    // A scene_id / conversation / agent filter bounds the result to a single
-    // scene, conversation, or NPC — each backed by an index — so a bounded query
-    // returns its complete set by default (see the limit handling below). since /
-    // until / status narrow but don't bound, so they don't flip this.
+    // A scene_id / conversation / agent / sim_actor filter bounds the result to a
+    // single scene, conversation, VA, or in-world actor — each backed by an index
+    // — so a bounded query returns its complete set by default (see the limit
+    // handling below). since / until / status narrow but don't bound, so they
+    // don't flip this.
     let hasBoundingFilter = false;
 
     if (body.scene_id !== undefined && body.scene_id !== null && body.scene_id !== '') {
@@ -155,6 +162,24 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
         hasBoundingFilter = true;
     }
 
+    if (body.sim_actor !== undefined && body.sim_actor !== null && body.sim_actor !== '') {
+        if (typeof body.sim_actor !== 'string') {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor must be a string' } });
+        }
+        // sim_actor_id is the salem engine actor id (MEM-139) — a TEXT column, so
+        // no format cast. It's a bounding filter (indexed by idx_va_calls_sim_actor):
+        // "every turn this in-world character took," which for a shared-VA NPC is
+        // the attribution the agent-name filter can't give (salem-vendor backs
+        // many characters). Length-bounded like `agent` / `conversation`; the value
+        // is a bound parameter, so there's no injection risk either way.
+        if (body.sim_actor.length > 200) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'sim_actor is too long' } });
+        }
+        conditions.push(`c.sim_actor_id = $${idx++}`);
+        params.push(body.sim_actor);
+        hasBoundingFilter = true;
+    }
+
     if (body.since !== undefined && body.since !== null && body.since !== '') {
         const since = new Date(body.since);
         if (Number.isNaN(since.getTime())) {
@@ -181,9 +206,10 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
         params.push(body.status);
     }
 
-    // A bounded query (scene_id / conversation / agent) returns its complete set
-    // by default — the filter already scopes it to one conversation/scene/NPC, so
-    // a small default would silently truncate the very thing the caller asked for.
+    // A bounded query (scene_id / conversation / agent / sim_actor) returns its
+    // complete set by default — the filter already scopes it to one
+    // conversation/scene/VA/actor, so a small default would silently truncate the
+    // very thing the caller asked for.
     // An unbounded query is a tail of the whole retention window where each row
     // carries a multi-KB prompt, so it stays small by default and must be raised
     // deliberately.
@@ -202,6 +228,7 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
     // row is enough to set has_more, and it's trimmed before returning.
     const result = await pool.query(
         `SELECT c.id, ac.name AS agent, c.scene_id, c.context, c.context_id, c.provider, c.model,
+                c.sim_actor_id, c.sim_actor_name,
                 c.system_prompt, c.user_message, c.response,
                 c.status, c.status_code, c.error_message,
                 c.input_tokens, c.output_tokens, c.cache_read_tokens, c.cache_write_tokens,

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -88,6 +88,13 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // conversation beat) the admin chat viewer collapses a whole exchange under,
     // distinct from the per-tick sceneId. NULL outside grouped sim ticks.
     const conversationId = opts && opts.conversationId !== undefined ? opts.conversationId : null;
+    // simActorId / simActorName (MEM-139 / LLM-236): the in-world actor a
+    // shared-VA turn is made on behalf of. Forwarded to handleDirectChat, which
+    // stamps them on the virtual_agent_calls row so a salem-vendor turn can be
+    // attributed to a specific character instead of only the switchboard agent.
+    // NULL outside sim ticks and for village-level cascades.
+    const simActorId = opts && opts.simActorId !== undefined ? opts.simActorId : null;
+    const simActorName = opts && opts.simActorName !== undefined ? opts.simActorName : null;
     // ephemeralContext (lean sim-history): per-tick scratch context (current
     // affordances / world-state) forwarded to handleDirectChat to attach to
     // the model's current turn. NOT persisted — it never enters rowSpecs, so
@@ -408,7 +415,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     if (dispatches.length === 1) {
                         const d = dispatches[0];
                         pendingReplyPromise = handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                            toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, ackReplyOnInsert: wait, ephemeralContext,
+                            toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ackReplyOnInsert: wait, ephemeralContext,
                         });
                         // Swallow rejection for non-wait callers so unhandled-promise
                         // warnings don't appear; wait-mode awaiters get the error.
@@ -419,7 +426,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                         // stays false here.
                         for (const d of dispatches) {
                             handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                                toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, ephemeralContext,
+                                toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ephemeralContext,
                             }).catch(() => {});
                         }
                     }

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -777,6 +777,9 @@ async function logTranscript(agentName, systemPrompt, userMessage, response, usa
 //   durationMs     — wall-clock time for the call
 //   error          — error object (if the call failed)
 //   sceneId        — engine cascade UUID (MEM-121); NULL outside sim-mode chat
+//   simActorId     — in-world actor id a shared-VA turn is FOR (MEM-139/LLM-236);
+//                    NULL outside sim ticks and for village-level cascades
+//   simActorName   — that actor's display name (<=100 chars)
 async function logCall(options) {
     try {
         // Extract the static portion of the system prompt (skip RAG context)
@@ -801,8 +804,9 @@ async function logCall(options) {
              (actor_id, context, context_id, provider, model, system_prompt, user_message,
               response, status, status_code, error_message,
               input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-              cost, duration_ms, usage_id, scene_id, conversation_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
+              cost, duration_ms, usage_id, scene_id, conversation_id,
+              sim_actor_id, sim_actor_name)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
             [
                 options.actorId,
                 options.context || null,
@@ -824,6 +828,8 @@ async function logCall(options) {
                 options.usageId || null,
                 options.sceneId || null,
                 options.conversationId || null,
+                options.simActorId || null,
+                options.simActorName || null,
             ]
         );
     } catch (err) {
@@ -2503,6 +2509,14 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     // narrative-beat grouping id as the perception that prompted them — keeping
     // the whole exchange in one conversation in the admin viewer.
     const conversationId = opts && opts.conversationId !== undefined ? opts.conversationId : null;
+    // simActorId / simActorName (MEM-139 / LLM-236): the in-world actor this
+    // shared-VA turn is FOR. Logged on this call's virtual_agent_calls row so a
+    // salem-vendor turn is attributable to a specific character instead of only
+    // the switchboard agent. NOT propagated to the reply row (the reply is the
+    // NPC speaking AS that actor; the attribution belongs on the LLM call). NULL
+    // outside sim ticks and for village-level cascades.
+    const simActorId = opts && opts.simActorId !== undefined ? opts.simActorId : null;
+    const simActorName = opts && opts.simActorName !== undefined ? opts.simActorName : null;
     // ephemeralContext (lean sim-history): per-tick scratch context (current
     // affordances / world-state) attached to the model's CURRENT turn below.
     // Never persisted — it only shapes this one provider call, so it can't
@@ -2832,7 +2846,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             actorId: agent.actor_id, agentName: agent.agent, context: 'chat',
             provider: agent.provider, model: agent.model,
             systemPrompt, userMessage: loggedUserMessage, response: loggedResponse, usage, cost: chatCost,
-            durationMs: chatDurationMs, usageId: chatUsageId, sceneId, conversationId,
+            durationMs: chatDurationMs, usageId: chatUsageId, sceneId, conversationId, simActorId, simActorName,
         }).catch(() => {});
 
         // Send response as direct chat back to the sender. Tool-use replies
@@ -2899,7 +2913,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             provider: agent ? agent.provider : 'unknown', model: agent ? agent.model : 'unknown',
             systemPrompt: typeof systemPrompt !== 'undefined' ? systemPrompt : null,
             userMessage: typeof loggedUserMessage !== 'undefined' ? loggedUserMessage : messageText,
-            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId, sceneId, conversationId,
+            error: err, durationMs: chatErrDuration, usageId: chatFailUsageId, sceneId, conversationId, simActorId, simActorName,
         }).catch(() => {});
         logError('virtual-agent', 'direct-chat-error', {
             agent: virtualAgentName,


### PR DESCRIPTION
## What

Persist and surface the in-world actor identity the salem engine now stamps on shared-VA turns, so `virtual_agent_calls` rows can be attributed to a specific character instead of only the switchboard agent (`salem-vendor`).

Companion PR (engine send side): jeffdafoe/llm-memory-plugin-salem-1692#760

## Why

For a shared switchboard VA, `virtual_agent_calls.actor_id` is the VA (many characters, one agent), so which actor a turn was FOR was only recoverable by parsing the perception text in `user_message` — slow for huddle forensics (the motivating case: a 122-turn Inn huddle, 66 `salem-vendor` turns across three interleaved actors).

## Changes

- **MEM-139 migration**: `sim_actor_id TEXT` + `sim_actor_name VARCHAR(100)` on `virtual_agent_calls`, plus `idx_va_calls_sim_actor` (partial, non-null) for the new filter. `sim_actor_id` is TEXT (opaque engine actor id, never cast to uuid — same rationale as `conversation_id`, MEM-133).
- `POST /v1/chat/send` parses + validates `sim_actor_id` / `sim_actor_name` (trim-then-cap-100, empty→null) and threads them `chatSend` → `handleDirectChat` → `logCall` into the row.
- `POST /v1/sim/raw-turns` returns both columns and gains a **bounding `sim_actor` filter** — the attribution the `agent` filter can't give for a shared VA (`agent=salem-vendor` returns every character it backs; `sim_actor=<id>` returns just one). Filter is trimmed + capped at 100 to match the write path. Backs the umbilical `/turns` proxy, which relays verbatim.
- Admin `call-detail` returns both; the call-detail dialog shows an **"as &lt;actor&gt;"** chip.

## Deploy ordering — migrate FIRST (reads *and* writes reference the new columns)

MEM-139 must run **before/with** this code. Both sides touch the columns:
- **Write**: `logCall` inserts them (fire-and-forget + try/catch, so it wouldn't break request flow, but would skip **all** call logging until the migration lands).
- **Read**: `/v1/sim/raw-turns` and `/admin/agents/call-detail` **SELECT** them — these would **error** (500) if the API is live before the migration.

Standard migrate-then-deploy, matching the `conversation_id` (MEM-133) precedent. The engine PR can ship independently — an old API just ignores the extra body fields.

## Tests

No route/integration test harness exists in this repo (the `*.test.js` are pure-function unit tests — no DB/express fixtures), so this plumbing has no unit-test seam in the existing convention; the behavioral coverage is on the engine side (wire marshal + end-to-end stamp). All changed JS passes `node --check`; INSERT placeholder count verified (22, confirmed by review).

## Review

code_review (GPT-5.4) round 1 applied: trim-before-length-validate on the write path, and align the `/sim/raw-turns` filter bound + trimming to the write path. Engine stamping boundary, TEXT choice, and not-propagating-to-reply-row all confirmed sound; no security issues.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)