### PR TITLE
Fix chunker emitting title-only chunks that break NPC recall

### DIFF
--- a/node/api/src/services/chunker.js
+++ b/node/api/src/services/chunker.js
@@ -1,32 +1,65 @@
+// A markdown H1–H3 heading line. Same test used to split sections and to
+// detect a section that carries no prose.
+function isHeadingLine(line) {
+    return /^#{1,3}\s/.test(line);
+}
+
+// True when `lines` holds at least one non-blank line that is NOT a heading —
+// i.e. real prose under the heading(s), not just stacked heading lines.
+function hasProse(lines) {
+    return lines.some(l => l.trim() !== '' && !isHeadingLine(l));
+}
+
 function chunkByHeading(content) {
     const lines = content.split('\n');
     const chunks = [];
     let currentHeading = null;
     let currentLines = [];
 
+    // Emit the accumulated section, but ONLY if it has prose under its heading.
+    // A heading with no body — e.g. a note whose "# Title" line is immediately
+    // followed by a "## Section" line — would otherwise become a chunk whose
+    // chunk_text is just the title. That title-only chunk is short and on-topic,
+    // so it out-ranks the note's real body chunks in search, and the recall tool
+    // strips its heading and renders an empty "— Title —" with no content
+    // (observed for the sim NPC dream notes, which are all "# A Day of … at the
+    // Inn" followed straight by "## Notable scenes"). Dropping it lets the body
+    // sections be the hits. The whole-note fallback below keeps a heading-only
+    // note searchable.
+    const flush = () => {
+        if (currentLines.length === 0) {
+            return;
+        }
+        const text = currentLines.join('\n').trim();
+        if (text && hasProse(currentLines)) {
+            chunks.push({
+                heading: currentHeading,
+                chunk_text: text
+            });
+        }
+    };
+
     for (const line of lines) {
-        if (line.match(/^#{1,3}\s/)) {
-            if (currentLines.length > 0) {
-                const text = currentLines.join('\n').trim();
-                if (text) {
-                    chunks.push({
-                        heading: currentHeading,
-                        chunk_text: text
-                    });
-                }
-            }
+        if (isHeadingLine(line)) {
+            flush();
             currentHeading = line.trim();
             currentLines = [line];
         } else {
             currentLines.push(line);
         }
     }
+    flush();
 
-    if (currentLines.length > 0) {
-        const text = currentLines.join('\n').trim();
+    // Fallback: a note built entirely of headings with no prose produces no
+    // chunks above and would become unsearchable. Preserve findability by
+    // emitting the whole trimmed content as one chunk (its heading text is all
+    // it has to match on).
+    if (chunks.length === 0) {
+        const text = content.trim();
         if (text) {
+            const firstHeading = lines.find(isHeadingLine);
             chunks.push({
-                heading: currentHeading,
+                heading: firstHeading ? firstHeading.trim() : null,
                 chunk_text: text
             });
         }

--- a/node/api/src/services/chunker.test.js
+++ b/node/api/src/services/chunker.test.js
@@ -1,0 +1,122 @@
+// Run with: node --test (from node/api). Uses the built-in node:test runner.
+//
+// Covers chunkByHeading — in particular the rule that a heading with no prose
+// under it must NOT become its own chunk (the title-only chunk that used to
+// out-rank real body sections in search and render as an empty "— Title —" in
+// the recall tool).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { chunkByHeading } = require('./chunker');
+
+test('an H1 title immediately followed by an H2 does not emit a title-only chunk', () => {
+    // This is the sim NPC dream-note shape: "# A Day …" straight into a section
+    // heading with no prose between them.
+    const content = [
+        '# A Day of Trade and Hospitality at the Inn',
+        '',
+        '## Notable scenes',
+        'Hannah had a series of conversations with the villagers.',
+        '',
+        '## Decisions',
+        'Hannah decided to trade flour for nails.',
+    ].join('\n');
+
+    const chunks = chunkByHeading(content);
+
+    // No chunk should be just the title line.
+    for (const c of chunks) {
+        assert.notStrictEqual(
+            c.chunk_text.trim(),
+            '# A Day of Trade and Hospitality at the Inn',
+            'title-only chunk must not be emitted'
+        );
+        assert.ok(
+            /[a-z]/.test(c.chunk_text.replace(/^#{1,3}\s.*$/gm, '')),
+            `chunk must carry prose, got: ${JSON.stringify(c.chunk_text)}`
+        );
+    }
+
+    // The two real sections survive as chunks with their bodies.
+    assert.strictEqual(chunks.length, 2);
+    assert.strictEqual(chunks[0].heading, '## Notable scenes');
+    assert.match(chunks[0].chunk_text, /series of conversations/);
+    assert.strictEqual(chunks[1].heading, '## Decisions');
+    assert.match(chunks[1].chunk_text, /trade flour for nails/);
+});
+
+test('a normal multi-section note keeps one chunk per section', () => {
+    const content = [
+        '## Intro',
+        'First paragraph.',
+        '',
+        '## Body',
+        'Second paragraph.',
+    ].join('\n');
+
+    const chunks = chunkByHeading(content);
+
+    assert.strictEqual(chunks.length, 2);
+    assert.strictEqual(chunks[0].heading, '## Intro');
+    assert.match(chunks[0].chunk_text, /First paragraph/);
+    assert.strictEqual(chunks[1].heading, '## Body');
+    assert.match(chunks[1].chunk_text, /Second paragraph/);
+});
+
+test('an H1 with prose directly under it (no subheading) is one chunk', () => {
+    const content = [
+        '# Title',
+        'Prose right under the title.',
+    ].join('\n');
+
+    const chunks = chunkByHeading(content);
+
+    assert.strictEqual(chunks.length, 1);
+    assert.strictEqual(chunks[0].heading, '# Title');
+    assert.match(chunks[0].chunk_text, /Prose right under the title/);
+});
+
+test('content with no headings becomes a single null-heading chunk', () => {
+    const content = 'Just a paragraph of prose with no headings at all.';
+
+    const chunks = chunkByHeading(content);
+
+    assert.strictEqual(chunks.length, 1);
+    assert.strictEqual(chunks[0].heading, null);
+    assert.strictEqual(chunks[0].chunk_text, content);
+});
+
+test('a trailing heading with no body under it is dropped', () => {
+    const content = [
+        '## Real section',
+        'Has content.',
+        '',
+        '## Empty trailer',
+    ].join('\n');
+
+    const chunks = chunkByHeading(content);
+
+    assert.strictEqual(chunks.length, 1);
+    assert.strictEqual(chunks[0].heading, '## Real section');
+    assert.match(chunks[0].chunk_text, /Has content/);
+});
+
+test('a note made entirely of headings stays searchable via the fallback', () => {
+    // No prose anywhere — must not vanish from the index.
+    const content = [
+        '# Title Only',
+        '## Section A',
+        '## Section B',
+    ].join('\n');
+
+    const chunks = chunkByHeading(content);
+
+    assert.strictEqual(chunks.length, 1);
+    assert.strictEqual(chunks[0].heading, '# Title Only');
+    assert.strictEqual(chunks[0].chunk_text, content.trim());
+});
+
+test('empty / whitespace-only content produces no chunks', () => {
+    assert.deepStrictEqual(chunkByHeading(''), []);
+    assert.deepStrictEqual(chunkByHeading('   \n\n  '), []);
+});


### PR DESCRIPTION
## Problem
Salem NPC recall (semantic search over an NPC's own memory) returned five near-identical dream titles with **empty bodies** for the innkeeper Hannah. Confirmed against the live `/v1/memory/search`: the note-grouped search (best chunk per `source_file`, `rn=1`) returned a **title-only chunk** as the winner for every dream note — `chunk_text` identical to the `# H1` title, no body — at similarity 0.758, out-ranking the notes' real body sections.

## Root cause
`chunkByHeading` seeds each new chunk with its heading line and flushes on the next heading. When an `# H1` has no prose before the following `## H2` (exactly how the NPC dream notes are shaped — `# A Day of … at the Inn` straight into `## Notable scenes`), it flushes a chunk whose text is only the title. Short + on-topic ⇒ it beats the body chunks in cosine + BM25; the salem recall renderer then strips the heading and prints an empty `— Title —`.

This chunker runs on **every** note ingest in the memory system, so the change is deliberately conservative.

## Fix
Only emit a section chunk when it carries prose (a non-blank, non-heading line). Heading-only sections are dropped so the real body sections become the search hits. A fallback emits the whole note as a single chunk when it is nothing but headings, preserving index findability. The `{heading, chunk_text}` contract is unchanged.

## Tests
`node --test` full services+routes suite: **53 pass / 0 fail**, including 7 new `chunker.test.js` cases (dream shape, normal multi-section, H1-with-direct-prose, no-heading prose, trailing bare heading, all-headings fallback, empty content).

Independent code_review (GPT): no blocking issues — "I'd ship this."

## Note
Takes effect on **newly ingested / re-ingested** notes; existing chunks stay title-chunked until their notes are re-saved (nightly dream sim writes new dreams correctly going forward). This fixes the mechanical empty-body bug only — the separate low-value issue of near-identical generic dream *titles* is a salem dream-synthesis prompt concern, not addressed here.

— Work