### PR TITLE
LLM-501: cache-stable sim prompts — byte-stable history, stable_context, soul length cap

### DIFF
--- a/node/api/scripts/test-build-current-turn-context.js
+++ b/node/api/scripts/test-build-current-turn-context.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Standalone test for buildCurrentTurnContext (virtual-agent.js, LLM-501) —
+// the assembler for the volatile context attached to the model's current turn
+// on the sim tool-use path: the Impressions block (moved out of the sim system
+// prompt, where a co-location flip was a full-request cache miss) followed by
+// the engine's ephemeral_context. Same require-stub preamble as the sibling
+// scripts so the heavy module graph never loads.
+//
+// Run: node scripts/test-build-current-turn-context.js   (exits 0 pass / 1 fail)
+
+const Module = require('module');
+const origRequire = Module.prototype.require;
+const stubExports = {};
+Module.prototype.require = function (id) {
+    if (id === '../db' || id === './db') return { query: async () => ({ rows: [] }) };
+    if (/\/(notes|chat|mail|api-spend|metering|conversations|llm-clients|system-handler)$/.test(id)) {
+        return new Proxy(stubExports, { get: function () { return function () { return Promise.resolve(null); }; } });
+    }
+    return origRequire.apply(this, arguments);
+};
+
+const { buildCurrentTurnContext } = require('../src/services/virtual-agent');
+
+let passed = 0, failed = 0;
+const failures = [];
+function check(label, cond) {
+    if (cond) { passed++; } else { failed++; failures.push('  FAIL [' + label + ']'); }
+}
+
+const PEOPLE = '## Your impressions of Hannah Boggs\n\nFair dealer, pays promptly.';
+const EPHEMERAL = '## You\nCoins in your purse: 3.\n\nWeigh what is in front of you.';
+
+// Sim tick with both: Impressions block leads, ephemeral (with its closing
+// triage coda) stays last.
+const both = buildCurrentTurnContext(true, PEOPLE, EPHEMERAL);
+check('impressions wrapped in the Impressions block', both.includes('<Impressions purpose="private-relationship-notes">') && both.includes(PEOPLE));
+check('ephemeral body present', both.includes(EPHEMERAL));
+check('impressions precede the ephemeral body', both.indexOf('<Impressions') < both.indexOf('## You'));
+check('ephemeral is last', both.endsWith(EPHEMERAL));
+
+// Empty peopleContext: NO empty Impressions wrapper — the payload is exactly
+// the ephemeral body.
+check('empty impressions -> ephemeral only', buildCurrentTurnContext(true, '', EPHEMERAL) === EPHEMERAL);
+check('whitespace impressions -> ephemeral only', buildCurrentTurnContext(true, '  \n ', EPHEMERAL) === EPHEMERAL);
+
+// Impressions with no ephemeral (tool-result follow-up with no perception).
+const impOnly = buildCurrentTurnContext(true, PEOPLE, null);
+check('impressions alone -> just the block', impOnly.startsWith('<Impressions') && impOnly.includes(PEOPLE));
+
+// Non-sim callers contribute no Impressions here (theirs stays in the system
+// prompt) — only the ephemeral passes through.
+check('non-sim -> no impressions block', buildCurrentTurnContext(false, PEOPLE, EPHEMERAL) === EPHEMERAL);
+
+// Nothing to attach -> empty string (caller skips the attachment).
+check('nothing -> empty', buildCurrentTurnContext(true, '', null) === '');
+
+if (failed > 0) {
+    console.log('FAILED ' + failed + ' / ' + (passed + failed));
+    failures.forEach(f => console.log(f));
+    process.exit(1);
+}
+console.log('PASS ' + passed + ' / ' + (passed + failed));
+process.exit(0);

--- a/node/api/scripts/test-build-tool-use-messages.js
+++ b/node/api/scripts/test-build-tool-use-messages.js
@@ -81,6 +81,21 @@ check('8m gap -> no marker', smallGap[1].content === '# Your turn again');
 const noTime = buildToolUseMessages([{ from_agent: 'salem-engine', message: '# Your turn\nno time' }], NPC);
 check('no sent_at -> raw content, no prefix', noTime[0].content === '# Your turn\nno time');
 
+// A malformed sent_at parses to NaN -> every gap threshold fails -> no marker
+// (graceful loss of that one row's grounding, never a crash or nondeterminism).
+const badTime = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: 'not-a-date' },
+    { from_agent: 'salem-engine', message: '# Your turn again', sent_at: agoISO(5) },
+], NPC);
+check('malformed sent_at -> no marker, raw content', badTime[1].content === '# Your turn again');
+
+// Out-of-order rows (clock skew) yield a negative gap -> no marker.
+const skewed = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(5) },
+    { from_agent: 'salem-engine', message: '# Your turn again', sent_at: agoISO(60) }, // 55m BEFORE the prior row
+], NPC);
+check('negative gap -> no marker', skewed[1].content === '# Your turn again');
+
 // ZBBS-HOME-436: a REJECTED quote-take replays its "bought" paraphrase with
 // the [error] tool result immediately adjacent (paired by tool_call_id in
 // stored row order), so the false-success window the wording opens is closed

--- a/node/api/scripts/test-build-tool-use-messages.js
+++ b/node/api/scripts/test-build-tool-use-messages.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // Standalone test for buildToolUseMessages (virtual-agent.js) — focused on the
-// MEM-133 relative-time grounding: engine perceptions get a [age] prefix and a
-// "--- gap: Nh ---" marker after a long pause, mirroring the companion path the
-// sim tool-use branch had dropped. Also pins the role mapping + salience content.
+// LLM-501 byte-stable temporal grounding: engine perceptions carry NO
+// replay-time relative-age prefix (those rewrote history bytes on every
+// assembly and killed provider prefix caching); pauses are marked instead
+// with "--- gap: Nm/Nh ---" lines computed purely from the rows' frozen
+// sent_at deltas. Also pins the role mapping + salience content.
 //
 // Run: node scripts/test-build-tool-use-messages.js   (exits 0 pass / 1 fail)
 
@@ -40,11 +42,9 @@ const history = [
 const msgs = buildToolUseMessages(history, NPC);
 
 check('4 messages', msgs.length === 4);
-// 1st perception: [3h] prefix, no gap (first row).
+// 1st perception: raw content — no age prefix (LLM-501), no gap (first row).
 check('msg0 is user', msgs[0].role === 'user');
-// WORK-434 spelled out relative timestamps ([3h] → [3 hours ago]); these
-// expectations were stale until LLM-237 touched this file.
-check('msg0 prefixed with [3 hours ago]', msgs[0].content.startsWith('[3 hours ago]\n# Your turn'));
+check('msg0 is the raw perception, unprefixed', msgs[0].content === '# Your turn\n## You\nstarving');
 check('msg0 has no gap marker (first row)', !msgs[0].content.includes('gap:'));
 // assistant: salience paraphrase, NO time prefix.
 check('msg1 is assistant', msgs[1].role === 'assistant');
@@ -53,9 +53,29 @@ check('msg1 carries the tool_call', Array.isArray(msgs[1].tool_calls) && msgs[1]
 check('msg1 NOT time-prefixed', !msgs[1].content.startsWith('['));
 // tool result: untouched.
 check('msg2 is tool', msgs[2].role === 'tool' && msgs[2].tool_call_id === 't1' && msgs[2].content === '[ok]');
-// 2nd perception: gap marker (~3h) + [5m].
+// 2nd perception: hour-tier gap marker (~2.9h → 3h), no age prefix.
 check('msg3 is user', msgs[3].role === 'user');
-check('msg3 has the gap marker', msgs[3].content.startsWith('--- gap: 3h ---\n[5 minutes ago]\n# Your turn'));
+check('msg3 has the gap marker, no age prefix', msgs[3].content.startsWith('--- gap: 3h ---\n# Your turn'));
+
+// LLM-501 byte-stability: no replayed message anywhere carries a
+// relative-age stamp — those are a function of NOW() and rewrite history
+// bytes between assemblies, killing provider prefix caching.
+const AGE_STAMP = /\[(just now|\d+ (minute|hour|day)s? ago)\]/;
+check('no message carries a relative-age stamp', msgs.every(m => !AGE_STAMP.test(m.content || '')));
+
+// Minutes-tier gap: >= 10 minutes gets a 5-minute-rounded marker...
+const minuteGap = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(60) },
+    { from_agent: 'salem-engine', message: '# Your turn again', sent_at: agoISO(18) }, // 42m later
+], NPC);
+check('42m gap -> "--- gap: 40m ---"', minuteGap[1].content.startsWith('--- gap: 40m ---\n# Your turn again'));
+
+// ...while a sub-10-minute pause (ordinary tick spacing) gets none.
+const smallGap = buildToolUseMessages([
+    { from_agent: 'salem-engine', message: '# Your turn', sent_at: agoISO(20) },
+    { from_agent: 'salem-engine', message: '# Your turn again', sent_at: agoISO(12) }, // 8m later
+], NPC);
+check('8m gap -> no marker', smallGap[1].content === '# Your turn again');
 
 // A perception with no sent_at -> no prefix (graceful).
 const noTime = buildToolUseMessages([{ from_agent: 'salem-engine', message: '# Your turn\nno time' }], NPC);

--- a/node/api/scripts/test-stabilize-history-window.js
+++ b/node/api/scripts/test-stabilize-history-window.js
@@ -67,12 +67,32 @@ const trimmedNext = stabilizeHistoryWindow(nextTurn, CAP);
 check('next turn, same band -> identical head timestamp',
     trimmedNext[0].sent_at === trimmed[0].sent_at);
 
-// Quality floor: the trim never leaves fewer than the newest 25 rows, even
-// when the whole window sits inside one grid band (round-up would otherwise
-// eat deep into it).
-const dense = rows(CAP, ANCHOR, 5000); // 50 rows spanning ~4 minutes
+// Boundary semantics: an oldest row exactly ON a grid line closes its band —
+// the grid line IS that timestamp, so nothing is trimmed on this turn...
+const BOUNDARY = Math.ceil(ANCHOR / GRID_MS) * GRID_MS;
+const onBoundary = rows(CAP, BOUNDARY + (CAP - 1) * 60000, 60000); // oldest exactly at BOUNDARY
+check('oldest exactly on grid line -> retained from that row',
+    stabilizeHistoryWindow(onBoundary, CAP)[0].sent_at === onBoundary[0].sent_at);
+// ...and once the oldest crosses into the next band, the head jumps to the
+// next line — exactly one jump, after which it is stable again.
+const crossed = rows(CAP, BOUNDARY + CAP * 60000, 60000); // oldest at BOUNDARY+1min
+const crossedTrimmed = stabilizeHistoryWindow(crossed, CAP);
+const nextLine = BOUNDARY + GRID_MS;
+check('oldest past the line -> head jumps to the next grid line',
+    new Date(crossedTrimmed[0].sent_at).getTime() >= nextLine);
+const crossedAgain = rows(CAP, BOUNDARY + (CAP + 5) * 60000, 60000); // 5 turns later, same band
+check('subsequent turns in the new band -> head identical',
+    stabilizeHistoryWindow(crossedAgain, CAP)[0].sent_at === crossedTrimmed[0].sent_at);
+
+// Quality floor: when every fetched row sits before the grid line (a dense
+// burst just under a boundary), the floor binds — exactly the newest
+// MIN_KEEP rows are returned, deliberately unaligned to the grid (cache
+// stability abandoned for context; see the implementation comment).
+const dense = rows(CAP, BOUNDARY - 60000, 5000); // 50 rows, all inside one band, none at/after its line
 const denseTrimmed = stabilizeHistoryWindow(dense, CAP);
-check('dense window -> min-keep floor holds', denseTrimmed.length >= 25);
+check('floor binds -> exactly the newest 25 rows', denseTrimmed.length === 25);
+check('floor binds -> retained head is the 25th-newest row',
+    denseTrimmed[0] === dense[CAP - 25]);
 
 // Graceful on rows without sent_at at the head.
 const noTime = [{ message: 'x' }].concat(rows(CAP - 1, ANCHOR, 60000));

--- a/node/api/scripts/test-stabilize-history-window.js
+++ b/node/api/scripts/test-stabilize-history-window.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Standalone test for stabilizeHistoryWindow (virtual-agent.js, LLM-501) —
+// the quantizer that stops a cap-bound history window's head from sliding
+// one row per turn (a full provider prefix-cache miss every tick). Same
+// require-stub preamble as test-build-tool-use-messages.js so the heavy
+// module graph never loads.
+//
+// Run: node scripts/test-stabilize-history-window.js   (exits 0 pass / 1 fail)
+
+const Module = require('module');
+const origRequire = Module.prototype.require;
+const stubExports = {};
+Module.prototype.require = function (id) {
+    if (id === '../db' || id === './db') return { query: async () => ({ rows: [] }) };
+    if (/\/(notes|chat|mail|api-spend|metering|conversations|llm-clients|system-handler)$/.test(id)) {
+        return new Proxy(stubExports, { get: function () { return function () { return Promise.resolve(null); }; } });
+    }
+    return origRequire.apply(this, arguments);
+};
+
+const { stabilizeHistoryWindow } = require('../src/services/virtual-agent');
+
+let passed = 0, failed = 0;
+const failures = [];
+function check(label, cond) {
+    if (cond) { passed++; } else { failed++; failures.push('  FAIL [' + label + ']'); }
+}
+
+const GRID_MS = 15 * 60 * 1000;
+const CAP = 50;
+
+// Build n rows spaced stepMs apart, the NEWEST at endMs and the oldest
+// earliest — mirroring loadDirectChatHistory's oldest-first return order.
+function rows(n, endMs, stepMs) {
+    const out = [];
+    for (let i = n - 1; i >= 0; i--) {
+        out.push({ sent_at: new Date(endMs - i * stepMs).toISOString(), message: 'm' + i });
+    }
+    return out;
+}
+
+// Fix an absolute anchor mid-band so grid math is deterministic in the test:
+// 2026-07-21T12:07:30Z is 7.5 minutes past a 15-minute grid line.
+const ANCHOR = Date.parse('2026-07-21T12:07:30Z');
+
+// Under the cap: untouched (the hour-quantized SQL time cutoff governs).
+const under = rows(30, ANCHOR, 60000);
+check('under cap -> untouched', stabilizeHistoryWindow(under, CAP) === under);
+
+// At the cap: head trimmed to the first row at/after the grid line above the
+// oldest fetched row.
+const atCap = rows(CAP, ANCHOR, 60000); // oldest at 11:18:30 -> grid line 11:30:00
+const trimmed = stabilizeHistoryWindow(atCap, CAP);
+const gridLine = Math.ceil((ANCHOR - (CAP - 1) * 60000) / GRID_MS) * GRID_MS;
+check('at cap -> head trimmed to grid line',
+    trimmed.length > 0 && new Date(trimmed[0].sent_at).getTime() >= gridLine);
+check('at cap -> rows before grid line dropped',
+    atCap.filter(r => new Date(r.sent_at).getTime() >= gridLine).length === trimmed.length);
+check('at cap -> tail preserved in order',
+    trimmed[trimmed.length - 1] === atCap[atCap.length - 1]);
+
+// STABILITY: one turn later (one new row appended, oldest fell off the
+// fetch) the retained head must be IDENTICAL as long as the oldest fetched
+// row stays inside the same grid band — that identity is the whole point.
+const nextTurn = rows(CAP, ANCHOR + 60000, 60000); // slid forward one row
+const trimmedNext = stabilizeHistoryWindow(nextTurn, CAP);
+check('next turn, same band -> identical head timestamp',
+    trimmedNext[0].sent_at === trimmed[0].sent_at);
+
+// Quality floor: the trim never leaves fewer than the newest 25 rows, even
+// when the whole window sits inside one grid band (round-up would otherwise
+// eat deep into it).
+const dense = rows(CAP, ANCHOR, 5000); // 50 rows spanning ~4 minutes
+const denseTrimmed = stabilizeHistoryWindow(dense, CAP);
+check('dense window -> min-keep floor holds', denseTrimmed.length >= 25);
+
+// Graceful on rows without sent_at at the head.
+const noTime = [{ message: 'x' }].concat(rows(CAP - 1, ANCHOR, 60000));
+check('missing head sent_at -> untouched', stabilizeHistoryWindow(noTime, CAP) === noTime);
+
+// Empty / non-array input passes through.
+check('empty -> untouched', Array.isArray(stabilizeHistoryWindow([], CAP)) );
+
+if (failed > 0) {
+    console.log('FAILED ' + failed + ' / ' + (passed + failed));
+    failures.forEach(f => console.log(f));
+    process.exit(1);
+}
+console.log('PASS ' + passed + ' / ' + (passed + failed));
+process.exit(0);

--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -57,6 +57,25 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     // never written to chat_message_texts, so it can't accumulate across the
     // replayed conversation. Absent = unchanged behavior. Length-capped as a
     // guard against an absurd payload (the engine's furniture block is a few KB).
+    // stable_context (LLM-501): optional per-actor DAILY-stable context —
+    // identity prose / trade rules / home-work anchors the engine wants
+    // appended to the (provider-cached) system prompt instead of re-billed
+    // cold in the volatile user turn. Same security posture as
+    // ephemeral_context below: forwarded to the model, NEVER persisted,
+    // gated to the sim engine principal.
+    const stableContext = req.body.stable_context;
+    if (stableContext !== undefined && stableContext !== null) {
+        if (from_agent !== 'salem-engine') {
+            return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'stable_context is only supported for sim engine chat' } });
+        }
+        if (typeof stableContext !== 'string') {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'stable_context must be a string' } });
+        }
+        if (stableContext.length > 65536) {
+            return res.status(400).json({ error: { code: 'BAD_REQUEST', message: 'stable_context exceeds 65536 chars' } });
+        }
+    }
+
     const ephemeralContext = req.body.ephemeral_context;
     if (ephemeralContext !== undefined && ephemeralContext !== null) {
         // SECURITY: ephemeral_context is forwarded to the model but NEVER
@@ -216,7 +235,7 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
     }
 
     const result = await chatSend(from_agent, to_agents, discussionId, message, {
-        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, conversationId, simActorId, simActorName, wait, ephemeralContext,
+        toolCalls, toolCallId, toolsOffered, toolCallResults, persistOnly, sceneId, sceneStructure, conversationId, simActorId, simActorName, wait, ephemeralContext, stableContext,
     });
 
     // wait=true: hold the connection open until the VA reply lands inline.

--- a/node/api/src/services/chat.js
+++ b/node/api/src/services/chat.js
@@ -100,6 +100,10 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
     // the model's current turn. NOT persisted — it never enters rowSpecs, so
     // only `message` (the durable narrative) hits chat_message_texts.
     const ephemeralContext = opts && opts.ephemeralContext !== undefined ? opts.ephemeralContext : null;
+    // stableContext (LLM-501): per-actor daily-stable context forwarded to
+    // handleDirectChat to append to the cached system prompt. NOT persisted —
+    // like ephemeralContext, it never enters rowSpecs.
+    const stableContext = opts && opts.stableContext !== undefined ? opts.stableContext : null;
     // is_error flag (MEM-122): set on retry/error breadcrumb rows so
     // history readers (loadDirectChatHistory, loadChatHistory) filter
     // them out of next-call context. Without this, virtual agents read
@@ -415,7 +419,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                     if (dispatches.length === 1) {
                         const d = dispatches[0];
                         pendingReplyPromise = handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                            toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ackReplyOnInsert: wait, ephemeralContext,
+                            toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ackReplyOnInsert: wait, ephemeralContext, stableContext,
                         });
                         // Swallow rejection for non-wait callers so unhandled-promise
                         // warnings don't appear; wait-mode awaiters get the error.
@@ -426,7 +430,7 @@ async function chatSend(fromAgent, toAgents, discussionId, message, opts) {
                         // stays false here.
                         for (const d of dispatches) {
                             handleDirectChat(d.agent, fromAgent, message, d.msgId, {
-                                toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ephemeralContext,
+                                toolsOffered, isToolResultCall, sceneId, sceneStructure, conversationId, simActorId, simActorName, ephemeralContext, stableContext,
                             }).catch(() => {});
                         }
                     }

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -130,6 +130,10 @@ function soulNeedsRebuild(existingSoul, minChars) {
 // writer's input (LLM-420). When a backload is not available (disabled or no
 // dreams yet) the day's chunk is used as the snapshot regardless of rebuild.
 function buildSoulUserMessage({ agentName, startupInstructions, existingSoul, needsRebuild, backloadDreams, chunkDate, dreamContent }) {
+    // Length cap shared with the sim-soul endpoint (LLM-501) — the soul is
+    // re-billed on every NPC turn, so both soul writers carry the same
+    // condense-don't-grow contract.
+    const { SOUL_LENGTH_DIRECTIVE } = require('./sim-soul');
     return '## Agent: ' + agentName + '\n\n'
         + (startupInstructions
             ? '## Character description\n\n' + startupInstructions + '\n\n'
@@ -140,7 +144,8 @@ function buildSoulUserMessage({ agentName, startupInstructions, existingSoul, ne
             ? '\n\n## Dream snapshot for initial soul rebuild\n\n'
                 + 'There is no usable prior soul document. Synthesize an initial soul from the recent dream history below; do not treat this as a single-day incremental update.\n\n'
                 + backloadDreams
-            : '\n\n## Dream snapshot for ' + chunkDate + '\n\n' + dreamContent);
+            : '\n\n## Dream snapshot for ' + chunkDate + '\n\n' + dreamContent)
+        + '\n\n' + SOUL_LENGTH_DIRECTIVE;
 }
 
 // Cheap detection for the typed-context JSON array format. The whole

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -146,6 +146,10 @@ test('evolve path feeds the existing soul plus the day chunk, no rebuild framing
     assert.ok(msg.includes('## Dream snapshot for 2026-07-15'));
     assert.ok(!msg.includes('rebuilding from recent dreams'));
     assert.ok(!msg.includes('initial soul rebuild'));
+    // The shared length cap (LLM-501) closes the message — same directive the
+    // sim-soul endpoint appends, so both soul writers carry one contract.
+    const { SOUL_LENGTH_DIRECTIVE } = require('./sim-soul');
+    assert.ok(msg.endsWith(SOUL_LENGTH_DIRECTIVE));
 });
 
 test('empty startup instructions produce no character-description section', () => {

--- a/node/api/src/services/sim-soul.js
+++ b/node/api/src/services/sim-soul.js
@@ -54,6 +54,18 @@ const MAX_FIELD_LEN = 100000;
 // "update" an empty document and produces something thin.
 //
 // Pure — exported for unit tests.
+// Soul length cap (LLM-501). The soul is rendered into every NPC turn — in
+// the shared-NPC perception's `## Who you are` block and the stateful NPC's
+// system prompt — so an unbounded "update the document" loop that only ever
+// grows it bills its full length on every LLM call, forever. Appended to the
+// user message (not the agent's startup_instructions) so it's versioned with
+// the code and applies to both the shared endpoint and the nightly stateful
+// path (dream.js imports it).
+const SOUL_LENGTH_DIRECTIVE = 'Keep the soul document under about 200 words. '
+    + 'When weaving in new material, condense: fold older detail into fewer, '
+    + 'stronger sentences and keep only what defines the character. A short, '
+    + 'sharp soul beats a long memoir.';
+
 function buildSoulUserMessage({ characterDescription, currentSoul, daySnapshot, day }) {
     const soulIsEmpty = !currentSoul || currentSoul.trim() === '';
     const snapshotHeader = day ? '## Dream snapshot for ' + day : '## Dream snapshot';
@@ -70,6 +82,7 @@ function buildSoulUserMessage({ characterDescription, currentSoul, daySnapshot, 
     }
 
     msg += daySnapshot.trim();
+    msg += '\n\n' + SOUL_LENGTH_DIRECTIVE;
     return msg;
 }
 
@@ -189,4 +202,6 @@ async function synthesizeSimSoul({ characterDescription, currentSoul, daySnapsho
 
 // buildSoulUserMessage is exported for unit tests (sim-soul.test.js);
 // synthesizeSimSoul is the production entry (routes/sim.js).
-module.exports = { synthesizeSimSoul, buildSoulUserMessage };
+// SOUL_LENGTH_DIRECTIVE is shared with the nightly stateful soul path
+// (dream.js) so both soul writers carry the same length contract.
+module.exports = { synthesizeSimSoul, buildSoulUserMessage, SOUL_LENGTH_DIRECTIVE };

--- a/node/api/src/services/sim-soul.test.js
+++ b/node/api/src/services/sim-soul.test.js
@@ -10,7 +10,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildSoulUserMessage, synthesizeSimSoul } = require('./sim-soul');
+const { buildSoulUserMessage, synthesizeSimSoul, SOUL_LENGTH_DIRECTIVE } = require('./sim-soul');
 
 const SEED = 'Lewis Walker, who lodges at the Wayfarer with Hannah Walker.';
 const SNAPSHOT = '- [Jun 30] spoke: "Good morrow."\n- [Jun 30] sold bread to a stranger.';
@@ -25,8 +25,10 @@ test('first run (empty soul) marks it empty and frames an initial synthesis', ()
     assert.match(msg, /## Character description\n\nLewis Walker/);
     assert.match(msg, /## Current soul document\n\n\(empty — first run\)/);
     assert.match(msg, /## Dream snapshot for 2026-06-30\n\nThe current soul document is empty\. Synthesize an initial soul/);
-    // The day material still lands at the end.
-    assert.ok(msg.endsWith(SNAPSHOT));
+    // The day material lands after the framing, with the length directive
+    // (LLM-501) closing the message.
+    assert.ok(msg.includes(SNAPSHOT));
+    assert.ok(msg.endsWith(SOUL_LENGTH_DIRECTIVE));
 });
 
 test('missing/whitespace soul is treated as a first run', () => {
@@ -75,7 +77,8 @@ test('inputs are trimmed at the section boundaries', () => {
     });
     assert.match(msg, /## Character description\n\nLewis Walker/);
     assert.match(msg, /## Current soul document\n\nprior soul\n\n/);
-    assert.ok(msg.endsWith(SNAPSHOT));
+    assert.ok(msg.includes(SNAPSHOT));
+    assert.ok(msg.endsWith(SOUL_LENGTH_DIRECTIVE));
     // No doubled blank padding from untrimmed inputs.
     assert.doesNotMatch(msg, /\n\n\n/);
 });

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -1029,17 +1029,22 @@ async function loadDirectChatHistory(agent1, agent2, sceneId) {
 // reason.)
 //
 // Fix: when the fetch hit the cap, trim the head to a fixed 15-minute grid
-// line in absolute time — the earliest fetched row's sent_at rounded UP to
-// the grid. As new rows arrive, the earliest-fetched row slides forward
-// WITHIN a grid band while the grid line itself stays put, so the retained
-// head — and therefore the replayed byte prefix — is identical across those
-// turns. Only when the earliest row crosses the grid line does the head
-// jump (one cache miss per ~15 minutes instead of one per turn).
+// line in ABSOLUTE (Unix-epoch) time — the earliest fetched row's sent_at
+// rounded UP to the grid. For any earliest row inside the half-open band
+// (k*GRID, (k+1)*GRID] the line is the same absolute timestamp
+// (k+1)*GRID, so as rows slide forward within a band the retained head —
+// and therefore the replayed byte prefix — is identical across those
+// turns. Only when the earliest row crosses into the next band does the
+// head jump (one cache miss per ~15 minutes instead of one per turn).
+// A row sitting exactly ON a boundary closes its band immediately (ceil
+// of an exact multiple is itself), which can cost one extra early jump —
+// never non-determinism, since the result is a pure function of the rows.
 //
 // MIN_KEEP quality floor: in a very busy scene the round-up could eat deep
-// into the cap'd window, so never trim below the newest MIN_KEEP rows —
-// falling back to the sliding head for that (rare) case; context beats
-// cache there.
+// into the cap'd window, so never trim below the newest MIN_KEEP rows.
+// When the floor binds, the retained head sits BEFORE the grid line and
+// slides one row per turn again — cache stability is deliberately
+// abandoned for that (rare) case; context beats cache there.
 //
 // Under the cap the fetch is bounded by the (hour-quantized) time cutoff
 // alone and rows are returned untouched. Pure; exported for unit tests.
@@ -2334,6 +2339,10 @@ function paraphraseToolCall(name, input) {
 // perception's own text still carries frozen "(4m ago)" stamps from the
 // engine's render.
 function formatGapMarker(gapMs) {
+    // A malformed sent_at parses to NaN and a clock-skewed out-of-order pair
+    // yields a negative gap; both fail every threshold below and emit no
+    // marker — losing that one row's temporal grounding, never determinism
+    // (the same rows always produce the same output).
     const HOUR_MS = 60 * 60 * 1000;
     const MINUTE_MS = 60 * 1000;
     if (gapMs >= 2 * HOUR_MS) {
@@ -2344,6 +2353,24 @@ function formatGapMarker(gapMs) {
         return '--- gap: ' + mins + 'm ---';
     }
     return null;
+}
+
+// buildCurrentTurnContext assembles the volatile per-call context attached to
+// the model's CURRENT turn on the sim tool-use path (LLM-501): the Impressions
+// block (private notes on co-located people — moved here from the sim system
+// prompt, where a co-location flip was a full-request cache miss) followed by
+// the engine's ephemeral_context (which ends with the triage coda, so it stays
+// last). Empty peopleContext emits NO Impressions block (wrapBlock returns ''
+// for empty content and the join drops it) — an empty wrapper would change the
+// payload for nothing. Non-sim callers contribute no Impressions here (theirs
+// stays in the system prompt). Returns '' when there is nothing to attach.
+// Pure; exported for unit tests.
+function buildCurrentTurnContext(isSimNpc, peopleContext, ephemeralContext) {
+    let impressionsBlock = '';
+    if (isSimNpc) {
+        impressionsBlock = wrapBlock('Impressions', 'private-relationship-notes', DIRECTIVE_IMPRESSIONS, peopleContext);
+    }
+    return [impressionsBlock, ephemeralContext].filter(Boolean).join('\n\n');
 }
 
 function buildToolUseMessages(history, npcAgentName) {
@@ -2866,11 +2893,7 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             // perception; for a tool-result follow-up (latest messages are tool
             // results) push a trailing user turn so the model still sees its
             // current options.
-            const impressionsBlock = isSimNpc
-                ? wrapBlock('Impressions', 'private-relationship-notes', DIRECTIVE_IMPRESSIONS, peopleContext)
-                : '';
-            const currentTurnContext = [impressionsBlock, ephemeralContext]
-                .filter(Boolean).join('\n\n');
+            const currentTurnContext = buildCurrentTurnContext(isSimNpc, peopleContext, ephemeralContext);
             if (currentTurnContext) {
                 const lastMsg = toolUseMessages[toolUseMessages.length - 1];
                 if (lastMsg && lastMsg.role === 'user') {
@@ -3228,4 +3251,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, effectiveRateLimit, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages, stabilizeHistoryWindow };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, effectiveRateLimit, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages, stabilizeHistoryWindow, buildCurrentTurnContext };

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -981,9 +981,13 @@ async function loadChatHistory(discussionId, limit) {
 // layer (actor_narrative_state, actor_relationship), not from chat
 // history. Persistent-VA callers pass null here and keep the agent-wide
 // time-windowed history they had pre-fix.
+// Row cap for direct-chat history. Module-scope because the sim tick path
+// also needs it to tell "the fetch hit the cap" (see stabilizeHistoryWindow).
+const MAX_DIRECT_CHAT_HISTORY = 50;
+
 async function loadDirectChatHistory(agent1, agent2, sceneId) {
     const hours = parseInt(config.get('virtual_agent_chat_history_hours')) || 4;
-    const maxMessages = 50;
+    const maxMessages = MAX_DIRECT_CHAT_HISTORY;
 
     const actor1 = await requireByName(agent1);
     const actor2 = await requireByName(agent2);
@@ -1007,12 +1011,60 @@ async function loadDirectChatHistory(agent1, agent2, sceneId) {
          WHERE cmt.discussion_id IS NULL AND cm.deleted_at IS NULL
            AND NOT cmt.is_error
          AND ((cmt.from_actor_id = $1 AND cm.to_actor_id = $2) OR (cmt.from_actor_id = $2 AND cm.to_actor_id = $1))
-         AND cmt.sent_at >= NOW() - INTERVAL '1 hour' * $3
+         AND cmt.sent_at >= date_trunc('hour', NOW()) - INTERVAL '1 hour' * $3
          AND ($5::uuid IS NULL OR cmt.scene_id = $5::uuid)
          ORDER BY cm.id DESC LIMIT $4`,
         [actor1.id, actor2.id, hours, maxMessages, sceneId || null]
     );
     return result.rows.reverse();
+}
+
+// Quantize the sliding head of a cap-bound history window (LLM-501).
+//
+// When a busy NPC runs at the MAX_DIRECT_CHAT_HISTORY cap, the plain
+// "newest N rows" fetch drops the oldest row on EVERY new row — a byte
+// shift at position 0 of the replayed history, which is a full-prefix
+// provider-cache miss on every single turn. (The time cutoff has the same
+// disease in slow motion; it's hour-truncated in SQL above for the same
+// reason.)
+//
+// Fix: when the fetch hit the cap, trim the head to a fixed 15-minute grid
+// line in absolute time — the earliest fetched row's sent_at rounded UP to
+// the grid. As new rows arrive, the earliest-fetched row slides forward
+// WITHIN a grid band while the grid line itself stays put, so the retained
+// head — and therefore the replayed byte prefix — is identical across those
+// turns. Only when the earliest row crosses the grid line does the head
+// jump (one cache miss per ~15 minutes instead of one per turn).
+//
+// MIN_KEEP quality floor: in a very busy scene the round-up could eat deep
+// into the cap'd window, so never trim below the newest MIN_KEEP rows —
+// falling back to the sliding head for that (rare) case; context beats
+// cache there.
+//
+// Under the cap the fetch is bounded by the (hour-quantized) time cutoff
+// alone and rows are returned untouched. Pure; exported for unit tests.
+const HISTORY_HEAD_GRID_MS = 15 * 60 * 1000;
+const HISTORY_HEAD_MIN_KEEP = 25;
+function stabilizeHistoryWindow(rows, maxMessages) {
+    if (!Array.isArray(rows) || rows.length < maxMessages) {
+        return rows;
+    }
+    const first = rows[0];
+    if (!first || !first.sent_at) {
+        return rows;
+    }
+    const firstMs = new Date(first.sent_at).getTime();
+    const gridLineMs = Math.ceil(firstMs / HISTORY_HEAD_GRID_MS) * HISTORY_HEAD_GRID_MS;
+    let cut = 0;
+    while (cut < rows.length - HISTORY_HEAD_MIN_KEEP) {
+        const row = rows[cut];
+        if (row.sent_at && new Date(row.sent_at).getTime() < gridLineMs) {
+            cut++;
+        } else {
+            break;
+        }
+    }
+    return rows.slice(cut);
 }
 
 // Search the agent's namespace for context relevant to the discussion topic.
@@ -1241,6 +1293,8 @@ const DIRECTIVE_REPLY_POLICY = 'You do not have to respond. If a reply is not wa
 const DIRECTIVE_OUTPUT = 'Reply with your own message content only — plain text, no JSON wrapper, no sender labels, no additional entries, no continuation of other participants\' messages. End when your own message is complete.';
 
 const DIRECTIVE_OUTPUT_CHAT = 'Respond concisely and naturally, the way a person would in conversation. Your reply only — no JSON, no speaker labels, no framing, no timestamp.';
+
+const DIRECTIVE_STANDING = 'Standing facts about your character — who you are, how you live and trade, where home and work are. They change rarely; treat them as background identity. What is happening right now arrives in the user messages.';
 
 const DIRECTIVE_SIM_CONTEXT = 'You are a character inside a village simulation. The user messages are perception updates emitted by the simulation engine — what your character sees, hears, or experiences in the moment. They are not chat from a person; do not address the engine, the narrator, or "the user". Choose actions by calling the provided tools. Do not reply with ordinary prose. If you want your character to say something, use the speak tool. Speak only to characters confirmed present in your perception or by tool results. If you want to go somewhere, use move_to. If no action is appropriate this round, call done. Treat perception and tool results as authoritative — do not invent unseen characters, unavailable locations, or events not supported by the simulation state. Use your identity, memories, and impressions to decide what your character wants, but express every action through tools.';
 
@@ -2264,17 +2318,43 @@ function paraphraseToolCall(name, input) {
     }
 }
 
+// Gap marker between two replayed history rows, or null when the gap is too
+// small to note. Two tiers: minutes (rounded to 5) from 10 minutes up, hours
+// (rounded) from 2 hours up — "--- gap: 25m ---" / "--- gap: 3h ---".
+//
+// LLM-501: this is a pure function of the two rows' FROZEN sent_at values, so
+// the marker text never changes between assemblies. Its predecessor — a
+// per-perception relative-age prefix ("[3 minutes ago]") recomputed from
+// NOW() on every assembly — rewrote history bytes as time passed, which
+// killed provider prefix caching from the first ticked-over stamp onward
+// (statefuls re-billed most of their history cold every turn). The gap
+// markers keep the temporal grounding the stamps provided (a busy scene vs.
+// one spread over hours still read differently) with replay-stable bytes.
+// The finer 10-minute tier compensates for the lost per-message ages; each
+// perception's own text still carries frozen "(4m ago)" stamps from the
+// engine's render.
+function formatGapMarker(gapMs) {
+    const HOUR_MS = 60 * 60 * 1000;
+    const MINUTE_MS = 60 * 1000;
+    if (gapMs >= 2 * HOUR_MS) {
+        return '--- gap: ' + Math.round(gapMs / HOUR_MS) + 'h ---';
+    }
+    if (gapMs >= 10 * MINUTE_MS) {
+        const mins = Math.round(gapMs / (5 * MINUTE_MS)) * 5;
+        return '--- gap: ' + mins + 'm ---';
+    }
+    return null;
+}
+
 function buildToolUseMessages(history, npcAgentName) {
     const messages = [];
     const npcLower = npcAgentName.toLowerCase();
-    // Relative-time grounding for the replayed sim history: prefix each engine
-    // perception with its age ([3h], [now], ...) and mark big inter-tick gaps,
-    // so the model knows WHEN each turn happened — a busy scene vs. one spread
-    // over hours read very differently, and the tool-use path otherwise carries
-    // no time at all. Mirrors the companion buildDirectChatUserMessage path
-    // (which the sim path had dropped). Replay-time annotation computed from
-    // sent_at — NEVER persisted.
-    const GAP_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2h, matching buildDirectChatUserMessage
+    // Temporal grounding for the replayed sim history: mark inter-tick gaps
+    // so the model knows how the turns are spaced — a busy scene vs. one
+    // spread over hours read very differently, and the tool-use path
+    // otherwise carries no time at all. Replay-time annotation computed from
+    // the rows' frozen sent_at deltas — NEVER persisted, and deliberately
+    // byte-stable across assemblies (see formatGapMarker / LLM-501).
     let prevSentAt = null;
     for (const row of history) {
         const fromLower = (row.from_agent || '').toLowerCase();
@@ -2308,21 +2388,17 @@ function buildToolUseMessages(history, npcAgentName) {
                 content: row.message || '',
             });
         } else {
-            // Engine perception (user turn). Prefix with a relative-time marker
-            // and, when there's a long pause since the previous row, a gap line.
-            // Only the perception turns are stamped — the assistant/tool rows of
-            // a tick are the same moment as their perception.
+            // Engine perception (user turn). When there's a notable pause
+            // since the previous row, lead with a gap line. Only the
+            // perception turns get one — the assistant/tool rows of a tick
+            // are the same moment as their perception.
             let content = row.message || '';
-            if (row.sent_at) {
-                const prefix = [];
-                if (prevSentAt) {
-                    const gap = new Date(row.sent_at).getTime() - new Date(prevSentAt).getTime();
-                    if (gap >= GAP_THRESHOLD_MS) {
-                        prefix.push('--- gap: ' + Math.round(gap / (60 * 60 * 1000)) + 'h ---');
-                    }
+            if (row.sent_at && prevSentAt) {
+                const gap = new Date(row.sent_at).getTime() - new Date(prevSentAt).getTime();
+                const marker = formatGapMarker(gap);
+                if (marker) {
+                    content = marker + '\n' + content;
                 }
-                prefix.push(formatRelativeTime(row.sent_at));
-                content = prefix.join('\n') + '\n' + content;
             }
             messages.push({ role: 'user', content });
         }
@@ -2537,6 +2613,13 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
     // accumulate across the replayed conversation. Empty/absent → no-op.
     const ephemeralContext = (opts && typeof opts.ephemeralContext === 'string' && opts.ephemeralContext.length > 0)
         ? opts.ephemeralContext : null;
+    // stableContext (LLM-501): per-actor DAILY-stable context (identity prose,
+    // trade rules, home/work anchors) the engine wants in the provider-cached
+    // zone. Appended to the system prompt below — NOT to the user turn — so it
+    // extends the stable byte prefix instead of re-billing cold every tick.
+    // Never persisted, same as ephemeralContext. Empty/absent → no-op.
+    const stableContext = (opts && typeof opts.stableContext === 'string' && opts.stableContext.length > 0)
+        ? opts.stableContext : null;
     const isToolUse = Array.isArray(toolsOffered) && toolsOffered.length > 0;
     // isToolResultCall=true means this chat/send is the model's response
     // to a tool result the engine just sent back (e.g. "[OK] You spoke.").
@@ -2707,7 +2790,25 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (isSimNpc && isToolUse) {
             // Action tick: tools_offered is non-empty, so SimContext's push toward
             // tool-call output is correct.
-            systemPrompt = buildSimChatSystemPrompt(agent, ragContext, soul, peopleContext);
+            //
+            // Cache-stable composition (LLM-501): the system message is the
+            // provider-cached prefix of every request, and any byte that
+            // changes in it invalidates the ENTIRE request — including all
+            // replayed history. So the action-tick system prompt carries only
+            // within-day-stable content:
+            //   - Impressions (co-located people notes) changes whenever
+            //     someone walks in or out, so it moves to the current-turn
+            //     attachment below instead (peopleContext deliberately NOT
+            //     passed here).
+            //   - The engine's stableContext (identity / trade rules /
+            //     anchors, daily-stable) is appended here, where it caches.
+            // The reflection and companion paths keep the original
+            // composition — they don't replay a per-tick history, so there's
+            // nothing to protect.
+            systemPrompt = buildSimChatSystemPrompt(agent, ragContext, soul, '');
+            if (stableContext) {
+                systemPrompt.static += '\n\n' + wrapBlock('Standing', 'standing-context', DIRECTIVE_STANDING, stableContext);
+            }
         } else if (isSimNpc) {
             // Engine-driven call with no tools = a prose-only reflection
             // (consolidation / narrative / atmosphere / noticeboard). The action
@@ -2726,7 +2827,12 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
         if (isToolUse) {
             let toolUseHistory = history;
             if (isSimChat) {
-                toolUseHistory = pruneSimHistory(history);
+                // Quantize the cap-bound sliding head BEFORE pruning so the
+                // at-cap detection sees the fetched row count (LLM-501), then
+                // prune consecutive perceptions as before — both steps are
+                // deterministic over the same row set, so the replayed byte
+                // prefix stays stable between head jumps.
+                toolUseHistory = pruneSimHistory(stabilizeHistoryWindow(history, MAX_DIRECT_CHAT_HISTORY));
             }
             toolUseMessages = buildToolUseMessages(toolUseHistory, virtualAgentName);
             toolUseMessages = trimHeadToUserMessage(toolUseMessages);
@@ -2745,21 +2851,34 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
                 }];
             }
 
-            // Attach ephemeral_context (lean sim-history) to the CURRENT turn,
-            // AFTER history assembly so it never becomes part of the persisted /
-            // replayed conversation — it carries the per-tick affordances /
-            // world-state the model needs to decide NOW. Append to the last user
-            // message when the latest turn is a fresh perception; for a
-            // tool-result follow-up (latest messages are tool results) push it as
-            // a trailing user turn so the model still sees its current options.
-            if (ephemeralContext) {
+            // Attach the per-tick volatile context to the CURRENT turn, AFTER
+            // history assembly so it never becomes part of the persisted /
+            // replayed conversation:
+            //   - the Impressions block (private notes on co-located people) —
+            //     moved here from the sim action-tick system prompt (LLM-501):
+            //     it changes whenever co-location changes, and a byte change in
+            //     the system message is a full-request provider-cache miss.
+            //     Same content and wrapper, volatile-zone placement.
+            //   - ephemeral_context (lean sim-history) — the per-tick
+            //     affordances / world-state the model needs to decide NOW. It
+            //     ends with the engine's triage coda, so it stays last.
+            // Append to the last user message when the latest turn is a fresh
+            // perception; for a tool-result follow-up (latest messages are tool
+            // results) push a trailing user turn so the model still sees its
+            // current options.
+            const impressionsBlock = isSimNpc
+                ? wrapBlock('Impressions', 'private-relationship-notes', DIRECTIVE_IMPRESSIONS, peopleContext)
+                : '';
+            const currentTurnContext = [impressionsBlock, ephemeralContext]
+                .filter(Boolean).join('\n\n');
+            if (currentTurnContext) {
                 const lastMsg = toolUseMessages[toolUseMessages.length - 1];
                 if (lastMsg && lastMsg.role === 'user') {
                     lastMsg.content = lastMsg.content
-                        ? lastMsg.content + '\n\n' + ephemeralContext
-                        : ephemeralContext;
+                        ? lastMsg.content + '\n\n' + currentTurnContext
+                        : currentTurnContext;
                 } else {
-                    toolUseMessages.push({ role: 'user', content: ephemeralContext });
+                    toolUseMessages.push({ role: 'user', content: currentTurnContext });
                 }
             }
         }
@@ -3109,4 +3228,4 @@ async function handleDirectMail(virtualAgentName, fromAgent, mailId) {
 const systemHandler = require('./system-handler');
 systemHandler.register('virtual-agent', handleVirtualAgent);
 
-module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, effectiveRateLimit, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages };
+module.exports = { handleVirtualAgent, handleDirectChat, handleDirectMail, resolveEffectiveLimits, effectiveRateLimit, startErrorPing, invokeAgent, loadAgent, extractCoLocatedNames, paraphraseToolCall, buildToolUseMessages, stabilizeHistoryWindow };


### PR DESCRIPTION
Stateful sim NPCs billed ~8k cold input tokens/turn (60% of the village's DeepSeek spend) because the replayed history's bytes changed on every assembly. Verified in raw turns + code; diagnosis on the ticket (LLM-501, comment of 2026-07-21).

## Changes
- **History byte-stability**: `buildToolUseMessages` no longer stamps replayed perceptions with relative ages recomputed from NOW() — deterministic gap markers (`--- gap: 25m/3h ---`) computed purely from frozen `sent_at` deltas replace them (10-min tier added; per-line frozen stamps inside each perception remain). `loadDirectChatHistory`'s time cutoff is hour-truncated in SQL, and `stabilizeHistoryWindow` quantizes the cap-bound head to a 15-minute absolute grid (min-keep floor 25) on the sim path — one prefix-cache miss per band instead of one per turn.
- **stable_context**: new `/chat/send` field (salem-engine-only gate, never persisted, mirror of `ephemeral_context`) appended to the sim action-tick system prompt as a `<Standing>` block — the engine's daily-stable identity content caches there.
- **Impressions move**: on the sim action-tick path the Impressions block leaves the system prompt (a co-location flip was a full-request cache miss) and joins the current-turn attachment ahead of `ephemeral_context` (`buildCurrentTurnContext`). Reflection + companion paths unchanged.
- **Soul length cap**: `SOUL_LENGTH_DIRECTIVE` (~200 words, condense-don't-grow) appended by both soul writers (sim-soul endpoint + nightly dream path).

## Deploy order
This PR must deploy BEFORE the engine half (salem `llm-501-stable-context`): a new engine sending `stable_context` to an old API would have the identity block silently dropped. Old engine + new API is fully compatible.

## Tests
`node --test` suite 86/86; standalone scripts: tool-use messages 34/34, stabilize-window 12/12, current-turn-context 9/9. code_review round 1 applied (boundary/floor/malformed-timestamp pins, pure-helper extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)