### PR TITLE
LLM-241: gate engine-internal /sim routes to the salem-engine service identity

### DIFF
--- a/node/api/src/routes/sim.js
+++ b/node/api/src/routes/sim.js
@@ -14,6 +14,41 @@ const router = Router();
 // a clean 400 instead.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// requireSalemEngine — service-identity gate for the engine-internal /sim routes
+// (LLM-241). The blanket `app.use('/v1', auth)` accepts ANY authenticated actor
+// (home, work, wendy, every virtual agent), so without this gate any of them
+// could trigger an LLM soul synthesis (real cost) or write a narrative note into
+// a target agent's namespace. These routes are only ever legitimately called by
+// the salem engine, which authenticates with its fixed API key as the actor
+// `salem-engine` — middleware/auth sets that name on req.authenticatedAgent for
+// both the session and API-key paths. An admin web session sets
+// req.authenticatedUser instead (leaving req.authenticatedAgent undefined), so
+// it's rejected here too — these are not part of the admin-UI surface. Mirrors
+// the `salem-engine` principal check already used in routes/chat.js. This gate
+// deliberately does NOT cover /sim/raw-turns, which is operator-facing (home/work
+// debugging via the salem umbilical) and keeps its own plugins/administer gate.
+function requireSalemEngine(req, res, next) {
+    if (req.authenticatedAgent !== 'salem-engine') {
+        return res.status(403).json({
+            error: { code: 'FORBIDDEN', message: 'This route is restricted to the salem-engine service account' }
+        });
+    }
+    next();
+}
+
+// Engine-internal /sim sub-router. Registering the engine-only routes here and
+// gating the whole sub-router once (engineRouter.use below) applies the service
+// identity as a SET: a future engine-internal /sim route added to engineRouter
+// inherits the gate automatically, instead of each route carrying its own copy
+// that a new one could forget to add. It's mounted at the `/sim` path at the
+// bottom of this file (router.use('/sim', engineRouter)) so the gate only ever
+// runs for /sim/* requests — a bare mount would run it against fall-through
+// traffic bound for the routers mounted after this one (e.g. adminRoutes).
+// /sim/raw-turns stays on the parent `router` and MUST be registered before that
+// mount so it matches first and never enters this gated sub-router.
+const engineRouter = Router();
+engineRouter.use(requireSalemEngine);
+
 // POST /v1/sim/conversation-day
 //
 // Receives a daily activity push from salem-engine for one sim NPC and
@@ -27,7 +62,11 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 // Idempotent — re-pushing the same (agent, day) overwrites the note.
 // 400 for malformed payload, 404 for unknown agent, 400 for non-sim
 // dream_mode.
-router.post('/sim/conversation-day', apiRoute('sim', 'conversation_day', async (req, res) => {
+//
+// Engine-internal: gated to the salem-engine service identity via engineRouter
+// (LLM-241). Registered relative to the `/sim` mount, so the full path stays
+// /v1/sim/conversation-day.
+engineRouter.post('/conversation-day', apiRoute('sim', 'conversation_day', async (req, res) => {
     // Defensive body fallback — express.json gives us {} for empty bodies
     // but a missing Content-Type or unparseable body leaves req.body
     // undefined, which would throw inside sanitize.agentName before our
@@ -267,8 +306,12 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
 // their day material here and stores the returned prose in
 // actor_narrative_state.about_me.
 //
-// Gated on plugins/administer — same capability as /sim/raw-turns, reachable by
-// the salem engine's authenticated AGENT session (not the web admin UI).
+// Engine-internal: gated to the salem-engine service identity via engineRouter
+// (LLM-241) — not reachable by other authenticated agents or the web admin UI.
+// (LLM-239 first dropped an over-broad plugins/administer gate that 403'd the
+// engine's own service key; LLM-241 replaces the resulting any-/v1-actor posture
+// with the narrow service-identity check.) Registered relative to the `/sim`
+// mount, so the full path stays /v1/sim/soul.
 //
 // Body: { character_description, current_soul?, day_snapshot, day? }
 //   character_description — live-composed per-actor seed (name + dwelling +
@@ -281,7 +324,7 @@ router.post('/sim/raw-turns', requirePerm('plugins', 'administer'), apiRoute('si
 // model produced nothing usable (empty reply or reasoning-preamble leakage), in
 // which case the engine keeps the prior soul. 400 on missing/oversized fields,
 // 503 when the soul agent isn't configured.
-router.post('/sim/soul', apiRoute('sim', 'soul', async (req, res) => {
+engineRouter.post('/soul', apiRoute('sim', 'soul', async (req, res) => {
     const body = req.body || {};
     const result = await synthesizeSimSoul({
         characterDescription: body.character_description,
@@ -291,5 +334,17 @@ router.post('/sim/soul', apiRoute('sim', 'soul', async (req, res) => {
     });
     res.json(result);
 }));
+
+// Mount the engine-internal sub-router at /sim. This comes AFTER /sim/raw-turns
+// is registered on the parent router above, so a /sim/raw-turns request matches
+// that operator-gated route first and never enters the salem-engine gate here.
+// The mount path is /sim (not bare) so requireSalemEngine only runs for /sim/*
+// traffic, not fall-through requests bound for routers mounted after this one.
+router.use('/sim', engineRouter);
+
+// Exported for unit testing the service-identity gate in isolation (there's no
+// route/supertest harness in this repo). Mirrors auth.js attaching sessionCache
+// to its exported middleware.
+router.requireSalemEngine = requireSalemEngine;
 
 module.exports = router;

--- a/node/api/src/routes/sim.test.js
+++ b/node/api/src/routes/sim.test.js
@@ -1,0 +1,82 @@
+// Tests for requireSalemEngine — the service-identity gate on the engine-internal
+// /sim routes (soul + conversation-day), added in LLM-241. Run with: node --test
+// (from node/api). Uses the built-in node:test runner + node:assert, matching
+// sim-soul.test.js / sim-conversation-distiller.test.js — no test-framework dep.
+//
+// There's no route/supertest harness in this repo, so we exercise the middleware
+// function directly with a minimal req/res/next triple. The gate is a pure
+// synchronous predicate over req.authenticatedAgent, so this fully covers it: the
+// only legitimate caller is the salem-engine service account; every other
+// authenticated actor (normal agent, admin/user web session) must be rejected.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { requireSalemEngine } = require('./sim');
+
+// Minimal res double: captures the status code and JSON body, and records
+// whether a response was sent. res.status(n) returns res so the route's
+// `res.status(403).json(...)` chain works.
+function makeRes() {
+    return {
+        statusCode: null,
+        body: null,
+        sent: false,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            this.sent = true;
+            return this;
+        },
+    };
+}
+
+test('allows the salem-engine service account through', () => {
+    const req = { authenticatedAgent: 'salem-engine' };
+    const res = makeRes();
+    let nextCalled = false;
+
+    requireSalemEngine(req, res, () => { nextCalled = true; });
+
+    assert.equal(nextCalled, true, 'next() should be called for salem-engine');
+    assert.equal(res.sent, false, 'no response should be sent on the allow path');
+});
+
+test('rejects a normal authenticated agent with 403', () => {
+    const req = { authenticatedAgent: 'work' };
+    const res = makeRes();
+    let nextCalled = false;
+
+    requireSalemEngine(req, res, () => { nextCalled = true; });
+
+    assert.equal(nextCalled, false, 'next() must not be called for a non-engine agent');
+    assert.equal(res.statusCode, 403);
+    assert.equal(res.body.error.code, 'FORBIDDEN');
+});
+
+test('rejects an admin/user web session (no authenticatedAgent) with 403', () => {
+    // Web/admin sessions set req.authenticatedUser and leave authenticatedAgent
+    // undefined — these routes are engine-internal, not part of the admin surface.
+    const req = { authenticatedUser: { id: 1, username: 'jeff' } };
+    const res = makeRes();
+    let nextCalled = false;
+
+    requireSalemEngine(req, res, () => { nextCalled = true; });
+
+    assert.equal(nextCalled, false, 'next() must not be called for an admin/user session');
+    assert.equal(res.statusCode, 403);
+    assert.equal(res.body.error.code, 'FORBIDDEN');
+});
+
+test('rejects an unauthenticated request (no principal at all) with 403', () => {
+    const req = {};
+    const res = makeRes();
+    let nextCalled = false;
+
+    requireSalemEngine(req, res, () => { nextCalled = true; });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 403);
+});


### PR DESCRIPTION
## What
Adds a service-identity gate so the engine-internal `/sim` routes — `/sim/soul` and `/sim/conversation-day` — require the **salem-engine** service account, instead of accepting any `/v1`-authenticated actor.

## Why
Every agent authenticates to `/v1` (home, work, wendy, all virtual agents), and these two routes were gated only by the blanket `app.use('/v1', auth)`. So any authenticated actor could trigger an LLM soul synthesis (real cost) or write a narrative note into a target agent's namespace. They're only ever legitimately called by the salem engine. This is the hardening follow-up flagged in the LLM-239 review (LLM-239 dropped an over-broad `plugins/administer` gate from `/sim/soul`, which had 403'd the engine's own key; it left the routes open to any `/v1` actor).

## How
- `requireSalemEngine` middleware: `403` unless `req.authenticatedAgent === 'salem-engine'`.
- The two engine-internal routes are grouped on a sub-router (`engineRouter`) gated once via `engineRouter.use(requireSalemEngine)` — so a future engine-internal `/sim` route inherits the gate (applied "as a set", per the ticket).
- Mounted at `/sim` (not bare) so the gate only runs for `/sim/*` traffic, never fall-through requests bound for routers mounted after `simRoutes` (e.g. `adminRoutes`).
- `/sim/raw-turns` is **not** in the set — it's operator-facing (home/work debug via the umbilical) and keeps `requirePerm('plugins','administer')`; it's registered before the mount so it matches first.
- `req.authenticatedAgent` is set only from validated auth state in `middleware/auth.js` (session / API-key lookup), never from request input — verified across the codebase.

## Testing
- 4 `node:test` unit tests on the middleware (salem-engine passes; normal agent, admin/user session, and unauthenticated all 403).
- Throwaway express harness: `work` → gate 403 on soul + conversation-day; `work` on raw-turns → `requirePerm`'s 403 (not the gate); `salem-engine` → passes gate, reaches handler.
- Independent code_review pass: no blocking issues; Express mount/ordering reasoning confirmed.

Docs: `sim-soul-endpoint` and `auth` codebase notes updated.

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)