### PR TITLE
LLM-418: check finish_reason/stop_reason — guard persist paths against truncated completions

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -478,13 +478,25 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
         + '\n\n## Recent conversation excerpts involving ' + display + '\n\n'
         + excerptsBlock;
 
-    const { text: rawUpdatedFile } = await invokeAgent(peopleAgentName, {
+    const { text: rawUpdatedFile, truncated: peopleTruncated, finish_reason: peopleFinish } = await invokeAgent(peopleAgentName, {
         userMessage: peopleUserMessage,
         context: 'people',
         skipRateLimit: true,
         skipCostLimit: true,
         skipRetry: false,
     });
+
+    if (peopleTruncated) {
+        // Length-stop: the relationship file came back cut off. The writer
+        // rewrites the whole file each pass, so a truncated version drops the
+        // bullets it didn't reach — and that lossy file would feed back in as
+        // input next time. Leave the prior file intact.
+        logDream('person-context-error', {
+            agent: agentName, person: display, slug, today,
+            reason: 'truncated', finishReason: peopleFinish,
+        });
+        return { existingFile, updatedFile: '', written: false, changed: false, emptyResponse: false, truncated: true };
+    }
 
     const updatedFile = rawUpdatedFile && rawUpdatedFile.trim();
     const changed = !!(updatedFile && updatedFile !== existingFile.trim());
@@ -674,7 +686,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
                         + backloadDreams
                     : '\n\n## Dream snapshot for ' + chunkDateStr + '\n\n' + content);
 
-            const { text: updatedSoul, usage: soulUsage } = await invokeAgent(soulAgentName, {
+            const { text: updatedSoul, usage: soulUsage, truncated: soulTruncated, finish_reason: soulFinish } = await invokeAgent(soulAgentName, {
                 userMessage: soulUserMessage,
                 context: 'soul',
                 skipRateLimit: true,
@@ -682,7 +694,24 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 skipRetry: false,
             });
 
-            if (updatedSoul && updatedSoul.trim()) {
+            if (soulTruncated) {
+                // Length-stop: the writer hit its token ceiling and the soul
+                // came back cut off mid-thought (observed: gemini-2.5-pro's
+                // thinking budget eats the output cap, leaving a partial like
+                // "...Stabilize, Observe,"). The partial has non-empty text, so
+                // it would sail past the checks below — saving it would poison
+                // every future tick's system prompt AND compound on the next
+                // dream cycle, since the writer reads its own prior output as
+                // input. Skip the save; the prior soul stays intact. Same
+                // contract as the reasoning-preamble guard below.
+                logDream('chunk-soul-error', {
+                    agent: agent.name,
+                    chunkDate: chunkDateStr,
+                    reason: 'truncated',
+                    finishReason: soulFinish,
+                    size: (updatedSoul || '').length,
+                });
+            } else if (updatedSoul && updatedSoul.trim()) {
                 const trimmedSoul = updatedSoul.trim();
                 // Reject reasoning-preamble leakage. Some chat models
                 // (observed: qwen3.5-flash) ignore the "Output ONLY"
@@ -801,7 +830,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 + '## Day\'s conversation excerpts\n\n'
                 + filtered;
 
-            const { text: extractionResult } = await invokeAgent(learningsAgentName, {
+            const { text: extractionResult, truncated: learningsTruncated, finish_reason: learningsFinish } = await invokeAgent(learningsAgentName, {
                 userMessage: learningsUserMessage,
                 context: 'learnings',
                 skipRateLimit: true,
@@ -810,7 +839,17 @@ async function processDreamChunk(agent, agentNames, chunk) {
             });
 
             const trimmed = extractionResult ? extractionResult.trim() : '';
-            if (trimmed && trimmed.toUpperCase() !== 'NONE') {
+            if (learningsTruncated) {
+                // Length-stop: the day's learnings synthesis was cut off. It
+                // upserts (integrates with and replaces the existing note), so a
+                // truncated version would drop earlier bullets. Keep the prior note.
+                logDream('chunk-learnings-error', {
+                    agent: agent.name,
+                    chunkDate: chunkDateStr,
+                    reason: 'truncated',
+                    finishReason: learningsFinish,
+                });
+            } else if (trimmed && trimmed.toUpperCase() !== 'NONE') {
                 await saveNote(
                     agent.name,
                     'Learnings — ' + chunkDateStr,

--- a/node/api/src/services/providers/anthropic.js
+++ b/node/api/src/services/providers/anthropic.js
@@ -3,6 +3,7 @@
 
 const { log } = require('../logger');
 const { asNumber } = require('./coerce');
+const { normalizeAnthropicStop, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -357,9 +358,14 @@ function createCall(model, apiKey, configuration) {
             cache_read_input_tokens: data.usage?.cache_read_input_tokens || 0
         };
 
-        logProvider('api-response', { provider: 'anthropic', model, tool_calls: tool_calls.length, ...usage });
+        // stop_reason "max_tokens" means the response was cut at the token
+        // ceiling — surface it so callers that persist output don't save a
+        // partial document as if it were whole.
+        const finish_reason = normalizeAnthropicStop(data.stop_reason);
 
-        return { text, tool_calls, usage };
+        logProvider('api-response', { provider: 'anthropic', model, tool_calls: tool_calls.length, finish_reason, ...usage });
+
+        return { text, tool_calls, usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/providers/finish.js
+++ b/node/api/src/services/providers/finish.js
@@ -45,9 +45,14 @@ function normalizeResponsesStatus(status, incompleteReason, hasToolCall) {
         if (incompleteReason === 'content_filter') return FINISH.CONTENT_FILTER;
         return FINISH.OTHER;
     }
-    // status 'completed' (or absent — treat as completed)
-    if (hasToolCall) return FINISH.TOOL_CALLS;
-    return FINISH.STOP;
+    if (status === 'completed') {
+        return hasToolCall ? FINISH.TOOL_CALLS : FINISH.STOP;
+    }
+    // failed / cancelled / queued / in_progress / missing / any future status —
+    // NOT a clean stop. This normalizer is the persistence safety boundary, so
+    // never label an unrecognized status as success (a partial body on a failed
+    // response must not read as a whole generation).
+    return FINISH.OTHER;
 }
 
 // Anthropic Messages shape — top-level `stop_reason`.

--- a/node/api/src/services/providers/finish.js
+++ b/node/api/src/services/providers/finish.js
@@ -1,0 +1,91 @@
+// Normalizes each provider's native stop/truncation signal into one vocabulary
+// so callers don't have to know each API's shape. Every provider's call()
+// returns a `finish_reason` (one of the strings below) plus a derived
+// `truncated` boolean.
+//
+// Vocabulary:
+//   'stop'           — model finished normally (end of turn / stop sequence)
+//   'length'         — output hit the token ceiling (THE truncation case)
+//   'tool_calls'     — model stopped to emit tool / function calls
+//   'content_filter' — provider blocked or refused the output (safety, refusal)
+//   'other'          — anything unrecognized, and the fallback when the signal
+//                      is missing entirely
+//
+// `truncated === (finish_reason === 'length')`. Callers that persist model
+// output (soul / people / learnings) treat a truncated generation as a failure
+// and refuse to overwrite good state with a cut-off document.
+
+const FINISH = {
+    STOP: 'stop',
+    LENGTH: 'length',
+    TOOL_CALLS: 'tool_calls',
+    CONTENT_FILTER: 'content_filter',
+    OTHER: 'other',
+};
+
+// OpenAI Chat Completions shape — `choice.finish_reason`.
+// Shared by openai (chat path), openrouter, and perplexity.
+function normalizeOpenAIChatFinish(reason) {
+    switch (reason) {
+        case 'stop': return FINISH.STOP;
+        case 'length': return FINISH.LENGTH;
+        case 'tool_calls':
+        case 'function_call': return FINISH.TOOL_CALLS;
+        case 'content_filter': return FINISH.CONTENT_FILTER;
+        default: return FINISH.OTHER;
+    }
+}
+
+// OpenAI /v1/responses and xAI /v1/responses shape — top-level `status` plus
+// `incomplete_details.reason`. A completed response is a normal stop unless it
+// carries a function_call item, which the caller signals via hasToolCall.
+function normalizeResponsesStatus(status, incompleteReason, hasToolCall) {
+    if (status === 'incomplete') {
+        if (incompleteReason === 'max_output_tokens') return FINISH.LENGTH;
+        if (incompleteReason === 'content_filter') return FINISH.CONTENT_FILTER;
+        return FINISH.OTHER;
+    }
+    // status 'completed' (or absent — treat as completed)
+    if (hasToolCall) return FINISH.TOOL_CALLS;
+    return FINISH.STOP;
+}
+
+// Anthropic Messages shape — top-level `stop_reason`.
+function normalizeAnthropicStop(reason) {
+    switch (reason) {
+        case 'end_turn':
+        case 'stop_sequence': return FINISH.STOP;
+        case 'max_tokens': return FINISH.LENGTH;
+        case 'tool_use': return FINISH.TOOL_CALLS;
+        case 'refusal': return FINISH.CONTENT_FILTER;
+        default: return FINISH.OTHER;
+    }
+}
+
+// Google Gemini shape — `candidate.finishReason` (UPPER_SNAKE_CASE).
+function normalizeGoogleFinish(reason) {
+    switch (reason) {
+        case 'STOP': return FINISH.STOP;
+        case 'MAX_TOKENS': return FINISH.LENGTH;
+        case 'SAFETY':
+        case 'RECITATION':
+        case 'BLOCKLIST':
+        case 'PROHIBITED_CONTENT':
+        case 'SPII': return FINISH.CONTENT_FILTER;
+        default: return FINISH.OTHER;
+    }
+}
+
+// True only for a length-stop — the actionable signal for the persist guards.
+function isTruncated(finishReason) {
+    return finishReason === FINISH.LENGTH;
+}
+
+module.exports = {
+    FINISH,
+    normalizeOpenAIChatFinish,
+    normalizeResponsesStatus,
+    normalizeAnthropicStop,
+    normalizeGoogleFinish,
+    isTruncated,
+};

--- a/node/api/src/services/providers/finish.test.js
+++ b/node/api/src/services/providers/finish.test.js
@@ -1,0 +1,66 @@
+// Tests for the finish-reason normalizers (LLM-418). Run with: node --test
+// (from node/api). These are pure functions — no fetch stub needed. They map
+// each provider's native stop signal onto the shared vocabulary, so the whole
+// truncation-guard chain hinges on these tables being right.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    FINISH,
+    normalizeOpenAIChatFinish,
+    normalizeResponsesStatus,
+    normalizeAnthropicStop,
+    normalizeGoogleFinish,
+    isTruncated,
+} = require('./finish');
+
+test('OpenAI chat finish_reason maps to the shared vocabulary', () => {
+    assert.equal(normalizeOpenAIChatFinish('stop'), FINISH.STOP);
+    assert.equal(normalizeOpenAIChatFinish('length'), FINISH.LENGTH);
+    assert.equal(normalizeOpenAIChatFinish('tool_calls'), FINISH.TOOL_CALLS);
+    assert.equal(normalizeOpenAIChatFinish('function_call'), FINISH.TOOL_CALLS);
+    assert.equal(normalizeOpenAIChatFinish('content_filter'), FINISH.CONTENT_FILTER);
+    // Unknown / missing signal falls back to 'other', never 'length'.
+    assert.equal(normalizeOpenAIChatFinish(undefined), FINISH.OTHER);
+    assert.equal(normalizeOpenAIChatFinish(null), FINISH.OTHER);
+    assert.equal(normalizeOpenAIChatFinish('surprise'), FINISH.OTHER);
+});
+
+test('/v1/responses status + incomplete_details maps correctly', () => {
+    // Incomplete because of the token ceiling is the truncation case.
+    assert.equal(normalizeResponsesStatus('incomplete', 'max_output_tokens', false), FINISH.LENGTH);
+    assert.equal(normalizeResponsesStatus('incomplete', 'content_filter', false), FINISH.CONTENT_FILTER);
+    assert.equal(normalizeResponsesStatus('incomplete', 'something_else', false), FINISH.OTHER);
+    // Completed is a normal stop, unless a function_call rode along.
+    assert.equal(normalizeResponsesStatus('completed', undefined, false), FINISH.STOP);
+    assert.equal(normalizeResponsesStatus('completed', undefined, true), FINISH.TOOL_CALLS);
+    // Absent status is treated as completed (safe default: not truncated).
+    assert.equal(normalizeResponsesStatus(undefined, undefined, false), FINISH.STOP);
+});
+
+test('Anthropic stop_reason maps to the shared vocabulary', () => {
+    assert.equal(normalizeAnthropicStop('end_turn'), FINISH.STOP);
+    assert.equal(normalizeAnthropicStop('stop_sequence'), FINISH.STOP);
+    assert.equal(normalizeAnthropicStop('max_tokens'), FINISH.LENGTH);
+    assert.equal(normalizeAnthropicStop('tool_use'), FINISH.TOOL_CALLS);
+    assert.equal(normalizeAnthropicStop('refusal'), FINISH.CONTENT_FILTER);
+    assert.equal(normalizeAnthropicStop('pause_turn'), FINISH.OTHER);
+    assert.equal(normalizeAnthropicStop(undefined), FINISH.OTHER);
+});
+
+test('Google finishReason maps to the shared vocabulary', () => {
+    assert.equal(normalizeGoogleFinish('STOP'), FINISH.STOP);
+    assert.equal(normalizeGoogleFinish('MAX_TOKENS'), FINISH.LENGTH);
+    assert.equal(normalizeGoogleFinish('SAFETY'), FINISH.CONTENT_FILTER);
+    assert.equal(normalizeGoogleFinish('RECITATION'), FINISH.CONTENT_FILTER);
+    assert.equal(normalizeGoogleFinish('PROHIBITED_CONTENT'), FINISH.CONTENT_FILTER);
+    assert.equal(normalizeGoogleFinish('OTHER'), FINISH.OTHER);
+    assert.equal(normalizeGoogleFinish(undefined), FINISH.OTHER);
+});
+
+test('isTruncated is true only for a length-stop', () => {
+    assert.equal(isTruncated(FINISH.LENGTH), true);
+    for (const r of [FINISH.STOP, FINISH.TOOL_CALLS, FINISH.CONTENT_FILTER, FINISH.OTHER, undefined]) {
+        assert.equal(isTruncated(r), false);
+    }
+});

--- a/node/api/src/services/providers/finish.test.js
+++ b/node/api/src/services/providers/finish.test.js
@@ -34,8 +34,14 @@ test('/v1/responses status + incomplete_details maps correctly', () => {
     // Completed is a normal stop, unless a function_call rode along.
     assert.equal(normalizeResponsesStatus('completed', undefined, false), FINISH.STOP);
     assert.equal(normalizeResponsesStatus('completed', undefined, true), FINISH.TOOL_CALLS);
-    // Absent status is treated as completed (safe default: not truncated).
-    assert.equal(normalizeResponsesStatus(undefined, undefined, false), FINISH.STOP);
+    // Any non-completed / non-incomplete status is NOT a clean stop — the
+    // normalizer is the persistence safety boundary, so failed/cancelled/
+    // unknown/missing all fall through to 'other', never 'stop'.
+    assert.equal(normalizeResponsesStatus('failed', undefined, false), FINISH.OTHER);
+    assert.equal(normalizeResponsesStatus('cancelled', undefined, false), FINISH.OTHER);
+    assert.equal(normalizeResponsesStatus('in_progress', undefined, false), FINISH.OTHER);
+    assert.equal(normalizeResponsesStatus('surprise_status', undefined, false), FINISH.OTHER);
+    assert.equal(normalizeResponsesStatus(undefined, undefined, false), FINISH.OTHER);
 });
 
 test('Anthropic stop_reason maps to the shared vocabulary', () => {

--- a/node/api/src/services/providers/google.js
+++ b/node/api/src/services/providers/google.js
@@ -3,6 +3,7 @@
 
 const { log } = require('../logger');
 const { asNumber } = require('./coerce');
+const { normalizeGoogleFinish, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -372,9 +373,15 @@ function createCall(model, apiKey, configuration) {
             output_tokens: data.usageMetadata?.candidatesTokenCount || 0
         };
 
-        logProvider('api-response', { provider: 'google', model, tool_calls: tool_calls.length, ...usage });
+        // finishReason "MAX_TOKENS" means output hit the cap. Gemini is the
+        // specific casualty here — thinking tokens count against maxOutputTokens,
+        // so a partial soul comes back with MAX_TOKENS while output_tokens looks
+        // healthy. Surface it so the persist guards can reject it.
+        const finish_reason = normalizeGoogleFinish(candidate.finishReason);
 
-        return { text, tool_calls, usage };
+        logProvider('api-response', { provider: 'google', model, tool_calls: tool_calls.length, finish_reason, ...usage });
+
+        return { text, tool_calls, usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/providers/google.test.js
+++ b/node/api/src/services/providers/google.test.js
@@ -1,0 +1,52 @@
+// Tests for Gemini truncation detection (LLM-418) in createCall. Run with:
+// node --test (from node/api). Gemini is the named casualty — thinking tokens
+// count against maxOutputTokens, so a partial soul comes back with
+// finishReason "MAX_TOKENS" while output_tokens looks healthy. Its response
+// shape (candidate.finishReason) is distinct from the OpenAI/Anthropic ones,
+// so it gets its own end-to-end assertion. Uses the built-in node:test runner
+// + node:assert with a globalThis.fetch stub, matching the other provider tests.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const google = require('./google');
+
+// Stub fetch to return a Gemini generateContent payload with the given
+// finishReason and a partial text part.
+function stubFinishReason(finishReason) {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => ({
+                candidates: [{
+                    content: { parts: [{ text: 'partial' }] },
+                    finishReason,
+                }],
+                usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 4096 },
+            }),
+        };
+    };
+    return { restore() { globalThis.fetch = original; } };
+}
+
+test('finishReason "MAX_TOKENS" surfaces truncated:true on the returned object', async () => {
+    const stub = stubFinishReason('MAX_TOKENS');
+    try {
+        const res = await google.createCall('gemini-2.5-pro', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'length');
+        assert.equal(res.truncated, true);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('finishReason "STOP" surfaces truncated:false', async () => {
+    const stub = stubFinishReason('STOP');
+    try {
+        const res = await google.createCall('gemini-2.5-pro', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'stop');
+        assert.equal(res.truncated, false);
+    } finally {
+        stub.restore();
+    }
+});

--- a/node/api/src/services/providers/openai.js
+++ b/node/api/src/services/providers/openai.js
@@ -8,6 +8,7 @@
 
 const { log } = require('../logger');
 const { asNumber } = require('./coerce');
+const { normalizeOpenAIChatFinish, normalizeResponsesStatus, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -418,16 +419,21 @@ async function callResponses(model, apiKey, conf, fullMessages, opts) {
         usage.cost = cost;
     }
 
+    // /v1/responses reports truncation via top-level status "incomplete" with
+    // incomplete_details.reason "max_output_tokens" (not a per-choice
+    // finish_reason). A completed response with a function_call is a tool stop.
+    const finish_reason = normalizeResponsesStatus(data.status, data.incomplete_details?.reason, tool_calls.length > 0);
+
     logProvider('api-response', {
         provider: 'openai', model,
         endpoint: 'responses',
         serviceTier: appliedServiceTier,
         input: uncachedInput, cached: cachedTokens,
         output: completionTokens, cost: cost != null ? cost.toFixed(6) : 'unknown',
-        tool_calls: tool_calls.length,
+        tool_calls: tool_calls.length, finish_reason,
     });
 
-    return { text, tool_calls, usage };
+    return { text, tool_calls, usage, finish_reason, truncated: isTruncated(finish_reason) };
 }
 
 // ── API call factory ────────────────────────────────────────────────────────
@@ -593,15 +599,18 @@ function createCall(model, apiKey, configuration) {
                 return { id: tc.id, name: tc.function.name, input };
             });
 
+        // finish_reason "length" means the response was cut at the token cap.
+        const finish_reason = normalizeOpenAIChatFinish(choice.finish_reason);
+
         logProvider('api-response', {
             provider: 'openai', model,
             serviceTier: appliedServiceTier,
             input: uncachedInput, cached: cachedTokens,
             output: completionTokens, cost: cost != null ? cost.toFixed(6) : 'unknown',
-            tool_calls: tool_calls.length
+            tool_calls: tool_calls.length, finish_reason
         });
 
-        return { text: choice.message.content || '', tool_calls, usage };
+        return { text: choice.message.content || '', tool_calls, usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/providers/openai.test.js
+++ b/node/api/src/services/providers/openai.test.js
@@ -46,3 +46,70 @@ test('gpt-5.6 calls route through /v1/responses like the rest of gpt-5.x', async
         globalThis.fetch = original;
     }
 });
+
+// LLM-418 — truncation on both endpoints. /v1/responses reports it as
+// status "incomplete" + incomplete_details.reason; chat-completions as a
+// per-choice finish_reason "length".
+test('/v1/responses incomplete/max_output_tokens surfaces truncated:true', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => ({
+                status: 'incomplete',
+                incomplete_details: { reason: 'max_output_tokens' },
+                output: [{ type: 'message', content: [{ type: 'output_text', text: 'partial' }] }],
+                usage: { input_tokens: 10, output_tokens: 8192 },
+            }),
+        };
+    };
+    try {
+        const res = await openai.createCall('gpt-5.6-sol', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'length');
+        assert.equal(res.truncated, true);
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
+test('/v1/responses completed surfaces truncated:false', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => ({
+                status: 'completed',
+                output: [{ type: 'message', content: [{ type: 'output_text', text: 'done' }] }],
+                usage: { input_tokens: 10, output_tokens: 5 },
+            }),
+        };
+    };
+    try {
+        const res = await openai.createCall('gpt-5.6-sol', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'stop');
+        assert.equal(res.truncated, false);
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
+test('chat-completions finish_reason "length" surfaces truncated:true', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => ({
+                choices: [{ message: { content: 'partial', tool_calls: [] }, finish_reason: 'length' }],
+                usage: { prompt_tokens: 10, completion_tokens: 4096 },
+            }),
+        };
+    };
+    try {
+        // gpt-4o-mini stays on /v1/chat/completions (not gpt-5.x, not o-series).
+        const res = await openai.createCall('gpt-4o-mini', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'length');
+        assert.equal(res.truncated, true);
+    } finally {
+        globalThis.fetch = original;
+    }
+});

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -12,6 +12,7 @@
 
 const { log } = require('../logger');
 const { asNumber, coerceToolArgs } = require('./coerce');
+const { normalizeOpenAIChatFinish, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -297,14 +298,19 @@ function createCall(model, apiKey, configuration) {
                 return { id: tc.id, name: tc.function.name, input: input };
             });
 
+        // finish_reason "length" means the upstream model hit its token cap.
+        // OpenRouter fronts the affected Gemini soul agent, so this is a live
+        // truncation path — surface it for the persist guards.
+        const finish_reason = normalizeOpenAIChatFinish(choice.finish_reason);
+
         logProvider('api-response', {
             provider: 'openrouter', model,
             input: uncachedInput, cached: cachedTokens,
             output: completionTokens, cost: cost != null ? cost.toFixed(6) : 'unknown',
-            tool_calls: tool_calls.length
+            tool_calls: tool_calls.length, finish_reason
         });
 
-        return { text: choice.message.content || '', tool_calls: tool_calls, usage: usage };
+        return { text: choice.message.content || '', tool_calls: tool_calls, usage: usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -76,3 +76,42 @@ test('a non-object conf.provider is ignored (guard against malformed config)', a
         stub.restore();
     }
 });
+
+// LLM-418 — the truncation signal. OpenRouter fronts the affected Gemini soul
+// agent, so a "length" finish_reason here is the live truncation path.
+function stubFinishReason(finish) {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function (url) {
+        if (String(url).includes('/models')) return { ok: true, json: async () => ({ data: [] }) };
+        return {
+            ok: true,
+            json: async () => ({
+                choices: [{ message: { content: 'partial', tool_calls: [] }, finish_reason: finish }],
+                usage: { prompt_tokens: 10, completion_tokens: 4096 },
+            }),
+        };
+    };
+    return { restore() { globalThis.fetch = original; } };
+}
+
+test('finish_reason "length" surfaces truncated:true on the returned object', async () => {
+    const stub = stubFinishReason('length');
+    try {
+        const res = await openrouter.createCall('google/gemini-2.5-pro', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'length');
+        assert.equal(res.truncated, true);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('finish_reason "stop" surfaces truncated:false', async () => {
+    const stub = stubFinishReason('stop');
+    try {
+        const res = await openrouter.createCall('google/gemini-2.5-pro', 'k', {})('sys', 'hi', {});
+        assert.equal(res.finish_reason, 'stop');
+        assert.equal(res.truncated, false);
+    } finally {
+        stub.restore();
+    }
+});

--- a/node/api/src/services/providers/perplexity.js
+++ b/node/api/src/services/providers/perplexity.js
@@ -4,6 +4,7 @@
 
 const { log } = require('../logger');
 const { asNumber } = require('./coerce');
+const { normalizeOpenAIChatFinish, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -223,11 +224,14 @@ function createCall(model, apiKey, configuration) {
             output_tokens: data.usage?.completion_tokens || 0
         };
 
-        logProvider('api-response', { provider: 'perplexity', model, ...usage });
+        // finish_reason "length" means the answer was cut at the token cap.
+        const finish_reason = normalizeOpenAIChatFinish(choice.finish_reason);
+
+        logProvider('api-response', { provider: 'perplexity', model, finish_reason, ...usage });
 
         // Empty tool_calls so callers always see a uniform shape across
         // providers — Perplexity Sonar models don't support function calling.
-        return { text, tool_calls: [], usage };
+        return { text, tool_calls: [], usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/providers/perplexity.test.js
+++ b/node/api/src/services/providers/perplexity.test.js
@@ -89,3 +89,25 @@ test('return_citations=false suppresses the Sources block', async () => {
     );
     assert.equal(text, 'answer body');
 });
+
+// LLM-418 — finish_reason lives on choices[0], so the shared stubFetch's
+// top-level `extra` merge won't reach it; use a dedicated stub.
+test('finish_reason "length" surfaces truncated:true', async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = async function () {
+        return {
+            ok: true,
+            json: async () => ({
+                choices: [{ message: { content: 'partial' }, finish_reason: 'length' }],
+                usage: { prompt_tokens: 10, completion_tokens: 4096 },
+            }),
+        };
+    };
+    try {
+        const res = await perplexity.createCall('sonar', 'k', {})('sys', 'q', {});
+        assert.equal(res.finish_reason, 'length');
+        assert.equal(res.truncated, true);
+    } finally {
+        globalThis.fetch = original;
+    }
+});

--- a/node/api/src/services/providers/xai.js
+++ b/node/api/src/services/providers/xai.js
@@ -10,6 +10,7 @@
 
 const { log } = require('../logger');
 const { asNumber } = require('./coerce');
+const { normalizeResponsesStatus, isTruncated } = require('./finish');
 
 function logProvider(action, details) {
     log('provider', action, details);
@@ -321,17 +322,23 @@ function createCall(model, apiKey, configuration) {
             usage.cost = cost;
         }
 
+        // xAI's Responses API mirrors OpenAI's: truncation shows as top-level
+        // status "incomplete" with incomplete_details.reason "max_output_tokens".
+        // No user function tools yet (hasToolCall false).
+        const finish_reason = normalizeResponsesStatus(data.status, data.incomplete_details?.reason, false);
+
         logProvider('api-response', {
             provider: 'xai', model,
             input: uncachedInput, cached: cachedTokens,
             output: completionTokens,
             cost: cost != null ? cost.toFixed(6) : 'unknown',
-            search: searchEnabled.length > 0 ? searchEnabled : false
+            search: searchEnabled.length > 0 ? searchEnabled : false,
+            finish_reason
         });
 
         // Always return an empty tool_calls so the result shape matches
         // tool-supporting providers. Real function-calling support is a TODO.
-        return { text, tool_calls: [], usage };
+        return { text, tool_calls: [], usage, finish_reason, truncated: isTruncated(finish_reason) };
     };
 }
 

--- a/node/api/src/services/sim-soul.js
+++ b/node/api/src/services/sim-soul.js
@@ -152,11 +152,19 @@ async function synthesizeSimSoul({ characterDescription, currentSoul, daySnapsho
     // the backstop bounding engine-triggered volume. invokeAgent throws on
     // limit; that surfaces as a 5xx the engine retries next sweep. Retry
     // transient provider errors with backoff, as the cron does.
-    const { text } = await invokeAgent(soulAgentName, {
+    const { text, truncated, finish_reason } = await invokeAgent(soulAgentName, {
         userMessage,
         context: 'soul',
         skipRetry: false,
     });
+
+    // Length-stop: the soul came back cut off mid-thought. Reject → empty text
+    // → the engine keeps the prior soul (same contract as the empty-reply and
+    // reasoning-preamble guards below).
+    if (truncated) {
+        log('sim-soul', 'truncated-rejected', { agent: soulAgentName, finishReason: finish_reason });
+        return { text: '', rejected: 'truncated' };
+    }
 
     const trimmed = (text || '').trim();
     if (!trimmed) {

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -582,10 +582,14 @@ async function invokeAgent(agentName, options) {
     }
 
     const durationMs = Date.now() - callStart;
-    const { text, tool_calls, usage } = result;
+    const { text, tool_calls, usage, finish_reason, truncated } = result;
     // Providers that pre-date tool support return undefined for tool_calls.
     // Normalize so callers always see an array.
     const toolCallsOut = Array.isArray(tool_calls) ? tool_calls : [];
+    // Normalize the truncation signal so every caller sees a uniform shape,
+    // even from a provider that hasn't been updated to report it.
+    const finishReasonOut = finish_reason || 'other';
+    const truncatedOut = truncated === true;
 
     // Record rate limit call
     if (!options.skipRateLimit) {
@@ -606,9 +610,9 @@ async function invokeAgent(agentName, options) {
 
     logVA('invoke', { agent: agentName, context: options.context || null, cost: cost.toFixed(6),
         input: usage.input_tokens || 0, output: usage.output_tokens || 0,
-        tool_calls: toolCallsOut.length });
+        tool_calls: toolCallsOut.length, finish_reason: finishReasonOut, truncated: truncatedOut });
 
-    return { text, tool_calls: toolCallsOut, usage, cost };
+    return { text, tool_calls: toolCallsOut, usage, cost, finish_reason: finishReasonOut, truncated: truncatedOut };
 }
 
 // Check if learning extraction is enabled for an agent.
@@ -859,13 +863,21 @@ async function extractLearnings(agent, systemPrompt, userMessage, response, inte
     const extractionPrompt = buildExtractionPrompt(interactionType, contextHint);
     const extractionUserMessage = `System prompt:\n${flatPrompt}\n\nUser message:\n${userMessage}\n\nYour response:\n${response}\n\n---\n\n${extractionPrompt}`;
 
-    const { text: extractionResult } = await invokeAgent(agent.agent, {
+    const { text: extractionResult, truncated: learningTruncated } = await invokeAgent(agent.agent, {
         systemPrompt: 'You are a knowledge extraction assistant. Your job is to identify key facts worth remembering from interactions.',
         userMessage: extractionUserMessage,
         context: 'learning',
         skipRateLimit: true,
         skipCostLimit: true,
     });
+
+    // Length-stop: a truncated extraction would persist a partial fact list
+    // with a cut-off final bullet. Skip the save — nothing is lost, extraction
+    // re-runs on the next interaction.
+    if (learningTruncated) {
+        logVA('learning-truncated', { agent: agent.agent, interactionType });
+        return;
+    }
 
     // Check for NONE response
     if (extractionResult.trim().toUpperCase() === 'NONE' || extractionResult.trim() === '') {

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -879,8 +879,10 @@ async function extractLearnings(agent, systemPrompt, userMessage, response, inte
         return;
     }
 
-    // Check for NONE response
-    if (extractionResult.trim().toUpperCase() === 'NONE' || extractionResult.trim() === '') {
+    // Check for NONE / empty response. Guard against a provider returning
+    // undefined text so this path (and the truncation path above) can't throw.
+    const extractionText = (extractionResult || '').trim();
+    if (extractionText.toUpperCase() === 'NONE' || extractionText === '') {
         logVA('learning-none', { agent: agent.agent, interactionType });
         return;
     }


### PR DESCRIPTION
## Problem

Every provider `call()` in `node/api/src/services/providers/` returned `{ text, tool_calls, usage }` and **none** inspected the truncation signal (`stop_reason`/`finish_reason`/`status`). A completion cut off at the token ceiling was assembled and persisted **as if whole**.

Concrete casualty: the `work` agent's `context/soul` was overwritten with a 708-char mid-word stub on a nightly dream run — the soul writer is gemini-2.5-pro via OpenRouter, and thinking tokens count against the output budget, so the visible soul truncated far below the cap while `output_tokens` looked healthy. Logged as a clean success.

## Change

- **`providers/finish.js`** (new) normalizes each API's native stop signal into one vocabulary (`stop | length | tool_calls | content_filter | other`) and derives a `truncated` boolean (= length-stop).
- **All providers** surface `{ finish_reason, truncated }`: anthropic (`stop_reason`), google (`candidate.finishReason`), openrouter / perplexity / openai-chat (`choice.finish_reason`), openai + xai `/v1/responses` (`status` + `incomplete_details`).
- **`invokeAgent`** passes both through and logs them on every invoke, so truncation is visible for live VA responses too (a truncated live reply still beats no reply — logged + surfaced, not suppressed).
- **Persist guards** refuse to overwrite good state with a truncated document — soul, people, learnings (`dream.js`), `sim-soul`, and live `extractLearnings`: skip the save, log an error (mirrors the reasoning-preamble guard). Composes with the LLM-419 empty-response branch already on main.

The config-level fix (raising the soul agent's `max_tokens` above its thinking budget) is handled separately by the owner.

## Tests

`node --test` — normalizer mapping tables + end-to-end `truncated` detection across both response shapes (chat `finish_reason`, `/v1/responses` `incomplete`) and google's distinct shape. 25 provider tests green; dream / sim-soul / rate-limit suites unaffected.

## Review

Reviewed by `code_review` pre-merge. One blocking item (Responses `status` normalization treating non-`completed` as a clean stop) fixed in the second commit + tests; guard ordering, people early-return shape, and sim-soul rejection all confirmed correct.

— Work