### PR TITLE
LLM-328: OpenRouter provider routing passthrough (deepseek warm-caching enabler)

### DIFF
--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -206,9 +206,10 @@ function createCall(model, apiKey, configuration) {
         // host A is a cold miss on host B and cross-tick/cross-actor cache hits
         // almost never land. Pinning the upstream is what lets the invariant
         // prefix stay warm across a burst of NPC ticks. Behavior-neutral — same
-        // prompt, same tools, only which host serves it. Guard against a stray
-        // scalar/array so a malformed config can't ship a garbage field.
-        if (conf.provider && typeof conf.provider === 'object' && !Array.isArray(conf.provider)) {
+        // prompt, same tools, only which host serves it. Require a plain object
+        // (config is parsed JSON in normal use) so a stray scalar/array — or an
+        // exotic object — can't ship a garbage routing field.
+        if (conf.provider && Object.prototype.toString.call(conf.provider) === '[object Object]') {
             body.provider = conf.provider;
         }
 

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -196,6 +196,22 @@ function createCall(model, apiKey, configuration) {
             });
         }
 
+        // OpenRouter provider routing (LLM-328). Passed through verbatim from the
+        // agent's configuration JSON (`configuration.provider`), which mirrors
+        // OpenRouter's own `provider` request field — e.g.
+        // { "order": ["deepinfra"], "allow_fallbacks": false }. OpenRouter fronts
+        // many upstream hosts for a single model id (deepseek-v4-flash alone has
+        // 10+), and prompt-prefix caching is per-host: without pinning, OpenRouter
+        // load-balances consecutive requests across hosts, so a prefix warmed on
+        // host A is a cold miss on host B and cross-tick/cross-actor cache hits
+        // almost never land. Pinning the upstream is what lets the invariant
+        // prefix stay warm across a burst of NPC ticks. Behavior-neutral — same
+        // prompt, same tools, only which host serves it. Guard against a stray
+        // scalar/array so a malformed config can't ship a garbage field.
+        if (conf.provider && typeof conf.provider === 'object' && !Array.isArray(conf.provider)) {
+            body.provider = conf.provider;
+        }
+
         logProvider('api-call', { provider: 'openrouter', model, tools: useTools });
 
         var response = await fetch('https://openrouter.ai/api/v1/chat/completions', {

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -1,0 +1,76 @@
+// Tests for the OpenRouter provider-routing passthrough (LLM-328) in
+// createCall. Run with: node --test (from node/api). Uses the built-in
+// node:test runner + node:assert, matching the other *.test.js modules.
+//
+// The call function issues a real fetch, so we stub globalThis.fetch to
+// capture the serialized request body without hitting the network. The stub
+// branches on URL: the /models catalog fetch (triggered by computeCost →
+// lookupPricing) gets an empty catalog; the chat/completions call gets a
+// minimal OpenAI-shape response and its body is captured for assertions.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const openrouter = require('./openrouter');
+
+// Install a fetch stub that records the chat-completions request body and
+// returns canned responses. Returns { restore, lastBody() }.
+function stubFetch() {
+    const original = globalThis.fetch;
+    let captured = null;
+    globalThis.fetch = async function (url, init) {
+        if (String(url).includes('/models')) {
+            // Catalog fetch — return an empty catalog so computeCost resolves
+            // to null (pricing unknown) without a network call.
+            return { ok: true, json: async () => ({ data: [] }) };
+        }
+        captured = init && init.body ? JSON.parse(init.body) : null;
+        return {
+            ok: true,
+            json: async () => ({
+                choices: [{ message: { content: 'ok', tool_calls: [] } }],
+                usage: { prompt_tokens: 10, completion_tokens: 2 },
+            }),
+        };
+    };
+    return {
+        restore() { globalThis.fetch = original; },
+        lastBody() { return captured; },
+    };
+}
+
+test('conf.provider is passed through to body.provider verbatim', async () => {
+    const stub = stubFetch();
+    try {
+        const routing = { order: ['deepinfra'], allow_fallbacks: false };
+        const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { provider: routing });
+        await call('sys', 'hi', {});
+        assert.deepEqual(stub.lastBody().provider, routing);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('no conf.provider leaves body.provider unset', async () => {
+    const stub = stubFetch();
+    try {
+        const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {});
+        await call('sys', 'hi', {});
+        assert.equal('provider' in stub.lastBody(), false);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('a non-object conf.provider is ignored (guard against malformed config)', async () => {
+    const stub = stubFetch();
+    try {
+        // scalar and array are both rejected — only a plain routing object ships
+        for (const bad of ['deepinfra', ['deepinfra']]) {
+            const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { provider: bad });
+            await call('sys', 'hi', {});
+            assert.equal('provider' in stub.lastBody(), false);
+        }
+    } finally {
+        stub.restore();
+    }
+});

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -38,12 +38,14 @@ function stubFetch() {
     };
 }
 
-test('conf.provider is passed through to body.provider verbatim', async () => {
+test('conf.provider reaches body.provider with the same JSON shape on the wire', async () => {
     const stub = stubFetch();
     try {
         const routing = { order: ['deepinfra'], allow_fallbacks: false };
         const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { provider: routing });
         await call('sys', 'hi', {});
+        // lastBody() is the JSON-round-tripped request body, so this asserts the
+        // serialized wire shape (what OpenRouter sees), not object identity.
         assert.deepEqual(stub.lastBody().provider, routing);
     } finally {
         stub.restore();


### PR DESCRIPTION
Part 1 of LLM-328 (memory-api side). Enables reliable prompt-prefix caching for the shared salem-vendor VA on OpenRouter.

## Problem
OpenRouter fronts many upstream hosts for one model id (`deepseek-v4-flash` has 10+: DeepInfra, GMICloud, Baidu, Morph [no cache], …). Prompt-prefix caching is **per-host**. `openrouter.js` sent no `provider` field, so OpenRouter load-balanced consecutive salem-vendor ticks across hosts — a prefix warmed on host A is a cold miss on host B. Live evidence: two consecutive vendor ticks, Moses `cache_read=1024`, Lewis (seconds later) `cache_read=0`.

## Change
`createCall` reads `configuration.provider` (mirrors OpenRouter's own `provider` request field) and sets it on the chat-completions body — e.g. `{"order":["deepinfra"],"allow_fallbacks":false}`. Pinning the upstream is what lets the invariant prefix stay warm across a burst. Behavior-neutral: same prompt/tools, only which host serves it. Guarded so a malformed scalar/array config can't ship a garbage field. Passthrough survives `sanitizeAgentConfiguration` (strips only empty numeric strings).

Configured per-agent via the admin UI (no code change to switch providers). Recommended pin: DeepInfra (fp4, cheapest cache_read).

## Tests
`openrouter.test.js` (node --test): passthrough verbatim, unset when absent, guard rejects non-object.

— Work