### PR TITLE
LLM-238: clamp VA RAG embedding query to the 8192-token embed budget

### DIFF
--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -32,12 +32,34 @@ const FILLER_WORDS = new Set([
     'please', 'thanks', 'thank',
 ]);
 
+// OpenAI's text-embedding-3-small caps each input at 8192 tokens. Search callers
+// pass raw inbound content — a virtual agent's mail subject+body, chat turns, a
+// discussion topic — that routinely exceeds that (a review diff mailed to
+// code_review is 25KB+). Without a clamp the embeddings API 400s and the caller
+// (loadRAGContext) swallows it, so the VA answers with zero memory recall exactly
+// when context matters most, leaving only a rag-error journal line. Clamp by chars:
+// the codebase carries no tokenizer, and ~3 chars/token for dense diffs keeps this
+// near 6000 tokens, well under the cap. Truncating a search query is cheap —
+// semantic search over the head of a long message is nearly as good as the whole,
+// and far better than the empty-recall fallback.
+const MAX_EMBED_QUERY_CHARS = 18000;
+
 function preprocessQuery(query) {
     // Defensive guard — the MCP dispatcher validates required fields, but
     // the /v1/search HTTP route and internal callers may reach here with a
     // non-string. Return empty to keep embedding calls from crashing; the
     // caller will get "no results" rather than a 500.
     if (typeof query !== 'string') return '';
+    // Clamp before any processing so every return path below — including the two
+    // raw-query fallbacks — stays within the embedding budget. slice() cuts UTF-16
+    // code units, so it can land inside a surrogate pair; drop a dangling high
+    // surrogate so the truncated query holds no malformed trailing character.
+    if (query.length > MAX_EMBED_QUERY_CHARS) {
+        query = query.slice(0, MAX_EMBED_QUERY_CHARS);
+        if (/[\uD800-\uDBFF]$/.test(query)) {
+            query = query.slice(0, -1);
+        }
+    }
     let cleaned = query.trim();
     // Strip leading filler phrases (apply repeatedly for stacked phrases)
     let prev;
@@ -462,4 +484,4 @@ async function ingestStatus(namespace) {
     return { files: result.rows };
 }
 
-module.exports = { ingestContent, searchMemory, deleteMemory, cleanupMemory, ingestStatus, escapeLikePattern };
+module.exports = { ingestContent, searchMemory, deleteMemory, cleanupMemory, ingestStatus, escapeLikePattern, preprocessQuery, MAX_EMBED_QUERY_CHARS };

--- a/node/api/src/services/memory.test.js
+++ b/node/api/src/services/memory.test.js
@@ -1,13 +1,14 @@
 // Run with: node --test (from node/api). Uses the built-in node:test runner.
 //
 // Covers escapeLikePattern — the LIKE-metacharacter escaping that keeps a
-// caller-supplied slug prefix from acting as a wildcard (LLM-355). The SQL
-// filtering and last_accessed stamping that use it are exercised end-to-end
-// against the live database (see the ticket), not here — this file has no DB.
+// caller-supplied slug prefix from acting as a wildcard (LLM-355) — and
+// preprocessQuery's embed-budget clamp (LLM-238). The SQL filtering and
+// last_accessed stamping are exercised end-to-end against the live database
+// (see the ticket), not here — this file has no DB.
 
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { escapeLikePattern } = require('./memory');
+const { escapeLikePattern, preprocessQuery, MAX_EMBED_QUERY_CHARS } = require('./memory');
 
 test('a plain hyphenated slug prefix is unchanged', () => {
     // Actor slugs are hyphenated, so the common case must pass through verbatim.
@@ -35,4 +36,44 @@ test('mixed metacharacters are each escaped', () => {
 
 test('an empty string yields an empty string', () => {
     assert.strictEqual(escapeLikePattern(''), '');
+});
+
+// --- preprocessQuery embed-budget clamp (LLM-238) ---
+// OpenAI's embeddings endpoint 400s on inputs over 8192 tokens. A 25KB+ inbound
+// message (a review diff mailed to a virtual agent) would otherwise reach embed()
+// unclamped and drop the VA's entire RAG recall. The clamp must bound EVERY return
+// path, including the two raw-query fallbacks that fire when filler-stripping empties
+// the query.
+
+test('an over-budget single-token query is clamped to the char budget', () => {
+    // No whitespace, no filler — exercises the normal return path with a query that
+    // survives stripping intact, so only the clamp keeps it in budget.
+    const huge = 'a'.repeat(MAX_EMBED_QUERY_CHARS + 5000);
+    assert.strictEqual(preprocessQuery(huge).length, MAX_EMBED_QUERY_CHARS);
+});
+
+test('an over-budget all-filler query stays clamped via the fallback path', () => {
+    // 'the' is a filler word, so stripping empties the word list and preprocessQuery
+    // falls back to returning the (now clamped) raw query. Regression guard: the
+    // fallback must not leak the full oversized input.
+    const huge = 'the '.repeat(Math.ceil((MAX_EMBED_QUERY_CHARS + 5000) / 4));
+    assert.ok(preprocessQuery(huge).length <= MAX_EMBED_QUERY_CHARS);
+});
+
+test('a truncation landing inside a surrogate pair drops the dangling half', () => {
+    // Budget-1 'a's push the cut point onto the first emoji, so a naive slice would
+    // keep a lone high surrogate. The guard must drop it — no malformed trailing char.
+    const query = 'a'.repeat(MAX_EMBED_QUERY_CHARS - 1) + '😀'.repeat(100);
+    const out = preprocessQuery(query);
+    assert.ok(out.length <= MAX_EMBED_QUERY_CHARS);
+    assert.ok(!/[\uD800-\uDBFF]$/.test(out), 'must not end on a lone high surrogate');
+});
+
+test('an under-budget query is still filler-stripped unchanged', () => {
+    // The clamp must not alter normal queries — same behavior as before LLM-238.
+    assert.strictEqual(preprocessQuery('how does the auth middleware work'), 'auth middleware work');
+});
+
+test('a non-string query still yields empty (guard preserved)', () => {
+    assert.strictEqual(preprocessQuery(null), '');
 });


### PR DESCRIPTION
## Problem

Virtual-agent RAG recall silently drops on large inbound messages. The search path `loadRAGContext` → `searchMemory` → `preprocessQuery` → `embed()` sends the query to OpenAI `text-embedding-3-small`, hard-capped at **8192 tokens** per input. The three callers build the query from raw inbound content — mail `subject+body`, chat turns, discussion topic — and a review diff mailed to `code_review` is routinely 25KB+. Over the cap, `embed()` returns HTTP 400, `loadRAGContext` catches it and returns `''`, so the VA answers with **zero memory recall** exactly when context matters most. The only trace is a `rag-error` journal line.

Observed live 2026-07-03: `OpenAI API error 400: ... Invalid 'input[0]': maximum input length is 8192 tokens.`

## Fix

Clamp the raw query to `MAX_EMBED_QUERY_CHARS` (18000) at the **top of `preprocessQuery`** — the single chokepoint for every search caller (the three VA paths plus `/v1/search` and MCP search). Placing it before any processing bounds every return path, including the two raw-query fallbacks that fire when filler-stripping empties the query.

- **Char-based, not token-based**: the repo carries no tokenizer and truncates by chars everywhere (`MAX_CONTEXT=100000`, enrichment's 4000). Dense diffs run ~3 chars/token, so 18000 chars ≈ 6000 tokens — headroom under the cap. Over-truncating a *search query* is cheap: semantic search over the head of a long message is nearly as good as the whole, and far better than the empty-recall fallback.
- **`preprocessQuery`, not `embed()`**: `embed()` is also the ingest path, where silent truncation of a source chunk would corrupt indexed content and hide chunker bugs. The clamp belongs to search only.
- Drops a dangling high surrogate if the slice lands inside a UTF-16 surrogate pair, so the truncated query holds no malformed trailing character.
- The `rag-error` log is kept for genuinely unexpected failures.

Out of scope: the ingest path (`embed` over chunks) has the same latent 8192 exposure if the chunker ever emits an oversized chunk — a separate concern from this search-query bug.

## Coverage

`node --test src/services/memory.test.js` — 11 pass. New cases exercise: over-budget single-token query clamps to the budget; over-budget all-filler query stays clamped via the fallback path; surrogate-pair cut drops the dangling half; under-budget query still filler-stripped unchanged; non-string guard preserved. Reviewed by `code_review` (GPT-5.4) — no blockers.

— Home
