### PR TITLE
LLM-219: carry account email forward onto actors

### DIFF
--- a/migrations/MEM-140-actor-email_down.sql
+++ b/migrations/MEM-140-actor-email_down.sql
@@ -1,0 +1,3 @@
+-- MEM-140 down: drop the actors.email column (the partial index drops with it).
+
+ALTER TABLE actors DROP COLUMN email;

--- a/migrations/MEM-140-actor-email_up.sql
+++ b/migrations/MEM-140-actor-email_up.sql
@@ -1,0 +1,56 @@
+-- MEM-140: carry the account's email forward onto actors (LLM-219).
+--
+-- Every real account is born from an access_request that holds the person's
+-- email (landing-page "Ask for Free Access" — auto-approved when
+-- open_registration is on, else admin-approved). But registration only ever
+-- wrote back invite_codes.used_by = '<handle string>', so the account itself
+-- carried NO identity: actors has never had an email column. Recovering "who is
+-- this account / what's their email" (the sirius42 stand-down) meant hand-
+-- joining access_requests -> invite_codes.used_by -> actors.name, a fragile
+-- name-string chain that breaks the moment two requests are approved close
+-- together.
+--
+-- Fix: a nullable email on actors, copied forward at account-creation time
+-- (registration + admin /admin/actors/create), so the account self-describes.
+-- Nullable because sim NPCs (zbbs realm), utility bots, and legacy accounts
+-- have no human behind them. Not UNIQUE: one person may own several agents,
+-- and sub-agents inherit their creator's email.
+--
+-- Backfill walks the existing (reliable) chain: for any invite code that was
+-- used (used_by = an actor name) and is tied to an access_request, stamp that
+-- request's email onto the matching actor. Accounts that registered before the
+-- invite flow, or whose used_by was never populated (the sirius42/greg cases),
+-- fall through this join and are reconciled by hand against live data.
+
+BEGIN;
+
+ALTER TABLE actors ADD COLUMN email VARCHAR(255);
+
+-- Recovery lookup: email -> account. Partial (the column is NULL for every
+-- sim/bot/legacy row, which is most of them).
+CREATE INDEX idx_actors_email ON actors (email) WHERE email IS NOT NULL;
+
+-- Backfill from the existing access_request -> invite_code -> used_by chain.
+-- Only stamp accounts whose chain resolves to a SINGLE distinct email: an actor
+-- name that matches invite codes carrying two different emails is exactly the
+-- ambiguous historical case this ticket calls out, and a bare UPDATE ... FROM
+-- join would pick one arbitrarily. Ambiguous names (email_count > 1) and names
+-- with no chain are left NULL for manual reconcile against live data.
+WITH resolved AS (
+    SELECT a.id AS actor_id,
+           MIN(ar.email)              AS email,
+           COUNT(DISTINCT ar.email)   AS email_count
+    FROM actors a
+    JOIN invite_codes ic     ON ic.used_by = a.name
+    JOIN access_requests ar  ON ar.id = ic.access_request_id
+    WHERE a.email IS NULL
+      AND ar.email IS NOT NULL
+    GROUP BY a.id
+)
+UPDATE actors a
+SET email = r.email
+FROM resolved r
+WHERE r.actor_id = a.id
+  AND r.email_count = 1;
+
+COMMIT;

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1519,7 +1519,7 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
     const { name, provider, model, welcome_template_id, welcome_note_template_id, virtual: isVirtual, personality,
             cost_budget_daily, cost_budget_monthly,
             cache_prompts, learning_enabled, max_tokens, temperature, configuration,
-            ui_access, password, dream_mode, dream_source } = req.body;
+            ui_access, password, dream_mode, dream_source, email } = req.body;
 
     if (!name || !name.trim()) {
         return res.status(400).json({
@@ -1554,6 +1554,15 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
                 error: { code: 'BAD_REQUEST', message: 'temperature must be a number between 0 and 2' }
             });
         }
+    }
+
+    // Bound an explicit email to the actors.email column width (VARCHAR(255)),
+    // matching the access-request form's cap, so an over-long value returns a
+    // controlled 400 rather than failing the actor INSERT with a DB error.
+    if (typeof email === 'string' && email.trim().length > 255) {
+        return res.status(400).json({
+            error: { code: 'BAD_REQUEST', message: 'email must be 255 characters or less' }
+        });
     }
 
     // Check if actor name is available (existing actors + namespace collisions)
@@ -1591,17 +1600,28 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
     try {
         await client.query('BEGIN');
 
-        // Inherit realms from the creator so new agents land in the same realm(s)
-        const creatorRealms = await client.query('SELECT realms FROM actors WHERE id = $1', [req.authenticatedUser.id]);
-        const realms = (creatorRealms.rows[0] && creatorRealms.rows[0].realms.length > 0)
-            ? creatorRealms.rows[0].realms
+        // Inherit realms + identity email from the creator so new agents land
+        // in the same realm(s) and carry the creator's email forward (LLM-219).
+        const creatorRow = (await client.query('SELECT realms, email FROM actors WHERE id = $1', [req.authenticatedUser.id])).rows[0];
+        const realms = (creatorRow && creatorRow.realms.length > 0)
+            ? creatorRow.realms
             : ['llm-memory'];
+        // An explicit email in the request wins (admin provisioning a new
+        // person whose email isn't the creator's); otherwise inherit the
+        // creator's. Virtual agents aren't a human identity, so they stay NULL
+        // unless an email was passed explicitly.
+        let actorEmail = null;
+        if (typeof email === 'string' && email.trim()) {
+            actorEmail = email.trim();
+        } else if (isVirtual !== true && creatorRow) {
+            actorEmail = creatorRow.email || null;
+        }
 
         // Create actor
         const actorResult = await client.query(
-            `INSERT INTO actors (name, token_hash, token_salt, password_hash, password_salt, status, created_by, realms)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
-            [actorName, passphraseHash, passphraseSalt, passwordHash, passwordSalt, isVirtual === true ? 'available' : 'active', req.authenticatedUser.id, realms]
+            `INSERT INTO actors (name, token_hash, token_salt, password_hash, password_salt, status, created_by, realms, email)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
+            [actorName, passphraseHash, passphraseSalt, passwordHash, passwordSalt, isVirtual === true ? 'available' : 'active', req.authenticatedUser.id, realms, actorEmail]
         );
         actorId = actorResult.rows[0].id;
 

--- a/node/api/src/routes/registration.js
+++ b/node/api/src/routes/registration.js
@@ -148,13 +148,17 @@ router.post('/api/register', async (req, res) => {
     // validating in Phase 1: two valid concurrent uses of the same code
     // serialize on the row lock, and the loser sees used_by already set.
     let actorId;
+    // Email of the person this account belongs to, carried forward from the
+    // access request that provisioned the invite (LLM-219). NULL for code-less
+    // open registration, which collects no access request.
+    let registrantEmail = null;
     const client = await pool.connect();
     try {
         await client.query('BEGIN');
 
         if (inviteId !== null) {
             const relock = await client.query(
-                `SELECT used_by, expires_at, realm FROM invite_codes WHERE id = $1 FOR UPDATE`,
+                `SELECT used_by, expires_at, realm, access_request_id FROM invite_codes WHERE id = $1 FOR UPDATE`,
                 [inviteId]
             );
             if (relock.rows.length === 0) {
@@ -173,12 +177,24 @@ router.post('/api/register', async (req, res) => {
             // Take realm from the locked row — authoritative if an admin edited
             // the invite between the Phase 1 read and now.
             realm = r.realm || 'llm-memory';
+            // Carry the registrant's email forward from the access request this
+            // invite came from, so the account self-describes. Plain read (no
+            // lock) — the email is set at request-approval time and immutable.
+            if (r.access_request_id) {
+                const areq = await client.query(
+                    `SELECT email FROM access_requests WHERE id = $1`,
+                    [r.access_request_id]
+                );
+                if (areq.rows.length > 0) {
+                    registrantEmail = areq.rows[0].email;
+                }
+            }
         }
 
         // Create actor with realm
         await client.query(
-            `INSERT INTO actors (name, token_hash, token_salt, password_hash, password_salt, status, realms) VALUES ($1, $2, $3, $4, $5, 'active', $6)`,
-            [agentName, passphraseHash, salt, passwordHash, passwordSalt, [realm]]
+            `INSERT INTO actors (name, token_hash, token_salt, password_hash, password_salt, status, realms, email) VALUES ($1, $2, $3, $4, $5, 'active', $6, $7)`,
+            [agentName, passphraseHash, salt, passwordHash, passwordSalt, [realm], registrantEmail]
         );
         // Set created_by to self so the agent owns itself
         await client.query(


### PR DESCRIPTION
## What & why

Every real memory-system account is born from an `access_requests` row (landing "Ask for Free Access" — auto-approved when `open_registration` is on, else admin-approved), which is the **only** place the person's email is captured. But registration only wrote back `invite_codes.used_by` (a name string), so the `actors` row itself carried **no identity**. Recovering "who is this account / what's their email" (the sirius42 stand-down) required a fragile `access_requests → invite_codes.used_by → actors.name` join that breaks when two requests are approved close together.

## Change

- **MEM-140** — nullable `actors.email VARCHAR(255)` + partial index `idx_actors_email`. Backfill walks the existing chain but stamps **only** actors whose chain resolves to a single distinct email; ambiguous (multiple distinct emails) and no-chain accounts stay NULL for manual reconcile.
- **`/api/register`** ([registration.js](node/api/src/routes/registration.js)) — reads the consumed invite's linked `access_requests.email` inside the same Phase-3 transaction and stamps it on the new actor. Code-less open registration has no request → stays NULL.
- **`/admin/actors/create`** ([admin.js](node/api/src/routes/admin.js)) — explicit `email` in the body (length-capped to 255 → 400) wins; otherwise inherits the creator's `actors.email`, on the same rail as the existing realms inheritance. Virtual agents stay NULL unless email is passed explicitly.

## Design notes

- **Not** an FK-to-access_request; a plain email copy was chosen so the account self-describes with no join (both lookups: `actors.email`, and `WHERE email = $1`).
- **Kind classifier dropped.** Sim-vs-real separation already lives on `actors.realms` (`zbbs` = salem's world vs `llm-memory`); email is human identity, realm is world scope. No `kind`/`account_type` column.

## Review / testing

- Independent review by the `code_review` VA; findings applied (explicit-email length bound → 400; deterministic single-email backfill).
- No automated coverage: CI builds/tests only the Go client, and the repo has no Node route/supertest harness. Verified via `node --check` on both edited files + review. Migration is idempotent-safe on a fresh column (guards `email IS NULL`).

— Work