### PR TITLE
LLM-355: slug_prefix scoping + last_accessed stamp on /v1/memory/search

### DIFF
--- a/node/api/src/routes/memory.js
+++ b/node/api/src/routes/memory.js
@@ -57,6 +57,10 @@ router.post('/memory/ingest/status', apiRoute('memory', 'ingest-status', async (
 router.post('/memory/search', apiRoute('memory', 'search', async (req, res) => {
     const query = sanitize.content(req.body.query);
     const { namespace, limit } = req.body;
+    // Optional slug-prefix scope (LLM-355): narrow the search to source_files
+    // under a prefix within the namespace. Sanitized as an identifier (permits
+    // '/', '-', '_'); LIKE metacharacters are escaped inside searchMemory.
+    const slugPrefix = req.body.slug_prefix ? sanitize.identifier(req.body.slug_prefix) : undefined;
 
     if (!query) {
         return res.status(400).json({
@@ -74,7 +78,7 @@ router.post('/memory/search', apiRoute('memory', 'search', async (req, res) => {
     if (!namespace || namespace === '*') {
         readable = await getReadableNamespaces(actor.actorId, actor.actorName, actor.actorType);
     }
-    const result = await searchMemory(query, namespace, limit, readable, actor.actorId);
+    const result = await searchMemory(query, namespace, limit, readable, actor.actorId, slugPrefix);
     res.json(result);
 }));
 

--- a/node/api/src/services/documents.js
+++ b/node/api/src/services/documents.js
@@ -331,7 +331,7 @@ async function listNotes(namespace, limit, offset, prefix, opts) {
             SELECT d.id, d.slug, d.title,
                    LEFT(d.content, 200) AS snippet,
                    MD5(d.content) AS content_hash,
-                   ac.name AS created_by, d.created_at, d.updated_at${deletedCol}
+                   ac.name AS created_by, d.created_at, d.updated_at, d.last_accessed${deletedCol}
             FROM documents d
             LEFT JOIN actors ac ON ac.id = d.created_by_actor_id
             WHERE d.namespace = $1 AND LOWER(d.slug) LIKE LOWER($4)${deletedFilter}
@@ -344,7 +344,7 @@ async function listNotes(namespace, limit, offset, prefix, opts) {
             SELECT d.id, d.slug, d.title,
                    LEFT(d.content, 200) AS snippet,
                    MD5(d.content) AS content_hash,
-                   ac.name AS created_by, d.created_at, d.updated_at${deletedCol}
+                   ac.name AS created_by, d.created_at, d.updated_at, d.last_accessed${deletedCol}
             FROM documents d
             LEFT JOIN actors ac ON ac.id = d.created_by_actor_id
             WHERE d.namespace = $1${deletedFilter}

--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -6,6 +6,7 @@ const { embed } = require('./embeddings');
 const { chunkByHeading, chunkConversation } = require('./chunker');
 const pgvector = require('pgvector');
 const config = require('./config');
+const { handleError } = require('./error-handler');
 
 function parseNonNegativeFinite(value, fallback = 0) {
     const n = Number(value);
@@ -115,7 +116,17 @@ async function ingestContent(namespace, sourceFile, content) {
     return { chunks_created: chunks.length, source_file: sourceFile, namespace };
 }
 
-async function searchMemory(query, namespace, limit, readableNamespaces, actorId) {
+// Escape the three LIKE metacharacters so a caller-supplied prefix is matched
+// literally. Backslash is the ESCAPE character in the LIKE clauses below, so it
+// must be escaped first (the alternation handles that — each match is replaced
+// with a backslash + itself). Without this, an underscore in a slug prefix
+// (sanitize.identifier permits '_') would act as a single-char wildcard, and a
+// '%' would match anything — a scoping filter that silently over-matches.
+function escapeLikePattern(value) {
+    return value.replace(/[\\%_]/g, '\\$&');
+}
+
+async function searchMemory(query, namespace, limit, readableNamespaces, actorId, slugPrefix) {
     // Coerce limit to a positive integer — Postgres LIMIT requires an integer,
     // and callers may pass floats (e.g. 0.15) which cause a SQL type error.
     const maxResults = Math.max(1, Math.floor(limit) || 5);
@@ -239,6 +250,21 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
         }
     }
 
+    // Slug-prefix scope (LLM-355): narrow a search to source_files under a
+    // prefix, e.g. "anne-walker/memory/" so one shared-VA namespace holds many
+    // NPCs' private memory without any of them recalling another's. Undefined =
+    // no filter, so existing callers are unaffected. The prefix is escaped and
+    // matched case-insensitively (consistent with the LOWER()-based join), then
+    // '%' is appended as the one live wildcard. Interpolated into BOTH inner
+    // selects below — a filter applied to only one path is a silent leak.
+    let slugPrefixFilter = '';
+    if (typeof slugPrefix === 'string' && slugPrefix.length > 0) {
+        const slugIdx = paramIdx;
+        params.push(escapeLikePattern(slugPrefix.toLowerCase()) + '%');
+        paramIdx++;
+        slugPrefixFilter = `AND LOWER(mc.source_file) LIKE $${slugIdx} ESCAPE '\\'`;
+    }
+
     // Time-decay: two-tier system. Cognitive type takes priority when available
     // (stored in metadata->>'cognitive_type' by enrichment), falls back to kind-based.
     // decay = 0.5 ^ (age_days / half_life). If half_life is 0, no decay (1.0).
@@ -315,7 +341,7 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
                    * ${decayExpression} * ${kindWeightExpression} AS similarity
             FROM memory_chunks mc
             LEFT JOIN documents d ON d.namespace = mc.namespace AND LOWER(d.slug) = LOWER(mc.source_file)
-            WHERE 1=1 ${nsFilter} ${softDeleteFilter}
+            WHERE 1=1 ${nsFilter} ${slugPrefixFilter} ${softDeleteFilter}
             ORDER BY similarity DESC
             LIMIT $2
         `;
@@ -326,7 +352,7 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
                    * ${decayExpression} * ${kindWeightExpression} AS similarity
             FROM memory_chunks mc
             LEFT JOIN documents d ON d.namespace = mc.namespace AND LOWER(d.slug) = LOWER(mc.source_file)
-            WHERE mc.namespace = $2 ${softDeleteFilter}
+            WHERE mc.namespace = $2 ${slugPrefixFilter} ${softDeleteFilter}
             ORDER BY similarity DESC
             LIMIT $3
         `;
@@ -350,7 +376,41 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
     `;
 
     const result = await pool.query(sql, params);
+
+    // Retrieval reinforces a memory (LLM-355). Stamp last_accessed on the
+    // documents a search surfaced — the same column readNote touches on a direct
+    // read. It feeds the access boost AND resets decay age (age is GREATEST of
+    // created_at, updated_at, last_accessed), so a note that keeps being found
+    // stays fresh and a note never recalled fades on its half-life. Keyed on
+    // (namespace, slug) because a wildcard search spans namespaces. Raw ingests
+    // (chunks with no documents row) simply match nothing. Fire-and-forget:
+    // stamping must never add latency to or fail the search — but a failure is
+    // recorded (not silently swallowed) via the same handleError path readNote's
+    // last_accessed stamp uses, so a regression after a migration/perm change is
+    // visible in system_errors.
+    if (result.rows.length > 0) {
+        stampLastAccessed(result.rows).catch(err => {
+            handleError(null, 'memory', 'LAST_ACCESSED_STAMP_FAILED', {
+                error: err.message
+            }).catch(() => {});
+        });
+    }
+
     return { results: result.rows };
+}
+
+// Reset last_accessed to now for the (namespace, source_file) pairs a search
+// returned. unnest pairs the two arrays positionally into rows to update.
+async function stampLastAccessed(rows) {
+    const namespaces = rows.map(r => r.namespace);
+    const sourceFiles = rows.map(r => r.source_file);
+    await pool.query(
+        `UPDATE documents d
+         SET last_accessed = NOW()
+         FROM (SELECT unnest($1::text[]) AS ns, unnest($2::text[]) AS sf) t
+         WHERE d.namespace = t.ns AND LOWER(d.slug) = LOWER(t.sf) AND d.deleted_at IS NULL`,
+        [namespaces, sourceFiles]
+    );
 }
 
 async function deleteMemory(namespace, sourceFile) {
@@ -402,4 +462,4 @@ async function ingestStatus(namespace) {
     return { files: result.rows };
 }
 
-module.exports = { ingestContent, searchMemory, deleteMemory, cleanupMemory, ingestStatus };
+module.exports = { ingestContent, searchMemory, deleteMemory, cleanupMemory, ingestStatus, escapeLikePattern };

--- a/node/api/src/services/memory.test.js
+++ b/node/api/src/services/memory.test.js
@@ -1,0 +1,38 @@
+// Run with: node --test (from node/api). Uses the built-in node:test runner.
+//
+// Covers escapeLikePattern — the LIKE-metacharacter escaping that keeps a
+// caller-supplied slug prefix from acting as a wildcard (LLM-355). The SQL
+// filtering and last_accessed stamping that use it are exercised end-to-end
+// against the live database (see the ticket), not here — this file has no DB.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { escapeLikePattern } = require('./memory');
+
+test('a plain hyphenated slug prefix is unchanged', () => {
+    // Actor slugs are hyphenated, so the common case must pass through verbatim.
+    assert.strictEqual(escapeLikePattern('anne-walker/memory/'), 'anne-walker/memory/');
+});
+
+test('an underscore is escaped (it is a single-char LIKE wildcard)', () => {
+    assert.strictEqual(escapeLikePattern('anne_walker/'), 'anne\\_walker/');
+});
+
+test('a percent is escaped (it is a multi-char LIKE wildcard)', () => {
+    assert.strictEqual(escapeLikePattern('100%/'), '100\\%/');
+});
+
+test('a backslash is escaped first so it cannot re-arm another metacharacter', () => {
+    // Input "\_" must become "\\\_": the backslash doubles, and the underscore
+    // is independently escaped. If backslash were escaped last, "\_" would wrongly
+    // collapse to a single escaped underscore.
+    assert.strictEqual(escapeLikePattern('\\_'), '\\\\\\_');
+});
+
+test('mixed metacharacters are each escaped', () => {
+    assert.strictEqual(escapeLikePattern('a%b_c\\d'), 'a\\%b\\_c\\\\d');
+});
+
+test('an empty string yields an empty string', () => {
+    assert.strictEqual(escapeLikePattern(''), '');
+});


### PR DESCRIPTION
## Problem

Salem is adding per-NPC memory (LLM-356). Seven NPCs share one memory-API namespace (`salem-vendor`); to give each its own private memory without minting seven namespaces, each NPC's notes get a slug prefix (`anne-walker/memory/...`). That requires `/v1/memory/search` to scope **below** a namespace by slug prefix — which it cannot do today. `searchMemory` takes only `query`, `namespace`, `limit`.

Separately, `documents.last_accessed` fed search decay (age = `GREATEST(created_at, updated_at, last_accessed)`) and the access boost, but was only ever **written** by `readNote` on a direct read. A note repeatedly surfaced by search still decayed as if untouched — retrieval never reinforced it.

## Fix

- **`searchMemory(query, namespace, limit, readableNamespaces, actorId, slugPrefix)`** — new 6th trailing param. When set, both inner selects (wildcard-namespace and single-namespace paths) get `AND LOWER(mc.source_file) LIKE $n ESCAPE '\'`. Applying it to only one path would be a silent leak. Undefined = no filter, so the four existing callers are byte-for-byte unchanged (appended, not inserted; all call positionally).
- **`escapeLikePattern()`** escapes `\ % _` so a caller prefix can't act as a wildcard — `sanitize.identifier` permits `_`, a genuine over-match risk. Backslash escaped first. The route runs `slug_prefix` through `sanitize.identifier`.
- **`stampLastAccessed()`** — after a search, fire-and-forget `UPDATE documents SET last_accessed = NOW()` over the returned `(namespace, source_file)` pairs. Now retrieval reinforces a memory. A failure is recorded via `handleError` (`system_errors`) — the same path `readNote`'s stamp uses — never silently swallowed.
- **`listNotes`** SELECTs `last_accessed` in both branches so callers can prune least-recently-used.

## Coverage

- `escapeLikePattern` unit-tested (`memory.test.js`, 6 cases, `node --test`).
- SQL validated against the live production DB (all rolled back): the prefix filter narrows (`shared/tasks/` = 3710 chunks vs `shared/notes/` = 1802); `ESCAPE '\'` treats `_` literally (`ab_c` matches `ab\_%`, `abxc` does not); the `unnest` stamp UPDATEs a real row (changed = true) and no-ops (`UPDATE 0`) on a missing pair.
- Reviewed by the `code_review` agent: no correctness/security blockers. Its one ask — don't swallow the stamp failure silently — is addressed via `handleError`.

Not exposing `slug_prefix` on the MCP `search` tool schema; the salem engine calls the HTTP route directly. Unblocks LLM-356.

— Home
