### PR TITLE
LLM-420: rebuild soul from scratch when the stored one is a degraded stub

### DIFF
--- a/migrations/LLM-420-dream-soul-min-chars_down.sql
+++ b/migrations/LLM-420-dream-soul-min-chars_down.sql
@@ -1,0 +1,2 @@
+-- Down for LLM-420
+DELETE FROM config WHERE key = 'dream_soul_min_chars';

--- a/migrations/LLM-420-dream-soul-min-chars_up.sql
+++ b/migrations/LLM-420-dream-soul-min-chars_up.sql
@@ -1,0 +1,12 @@
+-- LLM-420: Add dream_soul_min_chars config.
+-- The soul-update pass rebuilds from scratch (backloading recent dreams) only
+-- when the stored soul is empty. A non-empty but truncated/degraded stub slips
+-- past that check and gets "evolved" every night; because the soul-writer reads
+-- its own prior output as input, the stub compounds instead of self-healing.
+-- This threshold routes a suspiciously short soul (below N characters) through
+-- the rebuild path too. Tune per observed healthy soul sizes; 0 disables the
+-- short-stub check, leaving only the empty check.
+
+INSERT INTO config (key, value, description) VALUES
+    ('dream_soul_min_chars', '800', 'Minimum character length for a stored soul document to be treated as usable. A non-empty soul shorter than this is treated as a degraded/truncated stub and routed through the from-scratch rebuild path (backload recent dreams) instead of being evolved, so a truncated write cannot compound across dream cycles (LLM-420). Healthy souls run several KB; the observed degraded stub was 708 chars. 0 disables the short-stub check.')
+ON CONFLICT (key) DO NOTHING;

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -106,6 +106,43 @@ function detectReasoningPreamble(text) {
     return REASONING_PREAMBLE_MARKERS.find(m => leadCheck.includes(m)) || null;
 }
 
+// True when a soul has no usable prior document to evolve and should be rebuilt
+// from scratch (backload recent dreams) instead. Two cases: it's empty (deleted
+// or first run), or it's a suspiciously short stub — the fingerprint of a
+// truncated/degraded write. Detecting the stub at read time matters because the
+// soul-writer feeds its own prior output back in as input, so a garbled stub
+// left in evolve-only mode compounds every cycle instead of self-healing
+// (LLM-420). minChars <= 0 disables the short-stub arm, leaving only the empty
+// check. Exported as a module-scope helper so the threshold logic is unit-testable.
+function soulNeedsRebuild(existingSoul, minChars) {
+    const trimmed = (existingSoul || '').trim();
+    if (trimmed === '') return true;
+    if (minChars > 0 && trimmed.length < minChars) return true;
+    return false;
+}
+
+// Assembles the user message for the soul-writer. Kept as a pure, exported
+// helper so the rebuild-vs-evolve branching (which document goes in, which
+// framing) is unit-testable without standing up the whole dream cron. When
+// needsRebuild is true the prior soul is deliberately withheld — replaced by a
+// placeholder, plus the from-scratch rebuild framing when a dream backload is
+// available — so a degraded/truncated stub can never leak back into the
+// writer's input (LLM-420). When a backload is not available (disabled or no
+// dreams yet) the day's chunk is used as the snapshot regardless of rebuild.
+function buildSoulUserMessage({ agentName, startupInstructions, existingSoul, needsRebuild, backloadDreams, chunkDate, dreamContent }) {
+    return '## Agent: ' + agentName + '\n\n'
+        + (startupInstructions
+            ? '## Character description\n\n' + startupInstructions + '\n\n'
+            : '')
+        + '## Current soul document\n\n'
+        + (needsRebuild ? '(none on file — rebuilding from recent dreams)' : existingSoul)
+        + (backloadDreams
+            ? '\n\n## Dream snapshot for initial soul rebuild\n\n'
+                + 'There is no usable prior soul document. Synthesize an initial soul from the recent dream history below; do not treat this as a single-day incremental update.\n\n'
+                + backloadDreams
+            : '\n\n## Dream snapshot for ' + chunkDate + '\n\n' + dreamContent);
+}
+
 // Cheap detection for the typed-context JSON array format. The whole
 // multi-turn discussion history sits on a single line as a JSON array
 // of {sender, content} objects (see virtual-agent.js's <Conversation>
@@ -637,18 +674,50 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 // No soul yet — first run for this agent.
             }
 
-            // When the soul is empty (deleted or first run), backload the N
-            // most recent dreams instead of just feeding the chunk we just
-            // saved. Lets a deleted soul rebuild from accumulated personality
-            // rather than starting flat and slowly filling in over many
-            // cycles. The just-saved chunk is included as the first entry
-            // since listNotes orders by updated_at DESC. After this call
-            // existingSoul will be non-empty so subsequent cycles resume the
-            // normal per-chunk update path. Cost guards on the soul agent
+            // When there's no usable prior soul, backload the N most recent
+            // dreams instead of just feeding the chunk we just saved. Lets a
+            // rebuilt soul come back from accumulated personality rather than
+            // starting flat and slowly filling in over many cycles. "No usable
+            // prior soul" means empty (deleted or first run) OR a suspiciously
+            // short stub (dream_soul_min_chars) — the latter is the fingerprint
+            // of a truncated/degraded write, which must not be fed back in and
+            // "evolved" (it would compound; the writer reads its own prior
+            // output as input). The just-saved chunk is included as the first
+            // backload entry since listNotes orders by updated_at DESC. After
+            // the rebuild the soul is long again, so subsequent cycles resume
+            // the normal per-chunk update path. Cost guards on the soul agent
             // call protect against runaway prompt sizes.
+            let soulMinChars = 0;
+            try {
+                soulMinChars = parseInt(config.get('dream_soul_min_chars'), 10) || 0;
+            } catch (e) {
+                // Config key missing (deploy ordering: service started before
+                // migration ran). Treat as disabled — same contract as
+                // dream_backload_count below.
+                soulMinChars = 0;
+            }
             let backloadDreams = null;
-            const soulIsEmpty = existingSoul.trim() === '';
-            if (soulIsEmpty) {
+            // existingSoul is already a string (initialized '' and only ever
+            // set from soulNote.content || ''); normalize once anyway so the
+            // trimmed length is derived in one place and shared by the
+            // emptiness check, the rebuild helper, and the degraded log.
+            const normalizedSoul = typeof existingSoul === 'string' ? existingSoul : '';
+            const trimmedSoulLen = normalizedSoul.trim().length;
+            const soulIsEmpty = trimmedSoulLen === 0;
+            const needsRebuild = soulNeedsRebuild(normalizedSoul, soulMinChars);
+            if (needsRebuild && !soulIsEmpty) {
+                // Non-empty soul below the health floor: a degraded/truncated
+                // stub we're rerouting to a from-scratch rebuild. Log the
+                // self-heal so it's visible in the dream journal rather than a
+                // silent reroute.
+                logDream('chunk-soul-degraded-rebuild', {
+                    agent: agent.name,
+                    chunkDate: chunkDateStr,
+                    size: trimmedSoulLen,
+                    minChars: soulMinChars,
+                });
+            }
+            if (needsRebuild) {
                 let backloadCount = 0;
                 try {
                     backloadCount = parseInt(config.get('dream_backload_count'), 10) || 0;
@@ -674,17 +743,15 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 }
             }
 
-            const soulUserMessage = '## Agent: ' + agent.name + '\n\n'
-                + (agent.startup_instructions
-                    ? '## Character description\n\n' + agent.startup_instructions + '\n\n'
-                    : '')
-                + '## Current soul document\n\n'
-                + (soulIsEmpty ? '(empty — first run)' : existingSoul)
-                + (backloadDreams
-                    ? '\n\n## Dream snapshot for initial soul rebuild\n\n'
-                        + 'The current soul document is empty. Synthesize an initial soul from the recent dream history below; do not treat this as a single-day incremental update.\n\n'
-                        + backloadDreams
-                    : '\n\n## Dream snapshot for ' + chunkDateStr + '\n\n' + content);
+            const soulUserMessage = buildSoulUserMessage({
+                agentName: agent.name,
+                startupInstructions: agent.startup_instructions,
+                existingSoul: normalizedSoul,
+                needsRebuild,
+                backloadDreams,
+                chunkDate: chunkDateStr,
+                dreamContent: content,
+            });
 
             const { text: updatedSoul, usage: soulUsage, truncated: soulTruncated, finish_reason: soulFinish } = await invokeAgent(soulAgentName, {
                 userMessage: soulUserMessage,
@@ -1117,4 +1184,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage };

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage } = require('./dream');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -46,4 +46,117 @@ test('string updated_at (non-Date driver output) still renders the date', () => 
         buildNotesLog(rows),
         '## Note: sirius-identity (updated 2026-06-06)\n\nC'
     );
+});
+
+// soulNeedsRebuild — the read-side rebuild trigger (LLM-420). Routes an empty
+// OR suspiciously short soul through the from-scratch rebuild path so a
+// truncated/degraded stub cannot be fed back in and compounded.
+const HEALTHY_SOUL = 'x'.repeat(5000);
+
+test('empty soul needs a rebuild', () => {
+    assert.equal(soulNeedsRebuild('', 800), true);
+});
+
+test('whitespace-only soul needs a rebuild', () => {
+    assert.equal(soulNeedsRebuild('   \n\t  ', 800), true);
+});
+
+test('null/undefined soul needs a rebuild (defensive)', () => {
+    assert.equal(soulNeedsRebuild(null, 800), true);
+    assert.equal(soulNeedsRebuild(undefined, 800), true);
+});
+
+test('a short stub below the floor needs a rebuild', () => {
+    // The observed degraded stub was 708 chars; with an 800 floor it reroutes.
+    assert.equal(soulNeedsRebuild('x'.repeat(708), 800), true);
+});
+
+test('a healthy full-length soul is evolved, not rebuilt', () => {
+    assert.equal(soulNeedsRebuild(HEALTHY_SOUL, 800), false);
+});
+
+test('length is measured after trimming surrounding whitespace', () => {
+    // 700 real chars padded to >800 with whitespace still counts as a stub.
+    const padded = '   ' + 'x'.repeat(700) + '\n'.repeat(200);
+    assert.equal(soulNeedsRebuild(padded, 800), true);
+});
+
+test('a soul exactly at the floor is not below it (boundary)', () => {
+    assert.equal(soulNeedsRebuild('x'.repeat(800), 800), false);
+});
+
+test('minChars <= 0 disables the short-stub arm — only empty triggers rebuild', () => {
+    assert.equal(soulNeedsRebuild('x'.repeat(10), 0), false);
+    assert.equal(soulNeedsRebuild('x'.repeat(10), -1), false);
+    assert.equal(soulNeedsRebuild('', 0), true);
+});
+
+// buildSoulUserMessage — the rebuild-vs-evolve prompt assembler (LLM-420). The
+// critical guarantee: on a rebuild the degraded/truncated stub must NOT appear
+// in the writer's input, or it would compound on the next cycle.
+const STUB = 'a degraded truncated stub soul';
+
+test('rebuild with a backload omits the prior soul and uses rebuild framing', () => {
+    const msg = buildSoulUserMessage({
+        agentName: 'work',
+        startupInstructions: '',
+        existingSoul: STUB,
+        needsRebuild: true,
+        backloadDreams: '### dreams/2026-07-14-x\n\nyesterday material',
+        chunkDate: '2026-07-15',
+        dreamContent: 'today chunk',
+    });
+    assert.ok(!msg.includes(STUB), 'the degraded stub must not leak into the prompt');
+    assert.ok(msg.includes('(none on file — rebuilding from recent dreams)'));
+    assert.ok(msg.includes('## Dream snapshot for initial soul rebuild'));
+    assert.ok(msg.includes('There is no usable prior soul document.'));
+    assert.ok(msg.includes('yesterday material'));
+});
+
+test('rebuild without a backload still omits the stub and falls back to the day chunk', () => {
+    const msg = buildSoulUserMessage({
+        agentName: 'work',
+        startupInstructions: '',
+        existingSoul: STUB,
+        needsRebuild: true,
+        backloadDreams: null,
+        chunkDate: '2026-07-15',
+        dreamContent: 'today chunk',
+    });
+    assert.ok(!msg.includes(STUB), 'the degraded stub must not leak into the prompt');
+    assert.ok(msg.includes('(none on file — rebuilding from recent dreams)'));
+    assert.ok(msg.includes('## Dream snapshot for 2026-07-15'));
+    assert.ok(msg.includes('today chunk'));
+    assert.ok(!msg.includes('initial soul rebuild'));
+});
+
+test('evolve path feeds the existing soul plus the day chunk, no rebuild framing', () => {
+    const soul = 'a healthy multi-paragraph soul';
+    const msg = buildSoulUserMessage({
+        agentName: 'work',
+        startupInstructions: 'You are Work.',
+        existingSoul: soul,
+        needsRebuild: false,
+        backloadDreams: null,
+        chunkDate: '2026-07-15',
+        dreamContent: 'today chunk',
+    });
+    assert.ok(msg.includes(soul));
+    assert.ok(msg.includes('## Character description\n\nYou are Work.'));
+    assert.ok(msg.includes('## Dream snapshot for 2026-07-15'));
+    assert.ok(!msg.includes('rebuilding from recent dreams'));
+    assert.ok(!msg.includes('initial soul rebuild'));
+});
+
+test('empty startup instructions produce no character-description section', () => {
+    const msg = buildSoulUserMessage({
+        agentName: 'work',
+        startupInstructions: '',
+        existingSoul: 'soul',
+        needsRebuild: false,
+        backloadDreams: null,
+        chunkDate: '2026-07-15',
+        dreamContent: 'today',
+    });
+    assert.ok(!msg.includes('## Character description'));
 });


### PR DESCRIPTION
## Problem

The from-scratch soul rebuild (backload recent dreams) fired **only** when the stored soul was empty (`soulIsEmpty = existingSoul.trim() === ''`). A non-empty but truncated/degraded stub never triggered a rebuild — it was fed back in as input and "evolved" every night. Because the soul-writer reads its own prior output as input, a garbled stub degrades subsequent outputs instead of self-healing (observed: `work`'s soul stuck at a 708-char stub, degrading to an empty response the next night).

Sibling tickets already merged: **LLM-418** (provider layer now surfaces `truncated` from `finish_reason`, so the write-side guard refuses to *save* a length-stopped soul) and **LLM-419** (empty responses are logged). This ticket closes the **read-side** gap: a stub already on file is non-empty, so evolve-only compounds it. The stored note carries no `finish_reason`, so read-time detection is content-based.

## Change

- Generalize the rebuild trigger from "empty" to **"no usable prior soul"** — empty **or** a suspiciously short stub (below `dream_soul_min_chars`). A degraded stub is now treated exactly like a deleted soul: backload recent dreams, and the stub is **not** rendered as the current soul, so it can't leak back into the writer's prompt.
- New pure, unit-tested helpers `soulNeedsRebuild(existingSoul, minChars)` and `buildSoulUserMessage(...)` (the latter locks in the "stub is omitted from the rebuild prompt" guarantee).
- New config key `dream_soul_min_chars` (default `800`), read with the same missing-key try/catch tolerance as the adjacent `dream_backload_count`. Migration added (`ON CONFLICT (key) DO NOTHING`, matching the safer half of the repo's config-migration style).
- New `chunk-soul-degraded-rebuild` dream-journal log when a stub is rerouted (observability of the self-heal).

## Testing

`node --test src/services/dream.test.js` — 15/15 pass. Covers the threshold logic (empty / short / boundary / `minChars=0` disabled / trimming) and the prompt assembler (rebuild omits the stub with and without a backload; evolve feeds the existing soul; no rebuild framing leaks into evolve). CI (`ci.yml`) only builds/tests the Go client, so the Node path is verified locally.

## Notes

- `800` is a tunable policy default (live-editable in the `config` table, no redeploy). Healthy souls run several KB; the observed degraded stub was 708 chars. The one residual risk is an agent whose *healthy* soul is legitimately < 800 chars rebuilding nightly — set the key to `0` to disable the short-stub arm, or lower it. I only sampled `home`'s soul (~5.5 KB) as a healthy reference.
- Reviewed by `code_review` (round 1); its migration-idempotency and caller-normalization points are applied.

— Work
