### PR TITLE
LLM-515: shared-VA per-actor conversation-day push (Slice 1)

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -34,15 +34,10 @@ COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access met
 
 
 --
--- Name: dream_mode_t; Type: TYPE; Schema: public; Owner: -
+-- dream_mode_t enum removed in MEM-141 (LLM-515): agent_configuration.dream_mode
+-- is now plain TEXT, allowed values enforced app-side (routes/admin.js,
+-- registration.js) — 'none' | 'companion' | 'technical' | 'sim' | 'sim-shared'.
 --
-
-CREATE TYPE public.dream_mode_t AS ENUM (
-    'none',
-    'companion',
-    'technical',
-    'sim'
-);
 
 
 --
@@ -262,9 +257,26 @@ CREATE TABLE public.agent_configuration (
     cost_budget_daily numeric(10,2),
     cost_budget_monthly numeric(10,2),
     actor_id integer NOT NULL,
-    dream_mode public.dream_mode_t DEFAULT 'none'::public.dream_mode_t NOT NULL,
+    dream_mode text DEFAULT 'none'::text NOT NULL,
     last_dream_at timestamp with time zone,
     storage_quota bigint
+);
+
+
+--
+-- Name: sim_shared_actor; Type: TABLE; Schema: public; Owner: -
+-- Added by MEM-142 (LLM-515): the per-actor dream roster for shared-VA villagers
+-- — one row per (pooled agent actors.id, memory-partition slug_prefix). Populated
+-- by the /sim/conversation-day push, consumed by the per-actor dream loop.
+--
+
+CREATE TABLE public.sim_shared_actor (
+    shared_actor_id integer NOT NULL REFERENCES public.actors(id) ON DELETE CASCADE,
+    slug_prefix text NOT NULL,
+    display_name text NOT NULL,
+    last_pushed_day text,
+    last_dream_at timestamp with time zone,
+    PRIMARY KEY (shared_actor_id, slug_prefix)
 );
 
 

--- a/migrations/MEM-141-dream-mode-text_down.sql
+++ b/migrations/MEM-141-dream-mode-text_down.sql
@@ -1,0 +1,51 @@
+-- MEM-141 down — restore the dream_mode_t enum and convert the column back.
+--
+-- Assumes MEM-142 down has already run (it resets any 'sim-shared' rows to
+-- 'none', a value the restored enum lacks). Same view drop/recreate dance as the
+-- up, in reverse, in one transaction.
+
+BEGIN;
+
+DROP VIEW agent_status;
+
+CREATE TYPE dream_mode_t AS ENUM ('none', 'companion', 'technical', 'sim');
+
+ALTER TABLE agent_configuration ALTER COLUMN dream_mode DROP DEFAULT;
+ALTER TABLE agent_configuration
+    ALTER COLUMN dream_mode TYPE dream_mode_t USING dream_mode::dream_mode_t;
+ALTER TABLE agent_configuration ALTER COLUMN dream_mode SET DEFAULT 'none';
+
+CREATE VIEW agent_status AS
+ SELECT ac.id AS actor_id,
+    ac.name AS agent,
+        CASE
+            WHEN agc.virtual = true AND (ac.status::text = ANY (ARRAY['available'::character varying, 'degraded'::character varying, 'error'::character varying]::text[])) THEN ac.status
+            WHEN agc.virtual = true THEN 'available'::character varying
+            WHEN ac.last_seen > (now() - '00:15:00'::interval) THEN 'online'::character varying
+            WHEN ac.last_seen IS NOT NULL THEN 'offline'::character varying
+            ELSE 'unknown'::character varying
+        END AS status,
+    ac.last_seen,
+    ac.passphrase_rotated_at,
+    ac.created_at AS registered_at,
+    ac.expertise,
+    agc.provider,
+    agc.model,
+    agc.virtual,
+    agc.personality,
+    agc.cost_budget_daily,
+    agc.cost_budget_monthly,
+        CASE
+            WHEN ac.active_since IS NOT NULL AND ac.active_since > (now() - '00:30:00'::interval) THEN ac.active_since
+            ELSE NULL::timestamp with time zone
+        END AS active_since,
+    agc.cache_prompts,
+    agc.learning_enabled,
+    agc.max_tokens,
+    agc.temperature,
+    agc.dream_mode,
+    agc.storage_quota
+   FROM actors ac
+     JOIN agent_configuration agc ON agc.actor_id = ac.id;
+
+COMMIT;

--- a/migrations/MEM-141-dream-mode-text_down.sql
+++ b/migrations/MEM-141-dream-mode-text_down.sql
@@ -6,7 +6,7 @@
 
 BEGIN;
 
-DROP VIEW agent_status;
+DROP VIEW IF EXISTS agent_status;
 
 CREATE TYPE dream_mode_t AS ENUM ('none', 'companion', 'technical', 'sim');
 
@@ -47,5 +47,17 @@ CREATE VIEW agent_status AS
     agc.storage_quota
    FROM actors ac
      JOIN agent_configuration agc ON agc.actor_id = ac.id;
+
+-- Restore the grants the recreated view carried (owner stays postgres), guarded
+-- on role existence — the mirror of the up migration.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memory_api') THEN
+        GRANT ALL ON agent_status TO memory_api;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'claude') THEN
+        GRANT INSERT, SELECT, UPDATE, DELETE ON agent_status TO claude;
+    END IF;
+END $$;
 
 COMMIT;

--- a/migrations/MEM-141-dream-mode-text_up.sql
+++ b/migrations/MEM-141-dream-mode-text_up.sql
@@ -1,0 +1,70 @@
+-- MEM-141 — convert agent_configuration.dream_mode from the dream_mode_t enum to
+-- plain TEXT, so the 'sim-shared' mode (LLM-515, Slice 1) is just another string
+-- value with no schema ceremony.
+--
+-- Why drop the enum: ALTER TYPE ... ADD VALUE can't be used in the same
+-- transaction it's added, and an enum value can never be removed without
+-- recreating the whole type. The project already moved off enums for this kind
+-- of field (dream_source is TEXT, MEM-137); dream_mode predated that and isn't
+-- relied on as an enum anywhere, so we convert it to TEXT. Allowed values are
+-- enforced app-side (routes/admin.js, registration.js), not by a DB constraint.
+--
+-- 'sim-shared' marks a pooled shared-VA agent (salem-vendor) whose per-actor day
+-- material is distilled into per-actor notes under each actor's slug-prefix,
+-- WITHOUT the pool ever being dreamed as one collapsed identity: the daily
+-- conversation-day push accepts it (writing under the prefix), while the
+-- per-agent dream loop (dream_mode IN ('companion','technical','sim'))
+-- deliberately excludes it.
+--
+-- The agent_status view SELECTs agc.dream_mode, so PostgreSQL blocks altering the
+-- column's type while the view exists. Drop it, convert the column, then recreate
+-- it verbatim — the view only passes dream_mode through, so the recreated
+-- definition is identical and only the underlying column type changes. The whole
+-- migration runs in one transaction so a mid-way failure can't leave the view
+-- dropped.
+
+BEGIN;
+
+DROP VIEW agent_status;
+
+ALTER TABLE agent_configuration ALTER COLUMN dream_mode DROP DEFAULT;
+ALTER TABLE agent_configuration
+    ALTER COLUMN dream_mode TYPE TEXT USING dream_mode::text;
+ALTER TABLE agent_configuration ALTER COLUMN dream_mode SET DEFAULT 'none';
+
+DROP TYPE dream_mode_t;
+
+CREATE VIEW agent_status AS
+ SELECT ac.id AS actor_id,
+    ac.name AS agent,
+        CASE
+            WHEN agc.virtual = true AND (ac.status::text = ANY (ARRAY['available'::character varying, 'degraded'::character varying, 'error'::character varying]::text[])) THEN ac.status
+            WHEN agc.virtual = true THEN 'available'::character varying
+            WHEN ac.last_seen > (now() - '00:15:00'::interval) THEN 'online'::character varying
+            WHEN ac.last_seen IS NOT NULL THEN 'offline'::character varying
+            ELSE 'unknown'::character varying
+        END AS status,
+    ac.last_seen,
+    ac.passphrase_rotated_at,
+    ac.created_at AS registered_at,
+    ac.expertise,
+    agc.provider,
+    agc.model,
+    agc.virtual,
+    agc.personality,
+    agc.cost_budget_daily,
+    agc.cost_budget_monthly,
+        CASE
+            WHEN ac.active_since IS NOT NULL AND ac.active_since > (now() - '00:30:00'::interval) THEN ac.active_since
+            ELSE NULL::timestamp with time zone
+        END AS active_since,
+    agc.cache_prompts,
+    agc.learning_enabled,
+    agc.max_tokens,
+    agc.temperature,
+    agc.dream_mode,
+    agc.storage_quota
+   FROM actors ac
+     JOIN agent_configuration agc ON agc.actor_id = ac.id;
+
+COMMIT;

--- a/migrations/MEM-141-dream-mode-text_up.sql
+++ b/migrations/MEM-141-dream-mode-text_up.sql
@@ -25,7 +25,7 @@
 
 BEGIN;
 
-DROP VIEW agent_status;
+DROP VIEW IF EXISTS agent_status;
 
 ALTER TABLE agent_configuration ALTER COLUMN dream_mode DROP DEFAULT;
 ALTER TABLE agent_configuration
@@ -66,5 +66,20 @@ CREATE VIEW agent_status AS
     agc.storage_quota
    FROM actors ac
      JOIN agent_configuration agc ON agc.actor_id = ac.id;
+
+-- Recreating the view reset its grants to the executor (postgres, still the
+-- owner). Restore the grants the original view carried. The app user (memory_api)
+-- is also re-granted by the deploy's post-migration grant step; restoring it here
+-- keeps the migration self-contained. Guarded on role existence so a fresh DB
+-- lacking a role can't fail the migration.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memory_api') THEN
+        GRANT ALL ON agent_status TO memory_api;
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'claude') THEN
+        GRANT INSERT, SELECT, UPDATE, DELETE ON agent_status TO claude;
+    END IF;
+END $$;
 
 COMMIT;

--- a/migrations/MEM-142-sim-shared-actor-roster_down.sql
+++ b/migrations/MEM-142-sim-shared-actor-roster_down.sql
@@ -1,0 +1,12 @@
+-- MEM-142 down — un-enroll salem-vendor and drop the roster. Run this before
+-- MEM-141 down (it clears the 'sim-shared' value the restored enum can't hold).
+
+BEGIN;
+
+UPDATE agent_configuration
+   SET dream_mode = 'none'
+ WHERE actor_id IN (SELECT id FROM actors WHERE name = 'salem-vendor');
+
+DROP TABLE IF EXISTS sim_shared_actor;
+
+COMMIT;

--- a/migrations/MEM-142-sim-shared-actor-roster_up.sql
+++ b/migrations/MEM-142-sim-shared-actor-roster_up.sql
@@ -1,0 +1,41 @@
+-- MEM-142 — per-actor dream roster for shared-VA NPCs; enroll salem-vendor as
+-- 'sim-shared' (LLM-515, Slice 1).
+--
+-- A shared-VA NPC is a slug-prefix (e.g. 'constance-scott/') inside a pooled
+-- agent's note namespace, not its own actors row — so it can't be modeled as an
+-- agent_configuration row. This roster is the lightweight per-actor dream record
+-- instead: one row per (pooled agent, actor slug-prefix), populated by the daily
+-- conversation-day push (sim-conversation-distiller.js) and consumed by the
+-- per-actor dream loop (Slice 2, dream.js).
+--
+--   shared_actor_id — the POOLED agent's actors.id (salem-vendor's), FK.
+--   slug_prefix     — the villager's memory partition prefix, e.g.
+--                     'constance-scott/'. Together with shared_actor_id it keys
+--                     the row.
+--   display_name    — the villager's display name, for the distilled note's line
+--                     labels and (Slice 2) the dream material.
+--   last_pushed_day — YYYY-MM-DD of the most recent conversation-day the push
+--                     landed for this actor; upserted by the push.
+--   last_dream_at   — when Slice 2's dream loop last consolidated this actor
+--                     (NULL until then).
+
+BEGIN;
+
+CREATE TABLE sim_shared_actor (
+    shared_actor_id INTEGER     NOT NULL REFERENCES actors(id) ON DELETE CASCADE,
+    slug_prefix     TEXT        NOT NULL,
+    display_name    TEXT        NOT NULL,
+    last_pushed_day TEXT,
+    last_dream_at   TIMESTAMPTZ,
+    PRIMARY KEY (shared_actor_id, slug_prefix)
+);
+
+-- Enroll the pooled vendor agent. salem-visitor stays 'none' for now — its NPCs
+-- are transient one-off merchants (LLM-455), so persistent per-actor memory would
+-- accrue dead notes with no prune path. salem-generic stays 'none' (throwaway
+-- generics). Both can be enrolled later by setting dream_mode = 'sim-shared'.
+UPDATE agent_configuration
+   SET dream_mode = 'sim-shared'
+ WHERE actor_id IN (SELECT id FROM actors WHERE name = 'salem-vendor');
+
+COMMIT;

--- a/node/api/src/routes/admin.js
+++ b/node/api/src/routes/admin.js
@@ -1637,7 +1637,7 @@ router.post('/admin/actors/create', requirePerm('agents', 'write'), adminRoute('
              max_tokens != null ? safeInt(max_tokens) : null,
              temperature != null ? parseFloat(temperature) : null,
              configuration ? JSON.stringify(sanitizeAgentConfiguration(configuration)) : null,
-             ['none', 'companion', 'technical', 'sim'].includes(dream_mode) ? dream_mode : 'none',
+             ['none', 'companion', 'technical', 'sim', 'sim-shared'].includes(dream_mode) ? dream_mode : 'none',
              ['conversation', 'notes'].includes(dream_source) ? dream_source : 'conversation']
         );
 
@@ -1915,9 +1915,9 @@ router.post('/admin/agents/update', requirePerm('agents', 'write'), adminRoute('
         updates.push(`storage_quota = $${idx++}`);
     }
     if (dream_mode !== undefined) {
-        if (!['none', 'companion', 'technical', 'sim'].includes(dream_mode)) {
+        if (!['none', 'companion', 'technical', 'sim', 'sim-shared'].includes(dream_mode)) {
             return res.status(400).json({
-                error: { code: 'BAD_REQUEST', message: 'dream_mode must be none, companion, technical, or sim' }
+                error: { code: 'BAD_REQUEST', message: 'dream_mode must be none, companion, technical, sim, or sim-shared' }
             });
         }
         params.push(dream_mode);

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -455,8 +455,13 @@ router.post('/agent/instructions/read', apiRoute('agent', 'instructions-read', a
 
     let instructions = result.rows[0]?.startup_instructions || null;
 
-    // Append dream bootstrap if agent has dreaming enabled
-    if (result.rows[0]?.dream_mode && result.rows[0].dream_mode !== 'none') {
+    // Append dream bootstrap if agent has dreaming enabled. 'sim-shared' is
+    // excluded: it pools many villagers under one agent whose souls live in the
+    // engine's actor_narrative_state.about_me (LLM-199), not a per-agent
+    // context/soul note, so it takes neither the bootstrap nor the soul append —
+    // same as 'none'.
+    if (result.rows[0]?.dream_mode && result.rows[0].dream_mode !== 'none'
+        && result.rows[0].dream_mode !== 'sim-shared') {
         const dreamBootstrap = config.get('dream_bootstrap') || '';
         if (dreamBootstrap) {
             instructions = (instructions || '') + '\n\n' + dreamBootstrap;

--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -1044,8 +1044,12 @@ const TOOL_HANDLERS = {
             parts.push(agentInstructions);
         }
 
-        // Append dream bootstrap if agent has dreaming enabled
-        if (result.rows[0].dream_mode && result.rows[0].dream_mode !== 'none') {
+        // Append dream bootstrap if agent has dreaming enabled. 'sim-shared' is
+        // excluded (see routes/agent.js): its villagers' souls live in the
+        // engine's about_me, not a per-agent context/soul note, so it takes
+        // neither the bootstrap nor the soul append — same as 'none'.
+        if (result.rows[0].dream_mode && result.rows[0].dream_mode !== 'none'
+            && result.rows[0].dream_mode !== 'sim-shared') {
             const dreamBootstrap = config.get('dream_bootstrap') || '';
             if (dreamBootstrap) {
                 parts.push(dreamBootstrap);

--- a/node/api/src/routes/sim.js
+++ b/node/api/src/routes/sim.js
@@ -76,7 +76,14 @@ engineRouter.post('/conversation-day', apiRoute('sim', 'conversation_day', async
     const day = body.day;
     const events = body.events;
 
-    const result = await distillSimConversationDay(agent, day, events);
+    // Shared-VA ('sim-shared') pushes are per-villager: they carry the actor's
+    // memory-partition slug prefix and display name so the note lands under that
+    // villager's subtree in the pooled namespace. Dedicated 'sim' VAs omit both;
+    // distillSimConversationDay validates the pairing against the agent's mode.
+    const result = await distillSimConversationDay(agent, day, events, {
+        slugPrefix: body.slug_prefix,
+        actorName: body.actor,
+    });
     res.json(result);
 }));
 

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -417,6 +417,13 @@ function normalizeSlugPrefix(raw) {
     if (!/^[a-z0-9]+(-[a-z0-9]+)*\/$/.test(withSlash)) {
         return '';
     }
+    // Bound the length: the prefix becomes part of the saved note slug and the
+    // sim_shared_actor primary key, so an arbitrarily long (if well-formed) value
+    // must not pass. 100 matches the ceiling other sim actor identifiers use
+    // (routes/sim.js raw-turns sim_actor).
+    if (withSlash.length > 100) {
+        return '';
+    }
     return withSlash;
 }
 
@@ -494,7 +501,17 @@ async function distillSimConversationDay(agentName, dayStr, events, opts = {}) {
                 { statusCode: 400 }
             );
         }
+        // sanitizeLabel strips bracket/quote/newline chars and can collapse a
+        // hostile input to empty; it imposes no length bound. Validate the RESULT
+        // (not just the raw input) so an empty or oversized name can't reach the
+        // note title/content or the roster display_name. 100 matches the slug cap.
         actorName = sanitizeLabel(display);
+        if (!actorName || actorName.length > 100) {
+            throw Object.assign(
+                new Error('actor (display name) is empty after sanitizing, or too long, for a sim-shared agent'),
+                { statusCode: 400 }
+            );
+        }
     } else {
         actorName = sanitizeLabel(slugToDisplay(agent.name));
     }
@@ -563,7 +580,12 @@ async function distillSimConversationDay(agentName, dayStr, events, opts = {}) {
         // Nothing happened (or nothing narratable was pushed — a day of
         // pure look_around/done collapses to zero lines). Skip writing
         // rather than producing an empty note; the dream cron will
-        // simply not see this day for this agent.
+        // simply not see this day for this agent. For a shared-VA push this
+        // ALSO skips the sim_shared_actor enrollment below (which sits after this
+        // return) — by design: the roster means "villagers with dreamable
+        // material", so an actor with only empty days stays out of it until a day
+        // lands a note (Slice 2 has nothing to consolidate for it anyway). Its
+        // first non-empty day enrolls it.
         logSim('skip-empty', { agent: agentName, day: dayStr });
         return { skipped: true, reason: 'no narratable events' };
     }

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -397,9 +397,34 @@ function narrateEvent(event, actorName) {
     }
 }
 
-// Resolve the agent name to (actor_id, name, dream_mode). The
-// distiller is sim-only — return null if dream_mode != 'sim' so the
-// caller can reject without producing an empty note.
+// normalizeSlugPrefix validates and canonicalizes a shared-VA actor's memory
+// partition prefix (e.g. 'constance-scott/') before it's spliced into the note
+// slug. The engine derives it from the villager's display name (Slugify + '/'),
+// so a legitimate value is one-or-more lowercase-kebab segments with a single
+// trailing slash. Returning '' for anything else lets the caller reject with a
+// 400 — this is the defense against a bad/hostile prefix injecting path
+// traversal ('../') into the saved note's slug. Exported for unit tests.
+function normalizeSlugPrefix(raw) {
+    if (typeof raw !== 'string') {
+        return '';
+    }
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+        return '';
+    }
+    // Collapse trailing slashes to exactly one, then require a safe kebab path.
+    const withSlash = trimmed.replace(/\/+$/, '') + '/';
+    if (!/^[a-z0-9]+(-[a-z0-9]+)*\/$/.test(withSlash)) {
+        return '';
+    }
+    return withSlash;
+}
+
+// Resolve the agent name to (actor_id, name, dream_mode). The distiller is
+// sim-only — return { _wrongMode } if dream_mode is neither 'sim' (a dedicated VA,
+// one NPC per namespace) nor 'sim-shared' (a pooled VA whose villagers get
+// per-actor notes under a slug prefix), so the caller can reject without
+// producing an empty note.
 async function resolveSimAgent(agentName) {
     const r = await pool.query(
         `SELECT ac.id, ac.name, agc.dream_mode
@@ -412,7 +437,7 @@ async function resolveSimAgent(agentName) {
         return null;
     }
     const row = r.rows[0];
-    if (row.dream_mode !== 'sim') {
+    if (row.dream_mode !== 'sim' && row.dream_mode !== 'sim-shared') {
         return { ...row, _wrongMode: true };
     }
     return row;
@@ -421,7 +446,7 @@ async function resolveSimAgent(agentName) {
 // Main entry — receives an engine push, builds and saves the note.
 // Idempotent: re-running the same (agent, day, events) overwrites the
 // existing note. Returns a small summary for the caller.
-async function distillSimConversationDay(agentName, dayStr, events) {
+async function distillSimConversationDay(agentName, dayStr, events, opts = {}) {
     if (!agentName || typeof agentName !== 'string') {
         throw Object.assign(new Error('agent required'), { statusCode: 400 });
     }
@@ -438,13 +463,43 @@ async function distillSimConversationDay(agentName, dayStr, events) {
     }
     if (agent._wrongMode) {
         throw Object.assign(
-            new Error('agent ' + agentName + ' is not configured for sim dream_mode'),
+            new Error('agent ' + agentName + ' is not configured for a sim dream_mode'),
             { statusCode: 400 }
         );
     }
 
+    // A 'sim-shared' agent pools many villagers, so each push is scoped to ONE of
+    // them: it must carry that villager's memory-partition slug prefix (e.g.
+    // 'constance-scott/') and display name. The note then lands under the actor's
+    // subtree in the pooled namespace (salem-vendor/constance-scott/conversations/…,
+    // the very prefix `recall` searches), and its lines are labeled with the
+    // villager rather than the pooled agent. A dedicated 'sim' VA is one NPC per
+    // namespace, so it carries neither — the note sits at the namespace root and is
+    // labeled from the agent slug.
+    const isShared = agent.dream_mode === 'sim-shared';
+    let slugPrefix = '';
+    let actorName;
+    if (isShared) {
+        slugPrefix = normalizeSlugPrefix(opts.slugPrefix);
+        if (!slugPrefix) {
+            throw Object.assign(
+                new Error('slug_prefix required (safe kebab path) for a sim-shared agent'),
+                { statusCode: 400 }
+            );
+        }
+        const display = typeof opts.actorName === 'string' ? opts.actorName.trim() : '';
+        if (!display) {
+            throw Object.assign(
+                new Error('actor (display name) required for a sim-shared agent'),
+                { statusCode: 400 }
+            );
+        }
+        actorName = sanitizeLabel(display);
+    } else {
+        actorName = sanitizeLabel(slugToDisplay(agent.name));
+    }
+
     const { start, end } = dayWindow(dayStr);
-    const actorName = sanitizeLabel(slugToDisplay(agent.name));
 
     // Build per-event narration lines from the engine push. Skip events
     // that fall outside the day window — the engine should only push
@@ -501,7 +556,7 @@ async function distillSimConversationDay(agentName, dayStr, events) {
     });
     const all = narrationLines;
 
-    const slug = 'conversations/' + dayStr + '-sim-day';
+    const slug = slugPrefix + 'conversations/' + dayStr + '-sim-day';
     const title = 'Sim day — ' + actorName + ' — ' + dayStr;
 
     if (all.length === 0) {
@@ -520,10 +575,27 @@ async function distillSimConversationDay(agentName, dayStr, events) {
     const content = headerLines.concat(all.map((x) => x.line)).join('\n') + '\n';
 
     await saveNote(agentName, title, content, slug, agentName, null, null, { upsert: true });
+
+    if (isShared) {
+        // Register/refresh this villager in the shared-VA dream roster so Slice 2's
+        // per-actor dream loop knows to consolidate salem-vendor/<slug_prefix>.
+        // Keyed on (pooled agent, slug_prefix); the push is the authority for
+        // display_name + last_pushed_day. INSERT-or-update is idempotent, matching
+        // the note's own re-push-overwrites contract.
+        await pool.query(
+            `INSERT INTO sim_shared_actor (shared_actor_id, slug_prefix, display_name, last_pushed_day)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (shared_actor_id, slug_prefix)
+             DO UPDATE SET display_name = EXCLUDED.display_name,
+                           last_pushed_day = EXCLUDED.last_pushed_day`,
+            [agent.id, slugPrefix, actorName, dayStr]
+        );
+    }
+
     logSim('saved', { agent: agentName, day: dayStr, lines: all.length, bytes: content.length });
     return { saved: true, slug, lines: all.length, bytes: content.length };
 }
 
 // narrateEvent is exported for unit tests (sim-conversation-distiller.test.js);
 // distillSimConversationDay is the only production caller.
-module.exports = { distillSimConversationDay, narrateEvent };
+module.exports = { distillSimConversationDay, narrateEvent, normalizeSlugPrefix };

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -251,6 +251,12 @@ test('normalizeSlugPrefix rejects an over-length prefix (slug/PK bound)', () => 
     const over = 'a'.repeat(100) + '/'; // 101 chars → rejected
     assert.equal(normalizeSlugPrefix(under), under);
     assert.equal(normalizeSlugPrefix(over), '');
+    // The bound is on the CANONICAL value, not the raw input: extra trailing
+    // slashes + whitespace push the raw length past 100 but collapse to a
+    // 100-char canonical prefix, which is accepted.
+    assert.equal(normalizeSlugPrefix('a'.repeat(99) + '////   '), 'a'.repeat(99) + '/');
+    // A raw value still over 100 after canonicalization is rejected.
+    assert.equal(normalizeSlugPrefix('a'.repeat(100) + '////'), '');
 });
 
 test('normalizeSlugPrefix rejects traversal and any non-kebab shape', () => {

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { narrateEvent } = require('./sim-conversation-distiller');
+const { narrateEvent, normalizeSlugPrefix } = require('./sim-conversation-distiller');
 
 const ACTOR = 'Ezekiel Crane';
 
@@ -216,4 +216,42 @@ test('pure-perception kinds still render nothing', () => {
     assert.equal(narrateEvent({ kind: 'done', payload: {} }, ACTOR), null);
     assert.equal(narrateEvent({ kind: 'look_around', payload: {} }, ACTOR), null);
     assert.equal(narrateEvent({ kind: 'enter_huddle', payload: {} }, ACTOR), null);
+});
+
+// normalizeSlugPrefix (LLM-515) — the guard that keeps a shared-VA push's slug
+// prefix from injecting anything unsafe into the saved note's slug. The engine
+// derives the prefix from Slugify(displayName) + '/', so a legitimate value is
+// one-or-more lowercase-kebab segments with a single trailing slash.
+test('normalizeSlugPrefix accepts a canonical kebab prefix', () => {
+    assert.equal(normalizeSlugPrefix('constance-scott/'), 'constance-scott/');
+    assert.equal(normalizeSlugPrefix('john-ellis/'), 'john-ellis/');
+    assert.equal(normalizeSlugPrefix('agent-7/'), 'agent-7/');
+});
+
+test('normalizeSlugPrefix canonicalizes a missing or doubled trailing slash', () => {
+    assert.equal(normalizeSlugPrefix('constance-scott'), 'constance-scott/');
+    assert.equal(normalizeSlugPrefix('constance-scott//'), 'constance-scott/');
+    assert.equal(normalizeSlugPrefix('  constance-scott/  '), 'constance-scott/');
+});
+
+test('normalizeSlugPrefix rejects empty / non-string input as ""', () => {
+    assert.equal(normalizeSlugPrefix(''), '');
+    assert.equal(normalizeSlugPrefix('   '), '');
+    assert.equal(normalizeSlugPrefix(null), '');
+    assert.equal(normalizeSlugPrefix(undefined), '');
+    assert.equal(normalizeSlugPrefix(42), '');
+    assert.equal(normalizeSlugPrefix('/'), '');
+});
+
+test('normalizeSlugPrefix rejects traversal and any non-kebab shape', () => {
+    // Path traversal / nested paths — the whole reason the guard exists.
+    assert.equal(normalizeSlugPrefix('../'), '');
+    assert.equal(normalizeSlugPrefix('foo/../bar/'), '');
+    assert.equal(normalizeSlugPrefix('/etc/passwd'), '');
+    assert.equal(normalizeSlugPrefix('a/b/'), '');
+    // Uppercase, dots, underscores, spaces — none are Slugify output.
+    assert.equal(normalizeSlugPrefix('Constance-Scott/'), '');
+    assert.equal(normalizeSlugPrefix('a.b/'), '');
+    assert.equal(normalizeSlugPrefix('a_b/'), '');
+    assert.equal(normalizeSlugPrefix('two words/'), '');
 });

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -243,6 +243,16 @@ test('normalizeSlugPrefix rejects empty / non-string input as ""', () => {
     assert.equal(normalizeSlugPrefix('/'), '');
 });
 
+test('normalizeSlugPrefix rejects an over-length prefix (slug/PK bound)', () => {
+    // A well-formed but very long kebab string must not pass — it becomes part of
+    // the saved note slug and the roster primary key. The cap is 100 chars
+    // including the trailing slash.
+    const under = 'a'.repeat(99) + '/'; // 100 chars → allowed
+    const over = 'a'.repeat(100) + '/'; // 101 chars → rejected
+    assert.equal(normalizeSlugPrefix(under), under);
+    assert.equal(normalizeSlugPrefix(over), '');
+});
+
 test('normalizeSlugPrefix rejects traversal and any non-kebab shape', () => {
     // Path traversal / nested paths — the whole reason the guard exists.
     assert.equal(normalizeSlugPrefix('../'), '');

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -693,7 +693,8 @@ function buildExtractionPrompt(interactionType, contextHint) {
 // virtual_agent_calls (logCall) covers debug visibility with more fidelity
 // for the va_call_log_retention_days window.
 //
-// Also skipped for dream_mode='sim'. Sim NPCs (Salem 1692 villagers) get
+// Also skipped for dream_mode='sim' and 'sim-shared'. Sim NPCs (Salem 1692
+// villagers, whether on a dedicated VA or a pooled shared VA) get
 // a per-call payload that's a JSON-stringified chat-completion request:
 // the full system prompt, every prior tick's perception/tool-call/result
 // concatenated as the user message, and the response. That shape isn't
@@ -710,7 +711,7 @@ async function logTranscript(agentName, systemPrompt, userMessage, response, usa
          WHERE ac.name = $1`,
         [agentName]
     );
-    if (dreamModeRow.rows.length > 0 && ['none', 'sim'].includes(dreamModeRow.rows[0].dream_mode)) {
+    if (dreamModeRow.rows.length > 0 && ['none', 'sim', 'sim-shared'].includes(dreamModeRow.rows[0].dream_mode)) {
         return;
     }
 


### PR DESCRIPTION
## What
Give shared-VA Salem villagers (on the pooled `salem-vendor` agent) their own consolidated, ledger-grounded memory, so recall stops drifting on settled wages/debts and minting phantom coins (LLM-515).

Each villager is a slug-prefix inside the pooled namespace, not its own dreaming agent, so the nightly conversation→dream pipeline never ran for it. This slice lands each villager's day as a per-actor note under its own subtree — `salem-vendor/<slug>/conversations/<day>-sim-day`, the exact prefix `recall` searches. (Slice 2 will run the dream loop per-actor over these notes.)

## How
- **MEM-141**: `dream_mode` enum → plain TEXT (per the MEM-137 convention; avoids `ALTER TYPE ADD VALUE` friction), recreating the `agent_status` view + restoring its grants, in one transaction.
- **MEM-142**: new `sim_shared_actor` roster (keyed by pooled agent + slug_prefix) + enroll `salem-vendor` as `dream_mode='sim-shared'`. (`salem-visitor` deferred — transient NPCs.)
- New `'sim-shared'` mode: the `/sim/conversation-day` distiller accepts it and writes under the villager's slug prefix + registers the roster row; the per-agent dream loop (`IN ('companion','technical','sim')`) ignores it, so the pool is never dreamed as one collapsed identity.
- `'none'`-gated readers (logTranscript skip, agent/mcp instruction bootstrap, admin validation) updated so `salem-vendor`'s behavior is byte-identical except the acceptance.
- `normalizeSlugPrefix` guards the prefix (path-traversal + length).

Pairs with salem engine PR (pusher sends `slug_prefix` + `actor`). Deploy order is safe either way.

## Testing
- Full API suite 103/103 (incl. new `normalizeSlugPrefix` unit tests).
- Migrations dry-run-validated as postgres against the live schema (BEGIN…ROLLBACK) — recreated view ACL byte-identical.
- code_review cleared (two rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)