### PR TITLE
LLM-419: log chunk-soul-empty-response instead of skipping silently

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -674,7 +674,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
                         + backloadDreams
                     : '\n\n## Dream snapshot for ' + chunkDateStr + '\n\n' + content);
 
-            const { text: updatedSoul } = await invokeAgent(soulAgentName, {
+            const { text: updatedSoul, usage: soulUsage } = await invokeAgent(soulAgentName, {
                 userMessage: soulUserMessage,
                 context: 'soul',
                 skipRateLimit: true,
@@ -709,6 +709,20 @@ async function processDreamChunk(agent, agentNames, chunk) {
                     await saveNote(agent.name, 'Soul', trimmedSoul, 'context/soul', soulAgentName, null, null, { upsert: true });
                     logDream('chunk-soul-updated', { agent: agent.name, chunkDate: chunkDateStr, size: trimmedSoul.length });
                 }
+            } else {
+                // Empty/whitespace soul response — the writer returned no
+                // visible text (observed: gemini-2.5-pro spending its whole
+                // budget on thinking tokens, so output_tokens > 0 but the body
+                // is empty). Without this the branch skips silently: no save
+                // and no log, making an empty soul response indistinguishable
+                // from the step never running. Log it so it's visible in the
+                // dream journal, mirroring the people path's
+                // person-context-empty-response. The prior soul is left intact.
+                logDream('chunk-soul-empty-response', {
+                    agent: agent.name,
+                    chunkDate: chunkDateStr,
+                    outputTokens: soulUsage?.output_tokens ?? 0,
+                });
             }
         } catch (soulErr) {
             // Soul failure doesn't block the chunk's dream/people output.


### PR DESCRIPTION
## Problem

In `dream.js` `processDreamChunk()`, the soul save is gated `if (updatedSoul && updatedSoul.trim())`. Three outcomes log a `chunk-soul-*` journal line (updated, reasoning-preamble error, thrown error), but an **empty/whitespace** response falls through the `if` with no save and no log — making an empty soul response indistinguishable from the step never running.

On the 2026-07-15 04:04 run, `work`'s soul call returned `status=success` with `output_tokens=641` but an empty body (gemini-2.5-pro spent its whole budget on thinking tokens). The total absence of any `chunk-soul` line made it initially look like a server restart, though the process was alive (`home`'s soul wrote ~3 min later in the same `runDream()` loop).

## Fix

Add the missing `else` branch, mirroring the people path's `person-context-empty-response` (`dream.js:499`). Also destructure `usage` off the existing `invokeAgent` return and log `outputTokens`, so the journal line self-distinguishes "spent budget on thinking" from a genuinely empty call without cross-referencing `virtual_agent_calls`.

No behavior change beyond the log — the prior soul is left intact exactly as before. The "keep vs. rebuild on empty" decision is deferred to the related truncated-soul ticket.

## Verification

- `node --check` passes.
- Existing `dream.test.js` suite passes (3/3).
- No unit test added: `processDreamChunk` is unexported and has no mocking harness (the soul/cron path is exercised at deploy per the test file's own header); a test would require dependency-injection infra that doesn't exist, out of scope for an additive log line.

Reviewed by the code_review VA (accepted; adopted its `?.`/`??` suggestion for the usage fallback).

— Work