### PR TITLE
LLM-340: add gpt-5.6 (sol/terra/luna) support + fix Perplexity search_results

### DIFF
--- a/node/api/src/services/providers/openai.js
+++ b/node/api/src/services/providers/openai.js
@@ -101,6 +101,24 @@ function gpt5Capabilities() {
 // with the rest of the family.
 
 const models = {
+    'gpt-5.6-sol': {
+        label: 'GPT-5.6 Sol',
+        configVersion: 2,
+        pricing: { input: 5.00, output: 30, cache_read: 0.50 },
+        capabilities: gpt5Capabilities()
+    },
+    'gpt-5.6-terra': {
+        label: 'GPT-5.6 Terra',
+        configVersion: 2,
+        pricing: { input: 2.50, output: 15, cache_read: 0.25 },
+        capabilities: gpt5Capabilities()
+    },
+    'gpt-5.6-luna': {
+        label: 'GPT-5.6 Luna',
+        configVersion: 2,
+        pricing: { input: 1.00, output: 6, cache_read: 0.10 },
+        capabilities: gpt5Capabilities()
+    },
     'gpt-5.5': {
         label: 'GPT-5.5',
         configVersion: 2,

--- a/node/api/src/services/providers/openai.test.js
+++ b/node/api/src/services/providers/openai.test.js
@@ -1,0 +1,48 @@
+// Tests for the gpt-5.6 model registry entries (LLM-340) in the OpenAI
+// provider. Run with: node --test (from node/api). The gpt-5.x family is
+// generic, so the new variants need no plumbing — these assert the pricing is
+// exact (a typo corrupts the budget math, which fails closed on unknown cost)
+// and that gpt-5.6 routes through /v1/responses like the rest of the family.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const openai = require('./openai');
+
+test('gpt-5.6 sol/terra/luna are registered with the published pricing', () => {
+    assert.deepEqual(openai.models['gpt-5.6-sol'].pricing, { input: 5.00, output: 30, cache_read: 0.50 });
+    assert.deepEqual(openai.models['gpt-5.6-terra'].pricing, { input: 2.50, output: 15, cache_read: 0.25 });
+    assert.deepEqual(openai.models['gpt-5.6-luna'].pricing, { input: 1.00, output: 6, cache_read: 0.10 });
+});
+
+test('gpt-5.6 variants carry the shared gpt-5.x capability shape', () => {
+    for (const id of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+        const model = openai.models[id];
+        assert.equal(model.configVersion, 2);
+        assert.ok(model.capabilities.reasoning_effort, `${id} has reasoning_effort`);
+        assert.deepEqual(model.capabilities.reasoning_effort.options, ['none', 'low', 'medium', 'high', 'xhigh']);
+        assert.ok(model.capabilities.service_tier, `${id} has service_tier`);
+    }
+});
+
+test('gpt-5.6 calls route through /v1/responses like the rest of gpt-5.x', async () => {
+    const original = globalThis.fetch;
+    let calledUrl = null;
+    globalThis.fetch = async function (url) {
+        calledUrl = String(url);
+        return {
+            ok: true,
+            json: async () => ({
+                output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+                usage: { input_tokens: 10, output_tokens: 2 },
+            }),
+        };
+    };
+    try {
+        const call = openai.createCall('gpt-5.6-sol', 'k', {});
+        const { text } = await call('sys', 'hi', {});
+        assert.equal(calledUrl, 'https://api.openai.com/v1/responses');
+        assert.equal(text, 'ok');
+    } finally {
+        globalThis.fetch = original;
+    }
+});

--- a/node/api/src/services/providers/perplexity.js
+++ b/node/api/src/services/providers/perplexity.js
@@ -194,12 +194,28 @@ function createCall(model, apiKey, configuration) {
 
         let text = choice.message.content;
 
-        // Append citations if available and configured.
-        // Citations come as a top-level array of URLs in the response.
+        // Append sources if available and configured. Perplexity removed the
+        // top-level `citations` array (plain URL strings) in May 2025 in favor
+        // of `search_results` — an array of { title, url, date } with richer
+        // metadata. Prefer search_results; fall back to the legacy citations
+        // field so any model/response still returning it keeps working. The
+        // result index maps to the model's inline [n] markers, so numbering
+        // must stay 1-based in original order.
         const includeCitations = conf.return_citations !== false;
-        if (includeCitations && data.citations && data.citations.length > 0) {
-            const citationLines = data.citations.map((url, i) => `[${i + 1}] ${url}`);
-            text += '\n\nSources:\n' + citationLines.join('\n');
+        if (includeCitations) {
+            let sourceLines = null;
+            if (Array.isArray(data.search_results) && data.search_results.length > 0) {
+                sourceLines = data.search_results.map((r, i) => {
+                    const title = r.title ? `${r.title} — ` : '';
+                    const date = r.date ? ` (${r.date})` : '';
+                    return `[${i + 1}] ${title}${r.url || ''}${date}`;
+                });
+            } else if (Array.isArray(data.citations) && data.citations.length > 0) {
+                sourceLines = data.citations.map((url, i) => `[${i + 1}] ${url}`);
+            }
+            if (sourceLines) {
+                text += '\n\nSources:\n' + sourceLines.join('\n');
+            }
         }
 
         const usage = {

--- a/node/api/src/services/providers/perplexity.test.js
+++ b/node/api/src/services/providers/perplexity.test.js
@@ -1,0 +1,91 @@
+// Tests for Perplexity source extraction (LLM-340) in createCall. Run with:
+// node --test (from node/api). Uses the built-in node:test runner +
+// node:assert, matching the other *.test.js provider modules.
+//
+// Perplexity removed the top-level `citations` array (plain URL strings) in
+// May 2025 in favor of `search_results` ({ title, url, date }). These tests
+// stub globalThis.fetch to return canned response shapes and assert the
+// "Sources:" block the provider appends to the model text.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const perplexity = require('./perplexity');
+
+// Stub fetch to return a fixed Perplexity chat-completions payload. `extra`
+// is merged onto the response body so each test supplies its own
+// search_results / citations fields.
+function stubFetch(extra) {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => Object.assign({
+                choices: [{ message: { content: 'answer body' } }],
+                usage: { prompt_tokens: 10, completion_tokens: 5 },
+            }, extra),
+        };
+    };
+    return { restore() { globalThis.fetch = original; } };
+}
+
+async function callSonar(extra, conf) {
+    const stub = stubFetch(extra);
+    try {
+        const call = perplexity.createCall('sonar', 'k', conf || {});
+        return await call('sys', 'q', {});
+    } finally {
+        stub.restore();
+    }
+}
+
+test('search_results renders a Sources block with title, url and date', async () => {
+    const { text } = await callSonar({
+        search_results: [
+            { title: 'First Source', url: 'https://a.example/1', date: '2026-07-01' },
+            { title: 'Second Source', url: 'https://b.example/2', date: '2026-07-02' },
+        ],
+    });
+    assert.match(text, /\n\nSources:\n/);
+    assert.match(text, /\[1\] First Source — https:\/\/a\.example\/1 \(2026-07-01\)/);
+    assert.match(text, /\[2\] Second Source — https:\/\/b\.example\/2 \(2026-07-02\)/);
+});
+
+test('search_results entries missing title/date degrade to just the url', async () => {
+    const { text } = await callSonar({
+        search_results: [{ url: 'https://a.example/1' }],
+    });
+    assert.match(text, /\[1\] https:\/\/a\.example\/1/);
+    // no " — " title separator and no empty "()" date
+    assert.doesNotMatch(text, / — /);
+    assert.doesNotMatch(text, /\(\)/);
+});
+
+test('legacy citations array is used when search_results is absent', async () => {
+    const { text } = await callSonar({
+        citations: ['https://a.example/1', 'https://b.example/2'],
+    });
+    assert.match(text, /\[1\] https:\/\/a\.example\/1/);
+    assert.match(text, /\[2\] https:\/\/b\.example\/2/);
+});
+
+test('search_results takes precedence over legacy citations', async () => {
+    const { text } = await callSonar({
+        search_results: [{ title: 'New', url: 'https://new.example', date: '2026-07-03' }],
+        citations: ['https://old.example'],
+    });
+    assert.match(text, /https:\/\/new\.example/);
+    assert.doesNotMatch(text, /old\.example/);
+});
+
+test('no search_results or citations means no Sources block', async () => {
+    const { text } = await callSonar({});
+    assert.equal(text, 'answer body');
+});
+
+test('return_citations=false suppresses the Sources block', async () => {
+    const { text } = await callSonar(
+        { search_results: [{ title: 'X', url: 'https://x.example', date: '2026-07-01' }] },
+        { return_citations: false },
+    );
+    assert.equal(text, 'answer body');
+});


### PR DESCRIPTION
## What

Two provider-registry changes in `node/api/src/services/providers/`.

### 1. gpt-5.6 support (`openai.js`)
OpenAI released gpt-5.6 with a sol/terra/luna tier scheme (no pro/mini/nano). The gpt-5.x family is already generic — `usesResponsesEndpoint()` matches the `gpt-5.` prefix, so `/v1/responses` routing, cost calc, `reasoning_effort` values, and config sanitization all apply with zero new plumbing. Only the registry entries + pricing are new (per developers.openai.com/api/docs/pricing, verified 2026-07-09):

| Model | Input | Cached | Output |
|---|---|---|---|
| gpt-5.6-sol | $5.00 | $0.50 | $30.00 |
| gpt-5.6-terra | $2.50 | $0.25 | $15.00 |
| gpt-5.6-luna | $1.00 | $0.10 | $6.00 |

### 2. Perplexity `search_results` fix (`perplexity.js`)
Perplexity removed the top-level `citations` array (May 2025) in favor of `search_results` (`{title, url, date}`). The provider still read `data.citations`, which is now always empty — so `search-general` replies came back with **no source URLs** and looked ungrounded even though Sonar did search. Now prefers `search_results` (rendered as `[n] title — url (date)`), falling back to legacy `citations`.

## Tests
Adds `openai.test.js` and `perplexity.test.js` (fetch-stub unit tests, matching `openrouter.test.js`). Local run of both: **9/9 pass**. Full provider suite runs in CI (needs installed deps).

— Work