### PR TITLE
LLM-436: search relevance floor — search_min_similarity config

### DIFF
--- a/migrations/LLM-436-search-min-similarity_down.sql
+++ b/migrations/LLM-436-search-min-similarity_down.sql
@@ -1,0 +1,3 @@
+-- LLM-436 down: remove the search relevance-floor config key.
+
+DELETE FROM config WHERE key = 'search_min_similarity';

--- a/migrations/LLM-436-search-min-similarity_up.sql
+++ b/migrations/LLM-436-search-min-similarity_up.sql
@@ -1,0 +1,10 @@
+-- LLM-436: Relevance floor for memory search.
+-- Search was a pure top-k ranker — against a small corpus (e.g. an NPC's
+-- private memory partition) it returned the nearest neighbor no matter how
+-- unrelated. This key floors the composite similarity score; hits below it
+-- are dropped. Measured on live data: pure noise scores <= ~0.25, legitimate
+-- fuzzy recalls >= ~0.37 — 0.3 is the recommended operating value.
+
+INSERT INTO config (key, value, description) VALUES
+    ('search_min_similarity', '0', 'Minimum composite similarity for search results; hits scoring below are dropped instead of padding the top-k. 0 = off. Measured: noise <= ~0.25, legit fuzzy recalls >= ~0.37; 0.3 recommended.')
+ON CONFLICT (key) DO NOTHING;

--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -172,6 +172,21 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
     const filenameBoostValue = parseNonNegativeFinite(config.get('search_filename_boost'), 0.15);
     const bm25BoostScale = parseNonNegativeFinite(config.get('search_bm25_boost'), 0.1);
 
+    // Relevance floor (LLM-436): drop results whose composite score is below
+    // this value instead of returning the k least-unrelated chunks. Without a
+    // floor, search is a pure top-k ranker — a query against a small corpus
+    // (e.g. an NPC's private memory partition of a handful of notes) returns
+    // its nearest neighbor no matter how unrelated, and downstream consumers
+    // that frame hits authoritatively ("You remember: ...") turn that noise
+    // into confabulation. Floored on the composite score, not raw vector
+    // similarity: the composite already encodes the kind-weight judgment that
+    // conversations are noisy (a noise chunk can sit at ~0.35 raw but ~0.25
+    // composite) and, where decay is configured, a memory fading below the
+    // floor IS forgetting by design. Measured on live data: pure noise scores
+    // <= ~0.25, legitimate fuzzy recalls >= ~0.37 — 0.3 is the recommended
+    // operating value. Default 0 = off (no behavior change until raised).
+    const minSimilarity = parseNonNegativeFinite(config.get('search_min_similarity'), 0);
+
     // Load decay/boost config (validated to finite non-negative numbers)
     // Kind-based half-lives (fallback when no cognitive type is set)
     const halfLives = {
@@ -391,6 +406,20 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
     params.push(maxResults);
     paramIdx++;
 
+    // Floor applied in the shared outer query (both namespace branches flow
+    // through it, so there is no second path to forget). Added only when
+    // enabled so the floor-off SQL stays byte-identical to the pre-LLM-436
+    // query. Scores are computed in the inner select, so sub-floor chunks
+    // still occupy candidate-pool slots — irrelevant to correctness since the
+    // floor removes them before the final trim.
+    let floorFilter = '';
+    if (minSimilarity > 0) {
+        const floorIdx = paramIdx;
+        params.push(minSimilarity);
+        paramIdx++;
+        floorFilter = ` AND similarity >= $${floorIdx}::numeric`;
+    }
+
     const sql = `
         SELECT source_file, heading, chunk_text, namespace, created_at, similarity, chunk_count
         FROM (
@@ -399,7 +428,7 @@ async function searchMemory(query, namespace, limit, readableNamespaces, actorId
                    COUNT(*) OVER (PARTITION BY namespace, source_file) AS chunk_count
             FROM (${innerSql}) candidates
         ) ranked
-        WHERE rn = 1
+        WHERE rn = 1${floorFilter}
         ORDER BY similarity DESC
         LIMIT $${finalLimitIdx}
     `;


### PR DESCRIPTION
## Problem

`searchMemory` is a pure top-k ranker — `ORDER BY similarity DESC LIMIT n`, no relevance floor. Against a small corpus the nearest neighbor is returned no matter how unrelated. Observed live in the village: Anne Walker's recall for "Josiah's General Store location" returned her **only** memory note (a dawn baking plan, composite 0.209) framed as "You remember:" — pure confabulation bait for a weak NPC model.

## Change

- New config key `search_min_similarity` (admin-tunable, **default 0 = off** — no behavior change until raised), migration pair included.
- Floor applied in the shared outer query (`WHERE rn = 1 AND similarity >= $N`) — both namespace branches flow through it, so no two-path leak. Floor-off SQL stays byte-identical to today's.

## Signal choice: composite score, not raw vector similarity

Measured on the live API (as work, real corpora):

| Case | Composite |
|---|---|
| Pure noise (the Anne hit; "chocolate cake" vs work ns) | 0.19–0.25 |
| Legit fuzzy recalls ("Lewis and Patience", "what did I agree to do tomorrow") | 0.37–0.41 |
| Strong true hits | 0.75–0.93 |

Raw vector sim was rejected: the top noise hit on the large corpus is a conversation chunk at **~0.35 raw** that only ranks as noise because the ×0.7 conversation kind-weight suppresses it to 0.25 composite — a raw floor low enough to keep the 0.37 legit band would pass it. The composite also makes decay-below-floor mean *forgetting*, which is the design for episodic salem memories.

**Recommended operating value: 0.3** (matches the existing BM25 gate's "decent similarity" line). Consumers are empty-safe: salem recall renders "nothing comes to mind" in-character, MCP search returns "No results found."

Jira: [LLM-436](https://jeffdafoe.atlassian.net/browse/LLM-436)

— Work

🤖 Generated with [Claude Code](https://claude.com/claude-code)