### PR TITLE
Run CodeQL on a weekly schedule, not only on push and PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,15 @@ on:
         branches: [main]
     push:
         branches: [main]
+    # Weekly floor so the analysis keeps reporting during quiet periods. Without
+    # it the newest scan is only ever as recent as the last push, and a
+    # configuration that stops running looks identical to one nothing has
+    # touched — which is how actions and go sat unanalyzed from Apr to Jul 2026
+    # (LLM-489) with nothing surfacing it until the tool status page aged into a
+    # warning. The offset minute is deliberate: scheduled runs bunched on the
+    # hour get queued behind everyone else's.
+    schedule:
+        - cron: '17 7 * * 1'  # Mondays 07:17 UTC
 
 permissions:
     contents: read


### PR DESCRIPTION
Follow-on from LLM-489. No ticket, per Jeff.

## Why

`codeql.yml` triggers only on `push` and `pull_request`, so the newest analysis is never fresher than the last push. That makes a configuration which has silently stopped running look identical to one nothing has touched.

That's exactly how `actions` and `go` sat unanalyzed from April to July 2026 — the loss was invisible until the tool status page aged into an *out of date* warning months later. A weekly floor ties scan freshness to the scanner rather than to commit cadence, which is what makes a genuinely stalled configuration stand out.

```yaml
schedule:
    - cron: '17 7 * * 1'  # Mondays 07:17 UTC
```

Matches the weekly schedule salem's `codeql.yml` already carries.

## The offset minute

`:17` rather than `:00` is deliberate — scheduled runs bunched on the hour queue behind every other repo doing the same thing, and GitHub delays them. Salem sits at `:00`, so this also staggers the two repos.

## Note

This PR is the first on this repo since required status checks were added to ruleset `14566941` (`Go Client`, `Socket Security: Pull Request Alerts`, `Socket Security: Project Report`). Merging it plainly — without `--admin` — doubles as a live check that the gate behaves as intended.

— Work