### PR TITLE
LLM-489: stop build-mode from re-filing the javascript analysis category

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,11 +26,11 @@ jobs:
             matrix:
                 include:
                     - language: javascript
-                      build-mode: none
                     - language: actions
-                      build-mode: none
-                    # The module lives at go/client, not the repo root;
-                    # autobuild locates it by finding go.mod.
+                    # Only Go needs a build. The module lives at go/client, not
+                    # the repo root; autobuild locates it by finding go.mod.
+                    # javascript and actions default to build-mode none, so they
+                    # deliberately leave it unset — see the category note below.
                     - language: go
                       build-mode: autobuild
 
@@ -41,15 +41,19 @@ jobs:
               uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
-                  # build-mode here replaces the separate autobuild step the
-                  # javascript-only version ran.
                   build-mode: ${{ matrix.build-mode }}
                   config-file: .github/codeql/codeql-config.yml
 
-            # No explicit `category:` on purpose. The default is derived from the
-            # workflow path plus language, which is what the existing javascript
-            # alerts are already filed under — setting one would re-file them
-            # under a new category and orphan the old one as a stale
-            # never-updated configuration, the exact failure this ticket fixes.
+            # The analysis category is NOT set explicitly, so it is derived —
+            # and the derivation includes build-mode when one is supplied, not
+            # just workflow path and language. Passing `build-mode: none` to the
+            # javascript leg therefore moved it from
+            #   .github/workflows/codeql.yml:analyze/language:javascript
+            # to
+            #   .github/workflows/codeql.yml:analyze/build-mode:none/language:javascript
+            # which orphaned 567 prior analyses and the alert history filed
+            # against them. Leaving build-mode unset for javascript keeps the
+            # original category and that continuity. Changing this input on an
+            # existing language is a category change — treat it as one.
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Fixes a regression I introduced in #286.

## What went wrong

#286 passed `build-mode` on every matrix leg. When `category:` is not set explicitly it is *derived* — and **the derivation includes `build-mode` whenever one is supplied**, not just workflow path and language. So the javascript leg moved:

```
from  .github/workflows/codeql.yml:analyze/language:javascript          (567 analyses)
to    .github/workflows/codeql.yml:analyze/build-mode:none/language:javascript
```

That orphaned 567 prior analyses and the alert history filed against them — including the dismissed `js/insufficient-password-hash` finding. #286's own comment asserted that omitting `category:` would preserve continuity. It doesn't, and I asserted the mechanism without checking what actually feeds the derived value.

Nothing was lost in practice: there were zero open javascript alerts, and #113 remains `dismissed / false positive`. But the old category became a configuration that would never update again — the same stale-tool state LLM-489 exists to clear.

## The fix

`javascript` and `actions` both default to `build-mode: none`, so only the Go leg needs the input. Leaving it unset for the others restores the original javascript category and reconnects the history.

```yaml
include:
    - language: javascript
    - language: actions
    - language: go
      build-mode: autobuild
```

**No analyses are deleted.** This reconnects rather than erases.

## Verification

The thing to check on this PR is the category the javascript leg reports. It should read `…codeql.yml:analyze/language:javascript` again, with no `build-mode:` segment. I'll confirm from the analyses API before merging rather than assume — that assumption is what caused this.

The `actions` leg will also shed its `build-mode:none` segment. That category is two days old with no alert history, so it costs nothing.

— Work