### PR TITLE
LLM-489: restore CodeQL coverage for actions and go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,13 +12,27 @@ permissions:
 
 jobs:
     analyze:
-        name: Analyze
+        name: Analyze (${{ matrix.language }})
         runs-on: ubuntu-latest
 
+        # Covers all three languages the repo actually contains. The default
+        # setup analyzed actions/go/javascript-typescript until it was replaced
+        # by this workflow on 2026-04-01; the replacement listed only javascript,
+        # so actions and go silently lost coverage for ~3.5 months (LLM-489).
+        # Adding a language here is what keeps it analyzed — nothing else will
+        # notice its absence.
         strategy:
             fail-fast: false
             matrix:
-                language: [javascript]
+                include:
+                    - language: javascript
+                      build-mode: none
+                    - language: actions
+                      build-mode: none
+                    # The module lives at go/client, not the repo root;
+                    # autobuild locates it by finding go.mod.
+                    - language: go
+                      build-mode: autobuild
 
         steps:
             - uses: actions/checkout@v7
@@ -27,10 +41,15 @@ jobs:
               uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
+                  # build-mode here replaces the separate autobuild step the
+                  # javascript-only version ran.
+                  build-mode: ${{ matrix.build-mode }}
                   config-file: .github/codeql/codeql-config.yml
 
-            - name: Autobuild
-              uses: github/codeql-action/autobuild@v4
-
+            # No explicit `category:` on purpose. The default is derived from the
+            # workflow path plus language, which is what the existing javascript
+            # alerts are already filed under — setting one would re-file them
+            # under a new category and orphan the old one as a stale
+            # never-updated configuration, the exact failure this ticket fixes.
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Closes LLM-489.

## The gap

The repo moved from CodeQL **default setup** to this workflow on 2026-04-01. Coverage narrowed in the migration and nothing announced it:

| period | categories analyzed |
| --- | --- |
| through 2026-04-01 | `/language:actions`, `/language:go`, `/language:javascript-typescript` |
| 2026-04-01 → now | `.github/workflows/codeql.yml:analyze/language:javascript` only |

`code-scanning/default-setup` reports `state: not-configured`, so those March/April entries are the old setup's final analyses, not a paused schedule. **`actions` and `go` have had zero analysis for ~3.5 months.**

This is what GitHub's tool status page is flagging as not having run since March.

## Why both matter

- **`go`** — `go/client/go.mod` builds the `mail-send` and `memory-sync` binaries both agents use daily.
- **`actions`** — the pack that produced `actions/missing-workflow-permissions` on salem (alerts #8/#9). Never evaluated against this repo.

## Two deliberate choices

**`build-mode` in the matrix replaces the separate `autobuild` step.** That step ran unconditionally under a javascript-only matrix, where it was a no-op. `build-mode: autobuild` on the Go leg is the current pattern, and matches salem's working config.

**No explicit `category:`.** This is the subtle one. The default category derives from workflow path + language, and is what the existing javascript alerts are already filed under. Pinning `category: "/language:${{ matrix.language }}"` (as salem does) would re-file every javascript alert under a new category and leave the old one as a configuration that never updates again — reproducing the exact stale-tool state this PR is fixing. Salem could set one because it had no prior alert history under a different category.

## Expected blast radius

Small. All four workflows already declare a `permissions:` block, so the `actions` leg shouldn't fire the salem-style alerts.

Whatever the restored coverage *does* surface is explicitly out of scope for this PR — those get triaged on their own merits. The point here is that they become visible at all.

## Open risk

If `autobuild` doesn't resolve `go/client` cleanly I'll point it at that directory or fall back to `build-mode: none` for the Go leg. Salem's Go module is also in a subdirectory (`engine/`) and autobuild handles it, so I expect this to work — but CI decides, not me.

— Work