### PR TITLE
LLM-488: drop the rotation_due advisory from /agent/login

### DIFF
--- a/migrations/MEM-011-session-auth_up.sql
+++ b/migrations/MEM-011-session-auth_up.sql
@@ -13,8 +13,8 @@ CREATE TABLE agent_sessions (
 CREATE INDEX idx_agent_sessions_agent ON agent_sessions(agent);
 CREATE INDEX idx_agent_sessions_expires ON agent_sessions(expires_at);
 
--- Track when passphrase was last rotated so login can hint rotation_due
+-- Track when the passphrase was last rotated (surfaced in the admin agent list)
 ALTER TABLE agents ADD COLUMN passphrase_rotated_at TIMESTAMPTZ;
 
--- Backfill existing agents so they don't immediately get rotation_due
+-- Backfill existing active agents with an initial rotation timestamp
 UPDATE agents SET passphrase_rotated_at = NOW() WHERE status = 'active';

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -25,9 +25,6 @@ const ONLINE_THRESHOLD_MINUTES = 5;
 // Session tokens expire after 24 hours
 const SESSION_TTL_HOURS = 24;
 
-// Passphrase rotation is suggested after 30 days
-const ROTATION_THRESHOLD_DAYS = 30;
-
 function logAgent(action, details) {
     log('agent', action, details);
 }
@@ -68,7 +65,7 @@ router.post('/agent/login', apiRoute('agent', 'login', async (req, res) => {
     // enforce that this actor actually has agent capability — token_hash
     // alone isn't sufficient (a web-only user could theoretically have one).
     const actorResult = await pool.query(
-        `SELECT a.id AS actor_id, a.name AS agent, a.token_hash, a.token_salt, a.status, a.passphrase_rotated_at
+        `SELECT a.id AS actor_id, a.name AS agent, a.token_hash, a.token_salt, a.status
          FROM actors a
          JOIN agent_configuration agc ON agc.actor_id = a.id
          WHERE a.name = $1 AND a.token_hash IS NOT NULL`,
@@ -114,25 +111,12 @@ router.post('/agent/login', apiRoute('agent', 'login', async (req, res) => {
         [row.actor_id]
     );
 
-    // Check if passphrase rotation is due
-    let rotationDue = false;
-    if (row.passphrase_rotated_at) {
-        const daysSinceRotation = (Date.now() - new Date(row.passphrase_rotated_at).getTime()) / (1000 * 60 * 60 * 24);
-        if (daysSinceRotation > ROTATION_THRESHOLD_DAYS) {
-            rotationDue = true;
-        }
-    } else {
-        // No rotation timestamp means never rotated — suggest rotation
-        rotationDue = true;
-    }
-
     logAgent('login', { agent, subsystem: subsystem || null });
 
     res.json({
         agent,
         session_token: sessionToken,
-        expires_at: expiresAt,
-        rotation_due: rotationDue
+        expires_at: expiresAt
     });
 }));
 


### PR DESCRIPTION
## What

`POST /agent/login` returned a `rotation_due` boolean advising a 30-day passphrase rotation. It was dead weight three ways:

1. **Nothing read it** — a repo-wide grep matched only the code producing it (`node/api/src/routes/agent.js`); every client discards it.
2. **Always `true`** — neither actor-creation path stamps `passphrase_rotated_at`, so it's NULL from birth and always hits the "never rotated" branch. A signal that's unconditionally on isn't a signal.
3. **Nothing enforced it** — login succeeds either way; no grace, no escalation, no lockout.

On single-user infra where the passphrase lives in plaintext in `.agent.json` anyway, removing it is more honest than leaving a field that asserts a policy nobody implemented.

## Changes (`node/api/src/routes/agent.js`)

- Remove `ROTATION_THRESHOLD_DAYS`
- Remove the `rotationDue` computation block in the login handler
- Remove `rotation_due` from the login response (now `{agent, session_token, expires_at}`)
- Remove `a.passphrase_rotated_at` from the login `SELECT` (nothing else in the handler reads it once the block is gone)

**Kept deliberately:** `POST /agent/rotate` (on-demand rotation, still writes `passphrase_rotated_at`) and the `actors.passphrase_rotated_at` column — still written by `/agent/rotate` + admin passphrase reset, read by the admin agent list. No migration.

Also refreshed two `MEM-011` migration comments that narrated the removed login hint, so the acceptance grep comes back clean (the runner tracks migrations by id, not content checksum, so editing an applied migration's comments is inert).

## Acceptance

- `POST /agent/login` no longer returns `rotation_due` ✓
- `POST /agent/rotate` untouched (verify current passphrase → new one once → invalidate sessions) ✓
- Admin agent list still shows `passphrase_rotated_at` (`admin.js:379`) ✓
- Repo-wide grep for `rotation_due` / `rotationDue` / `ROTATION_THRESHOLD_DAYS` returns nothing ✓
- No login-response docs enumerate the field ✓

— Work