### PR TITLE
LLM-513: return 402 OVER_BUDGET on the wait path so the engine can classify it

### DIFF
--- a/node/api/src/routes/chat.js
+++ b/node/api/src/routes/chat.js
@@ -265,13 +265,14 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
             // The VA reply path failed before sending its [Error] feedback
             // chat message. Surface the error directly so the wait-mode
             // caller can react instead of polling for a sentinel.
-            // One allowlisted typed error passes through: the 429
-            // RATE_LIMITED throw from handleDirectChat (ZBBS-WORK-404), so
-            // the engine can classify a cooldown honestly instead of
-            // booking it as malformed. Allowlisted rather than passing any
-            // thrown statusCode through — an arbitrary internal error
-            // carrying statusCode would otherwise widen this route's
-            // public contract. Everything else stays 502 REPLY_FAILED.
+            // Two allowlisted typed errors pass through: the 429 RATE_LIMITED
+            // throw from handleDirectChat (ZBBS-WORK-404) and the 402
+            // OVER_BUDGET throw (LLM-513), so the engine can classify a cooldown
+            // or a budget cap honestly instead of booking either as malformed.
+            // Allowlisted rather than passing any thrown statusCode through — an
+            // arbitrary internal error carrying statusCode would otherwise widen
+            // this route's public contract. Everything else stays 502
+            // REPLY_FAILED.
             if (replyErr.code === 'RATE_LIMITED' && replyErr.statusCode === 429) {
                 const error = {
                     code: 'RATE_LIMITED',
@@ -281,6 +282,14 @@ router.post('/chat/send', apiRoute('chat', 'send', async (req, res) => {
                     error.resumes_in_seconds = replyErr.resumesInSeconds;
                 }
                 return res.status(429).json({ error });
+            }
+            if (replyErr.code === 'OVER_BUDGET' && replyErr.statusCode === 402) {
+                return res.status(402).json({
+                    error: {
+                        code: 'OVER_BUDGET',
+                        message: replyErr.message || 'Cost budget exceeded',
+                    },
+                });
             }
             return res.status(502).json({
                 error: { code: 'REPLY_FAILED', message: replyErr.message || 'virtual agent reply failed' },

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -2956,7 +2956,19 @@ async function handleDirectChat(virtualAgentName, fromAgent, messageText, messag
             logVA('direct-chat-over-cost-limit', { agent: virtualAgentName, from: fromAgent, reason: costCheck.reason });
             await chatSend(virtualAgentName, [fromAgent], null,
                 `[Error] ${costCheck.reason}`, { sceneId, conversationId, isError: true });
-            return null;
+            // Throw rather than resolve null (LLM-513), mirroring the rate-limit
+            // branch above. Resolving null gave wait=true callers (the salem
+            // engine) a 200 with reply=null, which the engine could only classify
+            // as a malformed response — a budget-exhausted NPC brain masquerading
+            // as garbled model output. The route maps statusCode/code onto the
+            // HTTP reply so the engine sees an honest 402 and raises its live
+            // budget-exhaustion alarm. The breadcrumb chat row above still lands
+            // for history/admin; non-wait dispatch swallows the rejection
+            // (.catch in chat.js), same as the rate-limit throw.
+            throw Object.assign(new Error(costCheck.reason), {
+                statusCode: 402,
+                code: 'OVER_BUDGET',
+            });
         }
 
         // Call provider with retry+backoff and activity spinner.


### PR DESCRIPTION
## LLM-513 — API half (paired with salem PR jeffdafoe/llm-memory-plugin-salem-1692#959)

Makes VA cost-budget exhaustion a machine-recognizable signal on the sim path so the salem engine can classify it and raise a `va_budget_exceeded` umbilical alarm.

### The problem
On a `wait=true` sim call, the over-budget branch sent the requester an `[Error] …` breadcrumb chat and `return null`. Null resolves the wait promise, so `/chat/send` returned `200 {reply:null}` — which the engine could only read as a malformed response. A budget-dark NPC brain looked identical to garbled model output.

### The change (mirrors the rate-limit 429 path exactly)
- `virtual-agent.js`: the direct-chat over-budget branch now **throws** `{code:'OVER_BUDGET', statusCode:402}` instead of resolving null (same shape as the rate-limit throw just above it). The `[Error]` breadcrumb chat still lands for history/admin; the non-wait dispatch swallows the rejection via the existing `pendingReplyPromise.catch(()=>{})`.
- `chat.js`: allowlists `OVER_BUDGET`/402 to an HTTP `402` response, next to the existing `RATE_LIMITED`/429 branch. Narrow allowlist — an arbitrary internal error carrying a `statusCode` still can't widen the route's public contract.

The mail and discussion over-budget paths are unchanged (they aren't the engine).

### Deploy order
Harmless either order: old engine + new API just classifies the 402 as `ErrorMalformed` (today's behavior) until the engine half ships. Best landed together with #959.

### Tests
This repo has no route/supertest harness (only pure-function `node:test` units, e.g. `virtual-agent-rate-limit.test.js`), so there's no isolated unit for a throw + route branch. The behavior is covered end-to-end by the engine's `402 → ErrorBudgetExceeded` test and mirrors the production-proven rate-limit path; I'll live-verify at deploy (set a $0 budget on a throwaway VA and call it). `code_review` agreed this is a follow-up, not a blocker.

— Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)
