### PR TITLE
LLM-519: shared-VA per-actor dream loop (LLM-515 Slice 2)

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -661,7 +661,9 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
     if (slugPrefix && !(typeof scope.selfName === 'string' && scope.selfName.trim())) {
         throw new Error('processDreamChunk: shared scope requires a non-empty selfName');
     }
-    const selfName = scope.selfName || agent.name;
+    // Trim the shared self identity so a whitespace-padded display name matches
+    // the canonical speaker name in extractSpeakers and reads cleanly in prompts.
+    const selfName = slugPrefix ? scope.selfName.trim() : (scope.selfName || agent.name);
 
     let logs;
     if (notesMode) {
@@ -1547,11 +1549,15 @@ async function runDream() {
     return { processed: results.length, sharedActorErrorCount, results };
 }
 
-// Compute the ordered scheduler log events for a runDream result: any
-// shared-actor failure is emitted (as a durable system_errors record) BEFORE
-// the completion event, so a consumer watching 'cron-complete' can never observe
-// a clean run ahead of the failure. The completion event carries the status.
-// Pure + exported so the ordering is unit-testable without the cron runtime.
+// Map a runDream result to the scheduler's log events. The completion event
+// carries the run status ('completed-with-errors' when any shared-VA actor
+// failed, else 'ok') — that status field IS the authoritative, self-contained
+// failure signal, so a consumer reading the completion record never needs to
+// race it against a separate event. When there are failures a shared-failures
+// event is also emitted, which the scheduler records in the error_log table for
+// monitoring (best-effort/fire-and-forget, like every other error record — no
+// cross-event persistence ordering is relied upon). Pure + exported so the
+// status mapping is unit-testable without the cron runtime.
 function planCronReport(result) {
     const sharedFailures = result ? (result.sharedActorErrorCount || 0) : 0;
     const events = [];
@@ -1589,10 +1595,13 @@ function startDreamScheduler() {
         logDream('cron-trigger', { schedule });
         try {
             const result = await runDream();
-            // Emit events in planned order (see planCronReport): the durable
-            // failure record lands in system_errors BEFORE the completion event,
-            // so a shared-actor failure is never observable as a clean run.
-            // runDream still resolves (one bad villager never blocks the others).
+            // Emit the mapped events (see planCronReport): a completion event
+            // whose `status` field self-describes the run — so a shared-actor
+            // failure is never a clean-looking completion — plus, on failure, an
+            // error_log record for monitoring. No cross-event persistence
+            // ordering is assumed; the status lives in the completion record
+            // itself. runDream still resolves (one bad villager never blocks the
+            // others).
             for (const ev of planCronReport(result)) {
                 if (ev.kind === 'shared-failures') {
                     logError('dream', 'cron-shared-actor-failures', {

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -25,17 +25,40 @@ function validatePersonSlug(slug) {
     return canonical;
 }
 
-// Build the context/people note slug for a person under an optional scope
-// prefix: '' for a dedicated agent (namespace root) or a "<villager>/" prefix
-// for a shared-VA villager. This is a PURE builder that assumes an
-// already-validated prefix — validation is the caller's job and happens at the
-// real boundary (runPersonContextUpdate and processDreamChunk both canonicalize
-// the prefix before any path is built). Exported only so the path invariant
-// (empty → context/people/<slug>; shared → <villager>/context/people/<slug>) is
-// unit-testable without a document store; do not use it as a place to accept
-// unvalidated input.
+// The single validated boundary for a dream scope's slug prefix. Returns '' for
+// an ABSENT prefix (undefined/null/'' → dedicated agent, namespace root) or the
+// canonical "<villager>/" prefix for a shared-VA villager. THROWS on a
+// present-but-invalid prefix — a non-string (number/object/array), or a
+// non-canonical string (LIKE metacharacters, path traversal, wrong case,
+// over-length). Distinguishing "absent" from "present but invalid" matters: a
+// malformed shared prefix silently coerced to '' would collapse the villager's
+// notes into the unscoped namespace and cause cross-villager reads/writes.
+// Every path and LIKE pattern in the shared path flows from this. Pure +
+// exported so every branch is unit-testable.
+function resolveScopePrefix(raw) {
+    if (raw === undefined || raw === null) {
+        return '';
+    }
+    if (typeof raw !== 'string') {
+        throw new Error('invalid slug prefix: not a string');
+    }
+    if (raw === '') {
+        return '';
+    }
+    const canonical = normalizeSlugPrefix(raw);
+    if (!canonical) {
+        throw new Error('invalid slug prefix: ' + raw);
+    }
+    return canonical;
+}
+
+// Build the context/people note slug for a person under a scope prefix. Safe to
+// call with any input: the prefix runs through resolveScopePrefix (absent →
+// namespace root; present-but-invalid → throws), so this can never construct an
+// unsafe/traversing path from an untrusted prefix. Exported for direct unit
+// testing of the path invariant.
 function peopleNotePath(slugPrefix, personSlug) {
-    return (slugPrefix || '') + 'context/people/' + personSlug;
+    return resolveScopePrefix(slugPrefix) + 'context/people/' + personSlug;
 }
 
 // Signal patterns that indicate memory-worthy content.
@@ -493,23 +516,13 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
     opts = opts || {};
     const dryRun = !!opts.dryRun;
 
-    // Slug prefix scopes the relationship file under a shared-VA villager's
-    // subtree (e.g. "constance-scott/context/people/josiah-thorne"). Empty for
-    // a dedicated agent, so the path is byte-identical to the pre-Slice-2 form.
-    // A non-empty prefix must canonicalize cleanly through the same validator
-    // the distiller uses (lowercase kebab + one trailing slash, ≤100 chars) —
-    // this helper is exported, so we don't trust the caller to have validated
-    // a DB/operator-sourced prefix; an unchecked '%'/'_' would act as a LIKE
-    // wildcard downstream and '../' would escape the subtree. Reject rather
-    // than silently build a bad path.
-    const rawSlugPrefix = typeof opts.slugPrefix === 'string' ? opts.slugPrefix : '';
-    let slugPrefix = '';
-    if (rawSlugPrefix !== '') {
-        slugPrefix = normalizeSlugPrefix(rawSlugPrefix);
-        if (!slugPrefix) {
-            throw new Error('runPersonContextUpdate: invalid slug prefix: ' + rawSlugPrefix);
-        }
-    }
+    // The relationship note is scoped under a shared-VA villager's subtree via
+    // opts.slugPrefix ("<villager>/context/people/..."), or namespace root for a
+    // dedicated agent. The prefix is validated where the path is built, in
+    // peopleNotePath below (absent → root; present-but-invalid → throws), so
+    // there's no separate guard here. selfLabel is who the relationship is formed
+    // FOR in the people-VA prompt — the villager for a shared actor, not the
+    // pooled agent (salem-vendor).
     const selfLabel = opts.selfLabel || agentName;
 
     // Defend the path input now that this helper is exported. Reject
@@ -521,7 +534,7 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
         throw new Error('runPersonContextUpdate: invalid person slug: ' + slug);
     }
     slug = safeSlug;
-    const peopleSlug = peopleNotePath(slugPrefix, slug);
+    const peopleSlug = peopleNotePath(opts.slugPrefix, slug);
 
     // Sanitize display name before it's interpolated into the user
     // message. Note titles are operator-editable in admin UI, so a
@@ -620,17 +633,14 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
     // byte-identical.
     //
     // This function is the shared path's real security boundary: it builds every
-    // note slug and the conversation-source LIKE pattern from the prefix. Rather
-    // than trust the caller (the scope is an arbitrary internal object), a
-    // non-empty prefix is re-validated/canonicalized here through the same
-    // distiller normalizer — no LIKE metacharacters, no path traversal — and a
-    // non-empty-but-invalid prefix throws. '' (dedicated) passes through.
+    // note slug and the conversation-source LIKE pattern from the prefix. It does
+    // not trust the caller (scope is an arbitrary internal object) — the prefix
+    // runs through resolveScopePrefix, which returns '' for an absent prefix and
+    // throws on any present-but-invalid one (non-string, or non-canonical with
+    // LIKE metacharacters / traversal). A malformed prefix can never silently
+    // become the unscoped namespace.
     scope = scope || {};
-    const rawPrefix = typeof scope.slugPrefix === 'string' ? scope.slugPrefix : '';
-    const slugPrefix = rawPrefix ? normalizeSlugPrefix(rawPrefix) : '';
-    if (rawPrefix && !slugPrefix) {
-        throw new Error('processDreamChunk: invalid shared dream slug prefix: ' + rawPrefix);
-    }
+    const slugPrefix = resolveScopePrefix(scope.slugPrefix);
     const selfName = scope.selfName || agent.name;
 
     let logs;
@@ -1071,11 +1081,15 @@ async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor) {
 // LIKE metacharacters, path traversal, wrong case, over-length. Pure and
 // exported so the roster-boundary decision is unit-testable.
 function validateRosterPrefix(rowPrefix) {
-    if (typeof rowPrefix !== 'string') {
+    // Delegate to the throwing boundary and convert to the roster loop's
+    // skip-this-row contract: null for anything invalid (non-string,
+    // non-canonical, LIKE metacharacters, traversal) OR absent (''), since a
+    // roster row must carry a real villager prefix.
+    try {
+        return resolveScopePrefix(rowPrefix) || null;
+    } catch (e) {
         return null;
     }
-    const canonical = normalizeSlugPrefix(rowPrefix);
-    return canonical || null;
 }
 
 // Count shared-VA actors that saw any failure this run — an actor-level error
@@ -1489,6 +1503,21 @@ async function runDream() {
     return { processed: results.length, sharedActorErrorCount, results };
 }
 
+// Compute the ordered scheduler log events for a runDream result: any
+// shared-actor failure is emitted (as a durable system_errors record) BEFORE
+// the completion event, so a consumer watching 'cron-complete' can never observe
+// a clean run ahead of the failure. The completion event carries the status.
+// Pure + exported so the ordering is unit-testable without the cron runtime.
+function planCronReport(result) {
+    const sharedFailures = result ? (result.sharedActorErrorCount || 0) : 0;
+    const events = [];
+    if (sharedFailures > 0) {
+        events.push({ kind: 'shared-failures', count: sharedFailures });
+    }
+    events.push({ kind: 'complete', status: sharedFailures > 0 ? 'completed-with-errors' : 'ok' });
+    return events;
+}
+
 // Start the dream scheduler. Reads dream_cron_schedule from config
 // and schedules runDream() accordingly. Called once at server startup.
 let scheduledTask = null;
@@ -1516,19 +1545,17 @@ function startDreamScheduler() {
         logDream('cron-trigger', { schedule });
         try {
             const result = await runDream();
-            const sharedFailures = result ? (result.sharedActorErrorCount || 0) : 0;
-            // Record the failure signal BEFORE the completion event so a
-            // consumer watching 'cron-complete' can't observe a clean run ahead
-            // of the durable error, and stamp the status onto the completion
-            // event itself. runDream still resolves (one bad villager never
-            // blocks the others), but this run is not a silent success.
-            if (sharedFailures > 0) {
-                logError('dream', 'cron-shared-actor-failures', { count: sharedFailures });
+            // Emit events in planned order (see planCronReport): the durable
+            // failure record lands in system_errors BEFORE the completion event,
+            // so a shared-actor failure is never observable as a clean run.
+            // runDream still resolves (one bad villager never blocks the others).
+            for (const ev of planCronReport(result)) {
+                if (ev.kind === 'shared-failures') {
+                    logError('dream', 'cron-shared-actor-failures', { count: ev.count });
+                } else {
+                    logDream('cron-complete', { result, status: ev.status });
+                }
             }
-            logDream('cron-complete', {
-                result,
-                status: sharedFailures > 0 ? 'completed-with-errors' : 'ok',
-            });
         } catch (err) {
             logDream('cron-error', { error: err.message });
             logError('dream', 'cron-error', { message: err.message, detail: err.stack });
@@ -1538,4 +1565,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countActorErrors, peopleNotePath, validateRosterPrefix };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countActorErrors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -36,17 +36,23 @@ function validatePersonSlug(slug) {
 // Every path and LIKE pattern in the shared path flows from this. Pure +
 // exported so every branch is unit-testable.
 function resolveScopePrefix(raw) {
-    if (raw === undefined || raw === null) {
+    if (raw === undefined || raw === null || raw === '') {
         return '';
     }
     if (typeof raw !== 'string') {
         throw new Error('invalid slug prefix: not a string');
     }
-    if (raw === '') {
-        return '';
-    }
+    // Require the input to be ALREADY canonical: normalize, then demand the
+    // result equals the input. normalizeSlugPrefix canonicalizes (adds a missing
+    // trailing slash, collapses doubled slashes, trims whitespace), so a bare
+    // !canonical check would silently accept non-canonical forms — and two
+    // distinct roster values ('constance-scott' and 'constance-scott/') would
+    // collapse to one namespace. The write path (the distiller) canonicalizes on
+    // store; this read boundary rejects anything that isn't already in canonical
+    // form (missing/doubled slash, surrounding whitespace, uppercase, LIKE
+    // metacharacters, traversal, over-length).
     const canonical = normalizeSlugPrefix(raw);
-    if (!canonical) {
+    if (!canonical || canonical !== raw) {
         throw new Error('invalid slug prefix: ' + raw);
     }
     return canonical;

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -26,10 +26,14 @@ function validatePersonSlug(slug) {
 }
 
 // Build the context/people note slug for a person under an optional scope
-// prefix: '' for a dedicated agent (namespace root) or a validated
-// "<villager>/" prefix for a shared-VA villager. Kept pure and exported so the
-// path invariant (empty prefix → context/people/<slug>; shared prefix →
-// <villager>/context/people/<slug>) is unit-testable without a document store.
+// prefix: '' for a dedicated agent (namespace root) or a "<villager>/" prefix
+// for a shared-VA villager. This is a PURE builder that assumes an
+// already-validated prefix — validation is the caller's job and happens at the
+// real boundary (runPersonContextUpdate and processDreamChunk both canonicalize
+// the prefix before any path is built). Exported only so the path invariant
+// (empty → context/people/<slug>; shared → <villager>/context/people/<slug>) is
+// unit-testable without a document store; do not use it as a place to accept
+// unvalidated input.
 function peopleNotePath(slugPrefix, personSlug) {
     return (slugPrefix || '') + 'context/people/' + personSlug;
 }
@@ -613,12 +617,20 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
     // identity whose own speech is skipped in extractSpeakers and whose name
     // labels the dream/people/learnings prompts — the villager for a shared
     // actor, else the agent itself. Defaulted so dedicated callers are
-    // byte-identical. The slug prefix comes from sim_shared_actor, written by
-    // the distiller's normalizeSlugPrefix (lowercase kebab + one trailing
-    // slash), so it carries no LIKE metacharacters and is safe to interpolate
-    // into the conversation-source LIKE pattern.
+    // byte-identical.
+    //
+    // This function is the shared path's real security boundary: it builds every
+    // note slug and the conversation-source LIKE pattern from the prefix. Rather
+    // than trust the caller (the scope is an arbitrary internal object), a
+    // non-empty prefix is re-validated/canonicalized here through the same
+    // distiller normalizer — no LIKE metacharacters, no path traversal — and a
+    // non-empty-but-invalid prefix throws. '' (dedicated) passes through.
     scope = scope || {};
-    const slugPrefix = typeof scope.slugPrefix === 'string' ? scope.slugPrefix : '';
+    const rawPrefix = typeof scope.slugPrefix === 'string' ? scope.slugPrefix : '';
+    const slugPrefix = rawPrefix ? normalizeSlugPrefix(rawPrefix) : '';
+    if (rawPrefix && !slugPrefix) {
+        throw new Error('processDreamChunk: invalid shared dream slug prefix: ' + rawPrefix);
+    }
     const selfName = scope.selfName || agent.name;
 
     let logs;
@@ -1119,6 +1131,54 @@ async function processSharedAgent(agent, simAgents, results) {
         learningsAgentName: simLearningsAgentName,
     };
 
+    // Accumulate villager results by reference so an unexpected roster/setup
+    // failure still preserves the villagers already processed in the single
+    // aggregate result below.
+    const actorResults = [];
+    let setupError = null;
+    let rosterSize = 0;
+    try {
+        rosterSize = await dreamSharedRoster(agent, agentNames, actorResults);
+    } catch (err) {
+        // A roster-query or other setup failure — record it and fall through so
+        // any partial actorResults are still reported, not discarded.
+        logDream('shared-agent-error', { agent: agent.name, error: err.message });
+        logError('dream', 'shared-agent-error', { agent: agent.name, message: err.message, detail: err.stack });
+        setupError = err.message;
+    }
+
+    if (rosterSize === 0 && actorResults.length === 0 && !setupError) {
+        // Empty roster — nothing enrolled yet (a legit, non-error state).
+        logDream('shared-no-roster', { agent: agent.name });
+        results.push({ agent: agent.name, mode: 'sim-shared', actorCount: 0 });
+        return;
+    }
+
+    // errorCount gives the cron summary a numeric failure signal for this pooled
+    // agent — actor-level errors, failed chunks nested in an actor's result, and
+    // a setup failure. Per-villager failures are also written to system_errors
+    // via logError, matching the dedicated per-agent contract: one bad villager
+    // never fails the whole run.
+    const errorCount = countActorErrors(actorResults) + (setupError ? 1 : 0);
+    const summary = {
+        agent: agent.name,
+        mode: 'sim-shared',
+        actorCount: actorResults.length,
+        errorCount,
+        actors: actorResults,
+    };
+    if (setupError) {
+        summary.error = setupError;
+    }
+    results.push(summary);
+}
+
+// Query the villager roster for one pooled shared-VA agent and dream each
+// villager, appending one result per villager to actorResults (populated by
+// reference). Separated from processSharedAgent so a roster/setup failure here
+// is caught by the caller — which still emits one aggregate result preserving
+// whatever villagers were already processed. Returns the roster size.
+async function dreamSharedRoster(agent, agentNames, actorResults) {
     const roster = await pool.query(
         `SELECT slug_prefix, display_name, last_dream_at
          FROM sim_shared_actor
@@ -1127,13 +1187,10 @@ async function processSharedAgent(agent, simAgents, results) {
         [agent.actor_id]
     );
     if (roster.rows.length === 0) {
-        logDream('shared-no-roster', { agent: agent.name });
-        results.push({ agent: agent.name, mode: 'sim-shared', actorCount: 0 });
-        return;
+        return 0;
     }
 
     const interActorDelay = parseInt(config.get('dream_interagent_delay')) || 2000;
-    const actorResults = [];
 
     for (let i = 0; i < roster.rows.length; i++) {
         const actorRow = roster.rows[i];
@@ -1234,19 +1291,7 @@ async function processSharedAgent(agent, simAgents, results) {
         }
     }
 
-    // errorCount gives the cron summary a numeric failure signal for this
-    // pooled agent — counting both actor-level errors and failed chunks nested
-    // in an actor's result (per-villager failures are also written to
-    // system_errors via logError, matching the dedicated per-agent contract —
-    // one bad villager never fails the whole run).
-    const errorCount = countActorErrors(actorResults);
-    results.push({
-        agent: agent.name,
-        mode: 'sim-shared',
-        actorCount: roster.rows.length,
-        errorCount,
-        actors: actorResults,
-    });
+    return roster.rows.length;
 }
 
 // Run the dream processing job.

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -1119,7 +1119,7 @@ function validateRosterPrefix(rowPrefix) {
 // otherwise-formed actor result. A skipped chunk (no logs / no signals) is not
 // a failure and is not counted. Exported so the cron's failure signal is
 // unit-testable without standing up the whole pipeline.
-function countActorErrors(actorResults) {
+function countFailedActors(actorResults) {
     return actorResults.filter(r =>
         r.error || (Array.isArray(r.chunks) && r.chunks.some(c => c.error))
     ).length;
@@ -1138,7 +1138,7 @@ function countActorErrors(actorResults) {
 async function processSharedAgent(agent, simAgents, results) {
     const { simAgentName, simPeopleAgentName, simLearningsAgentName } = simAgents;
     if (!simAgentName) {
-        results.push({ agent: agent.name, mode: 'sim-shared', errorCount: 1, error: 'dream-sim agent not available' });
+        results.push({ agent: agent.name, mode: 'sim-shared', failedActorCount: 1, error: 'dream-sim agent not available' });
         return;
     }
 
@@ -1157,7 +1157,7 @@ async function processSharedAgent(agent, simAgents, results) {
         results.push({
             agent: agent.name,
             mode: 'sim-shared',
-            errorCount: 1,
+            failedActorCount: 1,
             error: 'dream_source must be conversation for sim-shared (got ' + dreamSource + ')',
         });
         return;
@@ -1193,17 +1193,18 @@ async function processSharedAgent(agent, simAgents, results) {
         return;
     }
 
-    // errorCount gives the cron summary a numeric failure signal for this pooled
-    // agent — actor-level errors, failed chunks nested in an actor's result, and
-    // a setup failure. Per-villager failures are also written to system_errors
-    // via logError, matching the dedicated per-agent contract: one bad villager
-    // never fails the whole run.
-    const errorCount = countActorErrors(actorResults) + (setupError ? 1 : 0);
+    // failedActorCount = how many villagers this pooled agent saw fail — an
+    // actor-level error OR any failed chunk counts the villager once (actor
+    // granularity; per-villager plannedChunks/completedChunks carry the finer
+    // detail), plus 1 for a setup failure. Per-villager failures are also
+    // written to the error_log via logError, matching the dedicated per-agent
+    // contract: one bad villager never fails the whole run.
+    const failedActorCount = countFailedActors(actorResults) + (setupError ? 1 : 0);
     const summary = {
         agent: agent.name,
         mode: 'sim-shared',
         actorCount: actorResults.length,
-        errorCount,
+        failedActorCount,
         actors: actorResults,
     };
     if (setupError) {
@@ -1520,11 +1521,11 @@ async function runDream() {
             });
             // A throw out of processSharedAgent (e.g. the roster query failing
             // before any actor result is recorded) must still register as a
-            // shared failure so the run-level sharedActorErrorCount counts it.
+            // shared failure so the run-level failedSharedActorCount counts it.
             const failureResult = { agent: agent.name, error: err.message };
             if (agent.dream_mode === 'sim-shared') {
                 failureResult.mode = 'sim-shared';
-                failureResult.errorCount = 1;
+                failureResult.failedActorCount = 1;
             }
             results.push(failureResult);
         }
@@ -1541,12 +1542,12 @@ async function runDream() {
     // 'complete'. Scoped to sim-shared deliberately: the dedicated per-agent
     // contract (capture errors into results, resolve the run) is unchanged —
     // widening the whole cron's success semantics is a separate ticket.
-    const sharedActorErrorCount = results
+    const failedSharedActorCount = results
         .filter(r => r.mode === 'sim-shared')
-        .reduce((sum, r) => sum + (r.errorCount || 0), 0);
+        .reduce((sum, r) => sum + (r.failedActorCount || 0), 0);
 
-    logDream('complete', { processed: results.length, sharedActorErrorCount });
-    return { processed: results.length, sharedActorErrorCount, results };
+    logDream('complete', { processed: results.length, failedSharedActorCount });
+    return { processed: results.length, failedSharedActorCount, results };
 }
 
 // Map a runDream result to the scheduler's log events. The completion event
@@ -1559,7 +1560,7 @@ async function runDream() {
 // cross-event persistence ordering is relied upon). Pure + exported so the
 // status mapping is unit-testable without the cron runtime.
 function planCronReport(result) {
-    const sharedFailures = result ? (result.sharedActorErrorCount || 0) : 0;
+    const sharedFailures = result ? (result.failedSharedActorCount || 0) : 0;
     const events = [];
     if (sharedFailures > 0) {
         events.push({ kind: 'shared-failures', count: sharedFailures });
@@ -1620,4 +1621,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countActorErrors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -53,12 +53,18 @@ function resolveScopePrefix(raw) {
 }
 
 // Build the context/people note slug for a person under a scope prefix. Safe to
-// call with any input: the prefix runs through resolveScopePrefix (absent →
-// namespace root; present-but-invalid → throws), so this can never construct an
-// unsafe/traversing path from an untrusted prefix. Exported for direct unit
-// testing of the path invariant.
+// call with any input: BOTH components are validated — the prefix through
+// resolveScopePrefix (absent → namespace root; present-but-invalid → throws)
+// and the person slug through validatePersonSlug (must be a canonical
+// lowercase-kebab slug; a '../', space, or non-string throws). Neither path
+// component can traverse or inject. Exported for direct unit testing of the
+// path invariant.
 function peopleNotePath(slugPrefix, personSlug) {
-    return resolveScopePrefix(slugPrefix) + 'context/people/' + personSlug;
+    const safePersonSlug = validatePersonSlug(personSlug);
+    if (!safePersonSlug) {
+        throw new Error('invalid person slug: ' + personSlug);
+    }
+    return resolveScopePrefix(slugPrefix) + 'context/people/' + safePersonSlug;
 }
 
 // Signal patterns that indicate memory-worthy content.

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -10,6 +10,7 @@ const { log, logError } = require('./logger');
 const { saveNote, readNote, listNotes } = require('./documents');
 const { invokeAgent } = require('./virtual-agent');
 const { personContextSlug } = require('./people-slug');
+const { normalizeSlugPrefix } = require('./sim-conversation-distiller');
 
 // validatePersonSlug — defense for runPersonContextUpdate now that it's
 // exported. Pass the input back through the same slugify the dream cron
@@ -22,6 +23,15 @@ function validatePersonSlug(slug) {
     const canonical = personContextSlug(slug);
     if (!canonical || canonical !== slug) return null;
     return canonical;
+}
+
+// Build the context/people note slug for a person under an optional scope
+// prefix: '' for a dedicated agent (namespace root) or a validated
+// "<villager>/" prefix for a shared-VA villager. Kept pure and exported so the
+// path invariant (empty prefix → context/people/<slug>; shared prefix →
+// <villager>/context/people/<slug>) is unit-testable without a document store.
+function peopleNotePath(slugPrefix, personSlug) {
+    return (slugPrefix || '') + 'context/people/' + personSlug;
 }
 
 // Signal patterns that indicate memory-worthy content.
@@ -479,6 +489,25 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
     opts = opts || {};
     const dryRun = !!opts.dryRun;
 
+    // Slug prefix scopes the relationship file under a shared-VA villager's
+    // subtree (e.g. "constance-scott/context/people/josiah-thorne"). Empty for
+    // a dedicated agent, so the path is byte-identical to the pre-Slice-2 form.
+    // A non-empty prefix must canonicalize cleanly through the same validator
+    // the distiller uses (lowercase kebab + one trailing slash, ≤100 chars) —
+    // this helper is exported, so we don't trust the caller to have validated
+    // a DB/operator-sourced prefix; an unchecked '%'/'_' would act as a LIKE
+    // wildcard downstream and '../' would escape the subtree. Reject rather
+    // than silently build a bad path.
+    const rawSlugPrefix = typeof opts.slugPrefix === 'string' ? opts.slugPrefix : '';
+    let slugPrefix = '';
+    if (rawSlugPrefix !== '') {
+        slugPrefix = normalizeSlugPrefix(rawSlugPrefix);
+        if (!slugPrefix) {
+            throw new Error('runPersonContextUpdate: invalid slug prefix: ' + rawSlugPrefix);
+        }
+    }
+    const selfLabel = opts.selfLabel || agentName;
+
     // Defend the path input now that this helper is exported. Reject
     // anything that doesn't slug-roundtrip cleanly (path traversal,
     // whitespace, mixed case, etc.). Same regex that the cron's natural
@@ -488,6 +517,7 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
         throw new Error('runPersonContextUpdate: invalid person slug: ' + slug);
     }
     slug = safeSlug;
+    const peopleSlug = peopleNotePath(slugPrefix, slug);
 
     // Sanitize display name before it's interpolated into the user
     // message. Note titles are operator-editable in admin UI, so a
@@ -499,7 +529,7 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
     // Read the current relationship file (empty string if first encounter).
     let existingFile = '';
     try {
-        const note = await readNote(agentName, 'context/people/' + slug);
+        const note = await readNote(agentName, peopleSlug);
         existingFile = note.content || '';
     } catch (e) {
         // No existing file — first encounter.
@@ -512,7 +542,7 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
         ? excerpts
         : '(no new excerpts since last update — please consolidate any redundant bullets if present, or return file unchanged if already tight)';
 
-    const peopleUserMessage = '## Agent: ' + agentName + '\n'
+    const peopleUserMessage = '## Agent: ' + selfLabel + '\n'
         + '## Person: ' + display + '\n'
         + '## Today\'s date: ' + today + '\n\n'
         + '## Current relationship file\n\n'
@@ -560,7 +590,7 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
             agentName,
             'People — ' + display,
             updatedFile,
-            'context/people/' + slug,
+            peopleSlug,
             peopleAgentName,
             null, null, { upsert: true }
         );
@@ -570,11 +600,26 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
     return { existingFile, updatedFile, written, changed, emptyResponse };
 }
 
-async function processDreamChunk(agent, agentNames, chunk) {
+async function processDreamChunk(agent, agentNames, chunk, scope) {
     const { dreamAgentName, soulAgentName, peopleAgentName, learningsAgentName } = agentNames;
     const { from, to } = chunk;
     const chunkDateStr = from.toISOString().slice(0, 10);
     const notesMode = agent.dream_source === 'notes';
+
+    // Scope selects the slug subtree and the self-identity. slugPrefix is
+    // empty for a dedicated agent (all notes at namespace root) and a
+    // "<villager>/" prefix for a shared-VA villager, so every read and write
+    // below lands under the same subtree recall searches. selfName is the
+    // identity whose own speech is skipped in extractSpeakers and whose name
+    // labels the dream/people/learnings prompts — the villager for a shared
+    // actor, else the agent itself. Defaulted so dedicated callers are
+    // byte-identical. The slug prefix comes from sim_shared_actor, written by
+    // the distiller's normalizeSlugPrefix (lowercase kebab + one trailing
+    // slash), so it carries no LIKE metacharacters and is safe to interpolate
+    // into the conversation-source LIKE pattern.
+    scope = scope || {};
+    const slugPrefix = typeof scope.slugPrefix === 'string' ? scope.slugPrefix : '';
+    const selfName = scope.selfName || agent.name;
 
     let logs;
     if (notesMode) {
@@ -600,10 +645,10 @@ async function processDreamChunk(agent, agentNames, chunk) {
     } else {
         logs = await pool.query(
             `SELECT slug, content, created_at FROM documents
-             WHERE namespace = $1 AND slug LIKE 'conversations/%' AND deleted_at IS NULL
+             WHERE namespace = $1 AND slug LIKE $4 AND deleted_at IS NULL
              AND created_at > $2 AND created_at <= $3
              ORDER BY created_at ASC`,
-            [agent.name, from, to]
+            [agent.name, from, to, slugPrefix + 'conversations/%']
         );
     }
     if (logs.rows.length === 0) {
@@ -644,7 +689,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
     const userMessage = (notesMode
         ? 'Curated notes written or updated by agent "' + agent.name + '" on ' + chunkDateStr
             + ' (this agent\'s memory lives in hand-curated notes — journals, identity documents, session summaries — rather than conversation logs):\n\n'
-        : 'Conversation logs for agent "' + agent.name + '" on ' + chunkDateStr + ':\n\n')
+        : 'Conversation logs for agent "' + selfName + '" on ' + chunkDateStr + ':\n\n')
         + filtered
         + '\n\nAlso provide a brief title summarizing the overarching subject of the day.';
 
@@ -662,14 +707,19 @@ async function processDreamChunk(agent, agentNames, chunk) {
 
     // Slug uses the chunk's date so catching up multiple days produces
     // distinct dated notes (rather than overwriting the same NOW-dated slug).
-    const slug = 'dreams/' + chunkDateStr + '-' + slugify(title);
+    const slug = slugPrefix + 'dreams/' + chunkDateStr + '-' + slugify(title);
     await saveNote(agent.name, title + ' (' + chunkDateStr + ')', content, slug, dreamAgentName);
     logDream('chunk-saved', { agent: agent.name, slug, contentLength: content.length });
 
     // Soul synthesis — runs after each chunk per Jeff's call. The current
     // soul note is the prior chunk's output, so consecutive chunks build
     // on each other naturally rather than needing a single end-of-run pass.
-    if (soulAgentName) {
+    // Skipped under a shared-VA scope: a shared villager's soul lives in the
+    // engine's actor_narrative_state.about_me (LLM-199), not a note, and a
+    // namespace-root context/soul would collide across every pooled villager.
+    // The shared path also passes a null soul agent, so this is defense in
+    // depth for any future caller.
+    if (soulAgentName && !slugPrefix) {
         try {
             let existingSoul = '';
             try {
@@ -843,7 +893,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
     // dreaming deliberately writes only dreams/* and context/soul.
     if (peopleAgentName && !notesMode) {
         try {
-            const speakers = extractSpeakers(filtered, agent.name);
+            const speakers = extractSpeakers(filtered, selfName);
             for (const [slug, entry] of speakers) {
                 const { display, lines: personLines } = entry;
                 if (personLines.length === 0) {
@@ -852,7 +902,8 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 try {
                     const result = await runPersonContextUpdate(
                         agent.name, peopleAgentName, slug, display,
-                        personLines.join('\n'), chunkDateStr
+                        personLines.join('\n'), chunkDateStr,
+                        { slugPrefix, selfLabel: selfName }
                     );
                     if (result.written) {
                         logDream('chunk-people-updated', {
@@ -884,7 +935,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
     // (and learnings/% is an excluded source prefix — writing it would feed
     // the next run's input).
     if (learningsAgentName && !notesMode) {
-        const learningsSlug = 'learnings/' + chunkDateStr + '-sim-day';
+        const learningsSlug = slugPrefix + 'learnings/' + chunkDateStr + '-sim-day';
         try {
             let existingFile = '';
             try {
@@ -894,7 +945,7 @@ async function processDreamChunk(agent, agentNames, chunk) {
                 // No existing learnings file for this day — first pass.
             }
 
-            const learningsUserMessage = '## Agent: ' + agent.name + '\n'
+            const learningsUserMessage = '## Agent: ' + selfName + '\n'
                 + '## Date: ' + chunkDateStr + '\n\n'
                 + (existingFile
                     ? '## Existing learnings for today (refine, integrate; do not duplicate)\n\n' + existingFile + '\n\n'
@@ -958,6 +1009,246 @@ async function processDreamChunk(agent, agentNames, chunk) {
     };
 }
 
+// Run the per-day chunk loop for a single dreaming identity. Shared by the
+// dedicated per-agent path and the shared-VA per-actor path: the only
+// differences are the scope (namespace-root vs a villager slug prefix) and
+// where progress is stamped, both passed in. advanceCursor(chunkTo) persists
+// the cursor after each successful chunk so a later failure doesn't lose
+// earlier work; a failed chunk stops this identity's remaining chunks (so we
+// never skip past unprocessed logs) and the next cron retries it. Returns the
+// per-chunk result array.
+async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor) {
+    const interChunkDelay = parseInt(config.get('dream_interchunk_delay')) || 1000;
+    const chunkResults = [];
+
+    for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        try {
+            const r = await processDreamChunk(agent, agentNames, chunk, scope);
+            chunkResults.push(r);
+            await advanceCursor(chunk.to);
+        } catch (chunkErr) {
+            const chunkDate = chunk.from.toISOString().slice(0, 10);
+            const errDetail = { agent: agent.name, chunkDate, error: chunkErr.message };
+            if (scope.slugPrefix) {
+                errDetail.prefix = scope.slugPrefix;
+            }
+            logDream('chunk-error', errDetail);
+            logError('dream', 'chunk-error', {
+                agent: agent.name,
+                message: chunkErr.message,
+                detail: chunkErr.stack,
+            });
+            chunkResults.push({ chunkDate, error: chunkErr.message });
+            break;
+        }
+        // Inter-chunk pause for the same identity — politeness to the provider
+        // when catching up multiple days back-to-back.
+        if (i + 1 < chunks.length && interChunkDelay > 0) {
+            await new Promise(resolve => setTimeout(resolve, interChunkDelay));
+        }
+    }
+
+    return chunkResults;
+}
+
+// Validate a shared-VA roster row's slug_prefix at the dream boundary. Returns
+// the canonical prefix, or null for anything that must be skipped: a
+// NULL/non-string value (explicit type guard so a bad row can't throw and abort
+// the roster), or a non-canonical value the distiller's normalizer rejects —
+// LIKE metacharacters, path traversal, wrong case, over-length. Pure and
+// exported so the roster-boundary decision is unit-testable.
+function validateRosterPrefix(rowPrefix) {
+    if (typeof rowPrefix !== 'string') {
+        return null;
+    }
+    const canonical = normalizeSlugPrefix(rowPrefix);
+    return canonical || null;
+}
+
+// Count shared-VA actors that saw any failure this run — an actor-level error
+// (invalid prefix, per-actor exception) OR a failed chunk nested inside an
+// otherwise-formed actor result. A skipped chunk (no logs / no signals) is not
+// a failure and is not counted. Exported so the cron's failure signal is
+// unit-testable without standing up the whole pipeline.
+function countActorErrors(actorResults) {
+    return actorResults.filter(r =>
+        r.error || (Array.isArray(r.chunks) && r.chunks.some(c => c.error))
+    ).length;
+}
+
+// Dream every shared-VA villager enrolled under one pooled agent
+// (dream_mode='sim-shared', e.g. salem-vendor). Each villager is a slug
+// prefix in the pooled namespace — it has no actors row of its own — so it
+// gets a dedicated-VA-equivalent dream/learnings/people pass scoped under its
+// prefix, cursored on its own sim_shared_actor.last_dream_at. Soul is
+// deliberately omitted (null soul agent + the slug-prefix guard in
+// processDreamChunk): a shared villager's soul is the engine's
+// actor_narrative_state.about_me (LLM-199), not a note. The roster only holds
+// villagers that have landed at least one non-empty day (the distiller
+// enrolls on first material), so no empty-namespace villager reaches here.
+async function processSharedAgent(agent, simAgents, results) {
+    const { simAgentName, simPeopleAgentName, simLearningsAgentName } = simAgents;
+    if (!simAgentName) {
+        results.push({ agent: agent.name, mode: 'sim-shared', errorCount: 1, error: 'dream-sim agent not available' });
+        return;
+    }
+
+    // sim-shared is conversation-sourced only. processDreamChunk's notes-mode
+    // source query is NOT slug-scoped, so a misconfigured dream_source would
+    // read the pooled agent's cross-villager curated notes and write them into
+    // one villager's subtree — a cross-villager leak. Reject the whole agent
+    // rather than process it under the wrong source.
+    const dreamSource = agent.dream_source || 'conversation';
+    if (dreamSource !== 'conversation') {
+        logDream('shared-unsupported-source', { agent: agent.name, source: dreamSource });
+        logError('dream', 'shared-unsupported-source', { agent: agent.name, source: dreamSource });
+        results.push({
+            agent: agent.name,
+            mode: 'sim-shared',
+            errorCount: 1,
+            error: 'dream_source must be conversation for sim-shared (got ' + dreamSource + ')',
+        });
+        return;
+    }
+
+    const agentNames = {
+        dreamAgentName: simAgentName,
+        soulAgentName: null,
+        peopleAgentName: simPeopleAgentName,
+        learningsAgentName: simLearningsAgentName,
+    };
+
+    const roster = await pool.query(
+        `SELECT slug_prefix, display_name, last_dream_at
+         FROM sim_shared_actor
+         WHERE shared_actor_id = $1
+         ORDER BY slug_prefix ASC`,
+        [agent.actor_id]
+    );
+    if (roster.rows.length === 0) {
+        logDream('shared-no-roster', { agent: agent.name });
+        results.push({ agent: agent.name, mode: 'sim-shared', actorCount: 0 });
+        return;
+    }
+
+    const interActorDelay = parseInt(config.get('dream_interagent_delay')) || 2000;
+    const actorResults = [];
+
+    for (let i = 0; i < roster.rows.length; i++) {
+        const actorRow = roster.rows[i];
+        const rowPrefix = actorRow.slug_prefix;
+        // Declared before the try so the catch below can still reference it.
+        let slugPrefix = '';
+        try {
+            // Validate the roster prefix at this boundary — DB/operator-
+            // controlled state, not trusted just because the distiller normally
+            // writes it canonically. Kept inside the per-actor try so one bad row
+            // (including a NULL/non-string slug_prefix) skips only THIS villager,
+            // never aborting the rest of the roster. The canonical form drives
+            // every path built below; the stored value keys the cursor UPDATE so
+            // it targets the exact roster row.
+            const validated = validateRosterPrefix(rowPrefix);
+            if (!validated) {
+                logDream('shared-actor-invalid-prefix', { agent: agent.name, prefix: rowPrefix });
+                logError('dream', 'shared-actor-invalid-prefix', { agent: agent.name, prefix: String(rowPrefix) });
+                actorResults.push({ prefix: rowPrefix, error: 'invalid slug prefix' });
+                continue;
+            }
+            slugPrefix = validated;
+            const scope = { slugPrefix, selfName: actorRow.display_name };
+            // First run for this villager (no cursor yet): start at its
+            // earliest conversation note so a freshly-pushed backlog — an
+            // LLM-515 push-cursor backfill, or a villager enrolled several days
+            // before its first dream — is consolidated rather than skipped.
+            // Steady state, last_dream_at carries the window forward.
+            let since = actorRow.last_dream_at;
+            if (!since) {
+                const earliest = await pool.query(
+                    `SELECT MIN(created_at) AS min_created FROM documents
+                     WHERE namespace = $1 AND slug LIKE $2 AND deleted_at IS NULL`,
+                    [agent.name, slugPrefix + 'conversations/%']
+                );
+                if (!earliest.rows[0] || !earliest.rows[0].min_created) {
+                    logDream('shared-no-conversations', { agent: agent.name, prefix: slugPrefix });
+                    actorResults.push({ prefix: slugPrefix, skipped: true, reason: 'no conversation notes' });
+                    continue;
+                }
+                const minCreated = earliest.rows[0].min_created instanceof Date
+                    ? earliest.rows[0].min_created
+                    : new Date(earliest.rows[0].min_created);
+                // Window is exclusive on `from`; back off 1ms to include the
+                // earliest note itself.
+                since = new Date(minCreated.getTime() - 1);
+            }
+
+            const chunks = computeDailyChunks(since, new Date());
+            if (chunks.length === 0) {
+                logDream('shared-no-window', { agent: agent.name, prefix: slugPrefix, since });
+                actorResults.push({ prefix: slugPrefix, skipped: true, reason: 'last_dream_at is in the future' });
+                continue;
+            }
+
+            logDream('shared-chunks-planned', {
+                agent: agent.name,
+                prefix: slugPrefix,
+                count: chunks.length,
+                from: chunks[0].from.toISOString(),
+                to: chunks[chunks.length - 1].to.toISOString(),
+            });
+
+            const chunkResults = await runChunkLoop(
+                agent, agentNames, chunks, scope,
+                (chunkTo) => pool.query(
+                    `UPDATE sim_shared_actor SET last_dream_at = $1
+                     WHERE shared_actor_id = $2 AND slug_prefix = $3`,
+                    [chunkTo, agent.actor_id, rowPrefix]
+                )
+            );
+            // Report planned vs completed separately — runChunkLoop stops on the
+            // first failed chunk, so chunks.length alone would overstate progress
+            // to cron monitoring. A chunk result carries an `error` field only
+            // when it failed.
+            actorResults.push({
+                prefix: slugPrefix,
+                plannedChunks: chunks.length,
+                completedChunks: chunkResults.filter(r => !r.error).length,
+                chunks: chunkResults,
+            });
+        } catch (actorErr) {
+            const prefix = slugPrefix || rowPrefix;
+            logDream('shared-actor-error', { agent: agent.name, prefix, error: actorErr.message });
+            logError('dream', 'shared-actor-error', {
+                agent: agent.name,
+                prefix,
+                message: actorErr.message,
+                detail: actorErr.stack,
+            });
+            actorResults.push({ prefix, error: actorErr.message });
+        }
+
+        // Delay between villagers — same politeness as the inter-agent delay,
+        // since each villager is a full dedicated-VA-equivalent pass.
+        if (i + 1 < roster.rows.length && interActorDelay > 0) {
+            await new Promise(resolve => setTimeout(resolve, interActorDelay));
+        }
+    }
+
+    // errorCount gives the cron summary a numeric failure signal for this
+    // pooled agent — counting both actor-level errors and failed chunks nested
+    // in an actor's result (per-villager failures are also written to
+    // system_errors via logError, matching the dedicated per-agent contract —
+    // one bad villager never fails the whole run).
+    const errorCount = countActorErrors(actorResults);
+    results.push({
+        agent: agent.name,
+        mode: 'sim-shared',
+        actorCount: roster.rows.length,
+        errorCount,
+        actors: actorResults,
+    });
+}
+
 // Run the dream processing job.
 // Returns a summary object with counts and any errors.
 async function runDream() {
@@ -983,13 +1274,16 @@ async function runDream() {
         return { error: 'No valid dream agents found. At least one of dream-companion, dream-technical, or dream-sim must exist and be created by a trusted creator.' };
     }
 
-    // Find agents with dream mode enabled
+    // Find agents with dream mode enabled. sim-shared (pooled salem-vendor-
+    // style agents) is included but handled on a separate per-villager path
+    // below — it fans out over the sim_shared_actor roster instead of dreaming
+    // one identity across the whole namespace.
     const agents = await pool.query(
         `SELECT ac.name, ac.id AS actor_id, agc.dream_mode, agc.dream_source,
                 agc.last_dream_at, agc.startup_instructions
          FROM agent_configuration agc
          JOIN actors ac ON ac.id = agc.actor_id
-         WHERE agc.dream_mode IN ('companion', 'technical', 'sim')`
+         WHERE agc.dream_mode IN ('companion', 'technical', 'sim', 'sim-shared')`
     );
 
     if (agents.rows.length === 0) {
@@ -1003,6 +1297,19 @@ async function runDream() {
 
     for (const agent of agents.rows) {
         try {
+            if (agent.dream_mode === 'sim-shared') {
+                // Pooled shared-VA agent: fan out over its villager roster on a
+                // separate per-actor path (own cursors, slug-prefixed notes, no
+                // soul). The helper paces itself with an inter-villager delay,
+                // so skip straight to the next agent afterward.
+                await processSharedAgent(
+                    agent,
+                    { simAgentName, simPeopleAgentName, simLearningsAgentName },
+                    results
+                );
+                continue;
+            }
+
             // Pick the right dream/soul/people/learnings agents for this dream_mode.
             let dreamAgentName = null;
             let soulAgentName = null;
@@ -1079,48 +1386,16 @@ async function runDream() {
                 to: chunks[chunks.length - 1].to.toISOString(),
             });
 
-            const interChunkDelay = parseInt(config.get('dream_interchunk_delay')) || 1000;
-            const chunkResults = [];
-
-            for (let i = 0; i < chunks.length; i++) {
-                const chunk = chunks[i];
-                try {
-                    const r = await processDreamChunk(agent, agentNames, chunk);
-                    chunkResults.push(r);
-                    // Advance last_dream_at after each successful chunk so a
-                    // failure on a later chunk doesn't lose the work done on
-                    // earlier ones — the next cron resumes from where we
-                    // stopped, not from the start of the agent's backlog.
-                    await pool.query(
-                        'UPDATE agent_configuration SET last_dream_at = $1 WHERE actor_id = $2',
-                        [chunk.to, agent.actor_id]
-                    );
-                } catch (chunkErr) {
-                    // Don't advance last_dream_at — next cron retries this
-                    // chunk. Stop processing this agent's later chunks so we
-                    // don't skip past a failed one (would lose its logs).
-                    logDream('chunk-error', {
-                        agent: agent.name,
-                        chunkDate: chunk.from.toISOString().slice(0, 10),
-                        error: chunkErr.message,
-                    });
-                    logError('dream', 'chunk-error', {
-                        agent: agent.name,
-                        message: chunkErr.message,
-                        detail: chunkErr.stack,
-                    });
-                    chunkResults.push({
-                        chunkDate: chunk.from.toISOString().slice(0, 10),
-                        error: chunkErr.message,
-                    });
-                    break;
-                }
-                // Inter-chunk pause for the same agent — politeness to the
-                // provider when catching up multiple days back-to-back.
-                if (i + 1 < chunks.length && interChunkDelay > 0) {
-                    await new Promise(resolve => setTimeout(resolve, interChunkDelay));
-                }
-            }
+            // Dedicated agent: one identity across the whole namespace, cursor
+            // on agent_configuration.last_dream_at.
+            const chunkResults = await runChunkLoop(
+                agent, agentNames, chunks,
+                { slugPrefix: '', selfName: agent.name },
+                (chunkTo) => pool.query(
+                    'UPDATE agent_configuration SET last_dream_at = $1 WHERE actor_id = $2',
+                    [chunkTo, agent.actor_id]
+                )
+            );
 
             results.push({
                 agent: agent.name,
@@ -1138,7 +1413,15 @@ async function runDream() {
                 message: err.message,
                 detail: err.stack,
             });
-            results.push({ agent: agent.name, error: err.message });
+            // A throw out of processSharedAgent (e.g. the roster query failing
+            // before any actor result is recorded) must still register as a
+            // shared failure so the run-level sharedActorErrorCount counts it.
+            const failureResult = { agent: agent.name, error: err.message };
+            if (agent.dream_mode === 'sim-shared') {
+                failureResult.mode = 'sim-shared';
+                failureResult.errorCount = 1;
+            }
+            results.push(failureResult);
         }
 
         // Delay between agents to avoid hammering the provider
@@ -1148,8 +1431,17 @@ async function runDream() {
         }
     }
 
-    logDream('complete', { processed: results.length });
-    return { processed: results.length, results };
+    // Aggregate a run-level failure signal for shared-VA dreaming so the
+    // scheduler can record a persistent-failure run rather than a clean
+    // 'complete'. Scoped to sim-shared deliberately: the dedicated per-agent
+    // contract (capture errors into results, resolve the run) is unchanged —
+    // widening the whole cron's success semantics is a separate ticket.
+    const sharedActorErrorCount = results
+        .filter(r => r.mode === 'sim-shared')
+        .reduce((sum, r) => sum + (r.errorCount || 0), 0);
+
+    logDream('complete', { processed: results.length, sharedActorErrorCount });
+    return { processed: results.length, sharedActorErrorCount, results };
 }
 
 // Start the dream scheduler. Reads dream_cron_schedule from config
@@ -1179,7 +1471,19 @@ function startDreamScheduler() {
         logDream('cron-trigger', { schedule });
         try {
             const result = await runDream();
-            logDream('cron-complete', { result });
+            const sharedFailures = result ? (result.sharedActorErrorCount || 0) : 0;
+            // Record the failure signal BEFORE the completion event so a
+            // consumer watching 'cron-complete' can't observe a clean run ahead
+            // of the durable error, and stamp the status onto the completion
+            // event itself. runDream still resolves (one bad villager never
+            // blocks the others), but this run is not a silent success.
+            if (sharedFailures > 0) {
+                logError('dream', 'cron-shared-actor-failures', { count: sharedFailures });
+            }
+            logDream('cron-complete', {
+                result,
+                status: sharedFailures > 0 ? 'completed-with-errors' : 'ok',
+            });
         } catch (err) {
             logDream('cron-error', { error: err.message });
             logError('dream', 'cron-error', { message: err.message, detail: err.stack });
@@ -1189,4 +1493,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countActorErrors, peopleNotePath, validateRosterPrefix };

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -653,6 +653,14 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
     // become the unscoped namespace.
     scope = scope || {};
     const slugPrefix = resolveScopePrefix(scope.slugPrefix);
+    // A shared scope (non-empty prefix) MUST carry a real self identity — the
+    // villager's display name. Falling back to the pooled agent (salem-vendor)
+    // would make the villager's own lines read as counterparty speech and spawn
+    // a bogus self relationship note, so throw rather than silently default. A
+    // dedicated scope ('' prefix) legitimately uses the agent's own name.
+    if (slugPrefix && !(typeof scope.selfName === 'string' && scope.selfName.trim())) {
+        throw new Error('processDreamChunk: shared scope requires a non-empty selfName');
+    }
     const selfName = scope.selfName || agent.name;
 
     let logs;
@@ -1140,7 +1148,10 @@ async function processSharedAgent(agent, simAgents, results) {
     const dreamSource = agent.dream_source || 'conversation';
     if (dreamSource !== 'conversation') {
         logDream('shared-unsupported-source', { agent: agent.name, source: dreamSource });
-        logError('dream', 'shared-unsupported-source', { agent: agent.name, source: dreamSource });
+        logError('dream', 'shared-unsupported-source', {
+            agent: agent.name,
+            message: 'dream_source must be conversation for sim-shared (got ' + dreamSource + ')',
+        });
         results.push({
             agent: agent.name,
             mode: 'sim-shared',
@@ -1234,12 +1245,33 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
             const validated = validateRosterPrefix(rowPrefix);
             if (!validated) {
                 logDream('shared-actor-invalid-prefix', { agent: agent.name, prefix: rowPrefix });
-                logError('dream', 'shared-actor-invalid-prefix', { agent: agent.name, prefix: String(rowPrefix) });
+                logError('dream', 'shared-actor-invalid-prefix', {
+                    agent: agent.name,
+                    message: 'invalid roster slug prefix: ' + String(rowPrefix),
+                });
                 actorResults.push({ prefix: rowPrefix, error: 'invalid slug prefix' });
                 continue;
             }
             slugPrefix = validated;
-            const scope = { slugPrefix, selfName: actorRow.display_name };
+            // A shared villager needs a real display name (its self-identity for
+            // the self-skip + prompt labels). An empty one would fall back to the
+            // pooled agent (salem-vendor) in processDreamChunk, making the
+            // villager's own lines read as counterparty speech and spawning a
+            // bogus self relationship note — so skip the row rather than dream it
+            // under the wrong identity. (sim_shared_actor.display_name is NOT
+            // NULL, and the distiller stores a validated non-empty label, so this
+            // is defense against a hand-edited/corrupt row.)
+            const displayName = actorRow.display_name;
+            if (!(typeof displayName === 'string' && displayName.trim())) {
+                logDream('shared-actor-invalid-display', { agent: agent.name, prefix: slugPrefix });
+                logError('dream', 'shared-actor-invalid-display', {
+                    agent: agent.name,
+                    message: 'missing display name for roster prefix ' + slugPrefix,
+                });
+                actorResults.push({ prefix: slugPrefix, error: 'missing display name' });
+                continue;
+            }
+            const scope = { slugPrefix, selfName: displayName };
             // First run for this villager (no cursor yet): start at its
             // earliest conversation note so a freshly-pushed backlog — an
             // LLM-515 push-cursor backfill, or a villager enrolled several days
@@ -1303,7 +1335,7 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
             logDream('shared-actor-error', { agent: agent.name, prefix, error: actorErr.message });
             logError('dream', 'shared-actor-error', {
                 agent: agent.name,
-                prefix,
+                context: prefix,
                 message: actorErr.message,
                 detail: actorErr.stack,
             });
@@ -1563,7 +1595,9 @@ function startDreamScheduler() {
             // runDream still resolves (one bad villager never blocks the others).
             for (const ev of planCronReport(result)) {
                 if (ev.kind === 'shared-failures') {
-                    logError('dream', 'cron-shared-actor-failures', { count: ev.count });
+                    logError('dream', 'cron-shared-actor-failures', {
+                        message: ev.count + ' shared-VA actor(s) failed this dream run',
+                    });
                 } else {
                     logDream('cron-complete', { result, status: ev.status });
                 }

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countActorErrors, peopleNotePath, validateRosterPrefix } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countActorErrors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -266,6 +266,62 @@ test('peopleNotePath scopes the path under a shared-VA villager prefix', () => {
         peopleNotePath('constance-scott/', 'josiah-thorne'),
         'constance-scott/context/people/josiah-thorne'
     );
+});
+
+test('peopleNotePath throws (builds no path) on an invalid prefix', () => {
+    // A malformed prefix must not silently produce an unscoped or traversing
+    // path — the throw happens before any concatenation.
+    assert.throws(() => peopleNotePath(42, 'jeff'), /not a string/);
+    assert.throws(() => peopleNotePath('../evil/', 'jeff'), /invalid slug prefix/);
+    assert.throws(() => peopleNotePath('a%b/', 'jeff'), /invalid slug prefix/);
+});
+
+// resolveScopePrefix — the single validated boundary (LLM-519 round 5). It must
+// distinguish ABSENT (undefined/null/'' → dedicated namespace root) from
+// PRESENT-BUT-INVALID (throws), so a malformed shared prefix can never silently
+// collapse into the unscoped namespace.
+test('resolveScopePrefix returns "" for an absent prefix', () => {
+    assert.equal(resolveScopePrefix(undefined), '');
+    assert.equal(resolveScopePrefix(null), '');
+    assert.equal(resolveScopePrefix(''), '');
+});
+
+test('resolveScopePrefix canonicalizes a valid prefix', () => {
+    assert.equal(resolveScopePrefix('constance-scott/'), 'constance-scott/');
+    assert.equal(resolveScopePrefix('john-ellis'), 'john-ellis/');
+});
+
+test('resolveScopePrefix throws on a present non-string prefix (no silent "")', () => {
+    assert.throws(() => resolveScopePrefix(42), /not a string/);
+    assert.throws(() => resolveScopePrefix({}), /not a string/);
+    assert.throws(() => resolveScopePrefix([]), /not a string/);
+    assert.throws(() => resolveScopePrefix(true), /not a string/);
+});
+
+test('resolveScopePrefix throws on a non-canonical string (wildcard / traversal)', () => {
+    assert.throws(() => resolveScopePrefix('a%b/'), /invalid slug prefix/);
+    assert.throws(() => resolveScopePrefix('a_b/'), /invalid slug prefix/);
+    assert.throws(() => resolveScopePrefix('../secrets/'), /invalid slug prefix/);
+    assert.throws(() => resolveScopePrefix('foo/../bar/'), /invalid slug prefix/);
+    assert.throws(() => resolveScopePrefix('Constance-Scott/'), /invalid slug prefix/);
+});
+
+// planCronReport — the scheduler's event ordering (LLM-519 round 5). A shared
+// actor failure must produce the durable error event BEFORE the completion
+// event so a consumer watching 'cron-complete' can't observe a clean run ahead
+// of the failure.
+test('planCronReport emits only a clean completion when there are no failures', () => {
+    assert.deepEqual(planCronReport({ sharedActorErrorCount: 0 }), [
+        { kind: 'complete', status: 'ok' },
+    ]);
+    assert.deepEqual(planCronReport(null), [{ kind: 'complete', status: 'ok' }]);
+});
+
+test('planCronReport emits the failure event BEFORE completion when a shared actor failed', () => {
+    const events = planCronReport({ sharedActorErrorCount: 3 });
+    assert.equal(events.length, 2);
+    assert.deepEqual(events[0], { kind: 'shared-failures', count: 3 });
+    assert.deepEqual(events[1], { kind: 'complete', status: 'completed-with-errors' });
 });
 
 // validateRosterPrefix — the roster-boundary decision (LLM-519 round 3). A

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -310,6 +310,16 @@ test('resolveScopePrefix rejects non-canonical forms rather than silently canoni
     assert.throws(() => resolveScopePrefix('  constance-scott/  '), /invalid slug prefix/); // whitespace
 });
 
+test('resolveScopePrefix enforces the 100-char limit at the boundary', () => {
+    // The security boundary now depends on the normalizer's length semantics, so
+    // pin the edge directly: 100 chars (99 body + '/') is accepted, 101 rejected.
+    const atLimit = 'a'.repeat(99) + '/';
+    const overLimit = 'a'.repeat(100) + '/';
+    assert.equal(atLimit.length, 100);
+    assert.equal(resolveScopePrefix(atLimit), atLimit);
+    assert.throws(() => resolveScopePrefix(overLimit), /invalid slug prefix/);
+});
+
 test('resolveScopePrefix throws on a present non-string prefix (no silent "")', () => {
     assert.throws(() => resolveScopePrefix(42), /not a string/);
     assert.throws(() => resolveScopePrefix({}), /not a string/);

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -297,9 +297,17 @@ test('resolveScopePrefix returns "" for an absent prefix', () => {
     assert.equal(resolveScopePrefix(''), '');
 });
 
-test('resolveScopePrefix canonicalizes a valid prefix', () => {
+test('resolveScopePrefix accepts an already-canonical prefix unchanged', () => {
     assert.equal(resolveScopePrefix('constance-scott/'), 'constance-scott/');
-    assert.equal(resolveScopePrefix('john-ellis'), 'john-ellis/');
+    assert.equal(resolveScopePrefix('agent-7/'), 'agent-7/');
+});
+
+test('resolveScopePrefix rejects non-canonical forms rather than silently canonicalizing', () => {
+    // normalizeSlugPrefix would canonicalize these on WRITE; the read boundary
+    // requires them to be already canonical so distinct values can't collapse.
+    assert.throws(() => resolveScopePrefix('john-ellis'), /invalid slug prefix/);        // missing slash
+    assert.throws(() => resolveScopePrefix('constance-scott//'), /invalid slug prefix/); // doubled slash
+    assert.throws(() => resolveScopePrefix('  constance-scott/  '), /invalid slug prefix/); // whitespace
 });
 
 test('resolveScopePrefix throws on a present non-string prefix (no silent "")', () => {
@@ -356,8 +364,14 @@ test('validateRosterPrefix rejects LIKE-wildcard and traversal prefixes', () => 
     assert.equal(validateRosterPrefix('foo/../bar/'), null);
 });
 
-test('validateRosterPrefix accepts and canonicalizes a valid prefix', () => {
+test('validateRosterPrefix accepts an already-canonical prefix', () => {
     assert.equal(validateRosterPrefix('constance-scott/'), 'constance-scott/');
-    // Canonicalizes a missing trailing slash (defensive; distiller writes it).
-    assert.equal(validateRosterPrefix('john-ellis'), 'john-ellis/');
+});
+
+test('validateRosterPrefix rejects a non-canonical prefix (must be stored canonical)', () => {
+    // The distiller stores canonical values; the read boundary rejects drift
+    // rather than silently canonicalizing it, so distinct values can't collapse.
+    assert.equal(validateRosterPrefix('john-ellis'), null);       // missing slash
+    assert.equal(validateRosterPrefix('constance-scott//'), null); // doubled slash
+    assert.equal(validateRosterPrefix('  constance-scott/  '), null); // whitespace
 });

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -335,22 +335,25 @@ test('resolveScopePrefix throws on a non-canonical string (wildcard / traversal)
     assert.throws(() => resolveScopePrefix('Constance-Scott/'), /invalid slug prefix/);
 });
 
-// planCronReport — the scheduler's event ordering (LLM-519 round 5). A shared
-// actor failure must produce the durable error event BEFORE the completion
-// event so a consumer watching 'cron-complete' can't observe a clean run ahead
-// of the failure.
-test('planCronReport emits only a clean completion when there are no failures', () => {
+// planCronReport — the scheduler's status mapping. The completion event's
+// `status` field is the authoritative, self-contained failure signal (no
+// cross-event persistence ordering is relied upon); a shared-failures event is
+// additionally emitted for error_log monitoring when a shared actor failed.
+test('planCronReport marks a clean run "ok" with only a completion event', () => {
     assert.deepEqual(planCronReport({ sharedActorErrorCount: 0 }), [
         { kind: 'complete', status: 'ok' },
     ]);
     assert.deepEqual(planCronReport(null), [{ kind: 'complete', status: 'ok' }]);
 });
 
-test('planCronReport emits the failure event BEFORE completion when a shared actor failed', () => {
+test('planCronReport marks a failed run "completed-with-errors" and adds a failure event', () => {
     const events = planCronReport({ sharedActorErrorCount: 3 });
-    assert.equal(events.length, 2);
-    assert.deepEqual(events[0], { kind: 'shared-failures', count: 3 });
-    assert.deepEqual(events[1], { kind: 'complete', status: 'completed-with-errors' });
+    const complete = events.find(e => e.kind === 'complete');
+    const failure = events.find(e => e.kind === 'shared-failures');
+    // The completion record self-describes the failure via its status field.
+    assert.deepEqual(complete, { kind: 'complete', status: 'completed-with-errors' });
+    // A distinct failure event is also emitted (for error_log monitoring).
+    assert.deepEqual(failure, { kind: 'shared-failures', count: 3 });
 });
 
 // validateRosterPrefix — the roster-boundary decision (LLM-519 round 3). A

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countActorErrors, peopleNotePath, validateRosterPrefix } = require('./dream');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -163,4 +163,134 @@ test('empty startup instructions produce no character-description section', () =
         dreamContent: 'today',
     });
     assert.ok(!msg.includes('## Character description'));
+});
+
+// extractSpeakers self-skip under a shared-VA scope (LLM-519 Slice 2). The
+// dream cron threads the villager's display name as the self-identity so her
+// own sim-day lines are dropped (no self people-file) while counterparties are
+// kept. A shared villager's lines come through the sim distiller format
+// ([Weekday HH:MM Display Name] ...), and the display name is multi-word.
+const SIM_DAY_LOG = [
+    '[Wednesday 14:30 Constance Scott] (earned 6 coins working for Josiah Thorne)',
+    '[Wednesday 14:35 Josiah Thorne] Fair work, fairly paid.',
+].join('\n');
+
+test('shared-VA scope skips the villager\'s own sim-day lines, keeps the counterparty', () => {
+    const speakers = extractSpeakers(SIM_DAY_LOG, 'Constance Scott');
+    assert.ok(!speakers.has('constance-scott'), 'the villager herself must be self-skipped');
+    assert.ok(speakers.has('josiah-thorne'), 'the counterparty must be captured');
+    assert.equal(speakers.get('josiah-thorne').display, 'Josiah Thorne');
+});
+
+test('the pooled agent name does NOT self-skip the villager — why selfName threading is needed', () => {
+    // Passing the pooled agent (salem-vendor) as self, the pre-Slice-2 default,
+    // fails to match the villager's own lines: she'd wrongly accumulate a
+    // context/people file about herself. Slice 2 fixes this by passing her
+    // display name as selfName.
+    const speakers = extractSpeakers(SIM_DAY_LOG, 'salem-vendor');
+    assert.ok(speakers.has('constance-scott'), 'pooled agent name leaves the villager un-skipped');
+});
+
+// runPersonContextUpdate rejects a non-canonical slug prefix before touching
+// the store (LLM-519 code_review): the prefix reaches note paths and LIKE
+// patterns, so a '%'/'_' wildcard or a '../' traversal must be refused at this
+// exported boundary, not trusted from the roster row. The guard runs before any
+// readNote/invokeAgent call, so these assert only the synchronous rejection.
+test('runPersonContextUpdate rejects a LIKE-wildcard slug prefix', async () => {
+    await assert.rejects(
+        () => runPersonContextUpdate('salem-vendor', 'dream-sim-people', 'josiah-thorne', 'Josiah Thorne', 'x', '2026-07-15', { slugPrefix: 'cons%tance/' }),
+        /invalid slug prefix/
+    );
+});
+
+test('runPersonContextUpdate rejects a path-traversal slug prefix', async () => {
+    await assert.rejects(
+        () => runPersonContextUpdate('salem-vendor', 'dream-sim-people', 'josiah-thorne', 'Josiah Thorne', 'x', '2026-07-15', { slugPrefix: '../secrets/' }),
+        /invalid slug prefix/
+    );
+});
+
+// countActorErrors — the shared-VA run-level failure signal (LLM-519 round 2).
+// The subtle case is a failed CHUNK: it lives inside an actor result's chunks[]
+// array, not as an actor-level `error` field, so a naive actor-level filter
+// would report a clean run for an actor whose day actually failed.
+test('countActorErrors counts an actor-level error (invalid prefix / exception)', () => {
+    assert.equal(countActorErrors([{ prefix: 'bad/', error: 'invalid slug prefix' }]), 1);
+});
+
+test('countActorErrors counts an actor whose chunk failed (the round-2 regression)', () => {
+    const actors = [{
+        prefix: 'constance-scott/',
+        plannedChunks: 2,
+        completedChunks: 1,
+        chunks: [
+            { processed: true, chunkDate: '2026-07-15' },
+            { chunkDate: '2026-07-16', error: 'model timeout' },
+        ],
+    }];
+    assert.equal(countActorErrors(actors), 1);
+});
+
+test('countActorErrors ignores clean actors and skipped (non-error) chunks', () => {
+    const actors = [
+        { prefix: 'a/', plannedChunks: 1, completedChunks: 1, chunks: [{ processed: true }] },
+        { prefix: 'b/', skipped: true, reason: 'no conversation notes' },
+        { prefix: 'c/', plannedChunks: 1, completedChunks: 1, chunks: [{ skipped: true, reason: 'no signals' }] },
+    ];
+    assert.equal(countActorErrors(actors), 0);
+});
+
+test('countActorErrors sums actor-level and chunk-level failures across a roster', () => {
+    const actors = [
+        { prefix: 'a/', error: 'invalid slug prefix' },
+        { prefix: 'b/', chunks: [{ processed: true }, { error: 'x' }] },
+        { prefix: 'c/', chunks: [{ processed: true }] },
+    ];
+    assert.equal(countActorErrors(actors), 2);
+});
+
+// peopleNotePath is the exact path runPersonContextUpdate reads and writes, so
+// asserting it directly proves the dedicated/admin empty-prefix invariant
+// (context/people/<slug> at namespace root) and the shared-VA scoping without
+// mocking the document store — which the destructured-import style resists.
+test('peopleNotePath builds a namespace-root path for an empty prefix (dedicated/admin)', () => {
+    assert.equal(peopleNotePath('', 'jeff'), 'context/people/jeff');
+});
+
+test('peopleNotePath treats a missing prefix as empty', () => {
+    assert.equal(peopleNotePath(undefined, 'jeff'), 'context/people/jeff');
+});
+
+test('peopleNotePath scopes the path under a shared-VA villager prefix', () => {
+    assert.equal(
+        peopleNotePath('constance-scott/', 'josiah-thorne'),
+        'constance-scott/context/people/josiah-thorne'
+    );
+});
+
+// validateRosterPrefix — the roster-boundary decision (LLM-519 round 3). A
+// NULL/non-string row must be rejected (returns null → the caller skips only
+// that villager, never aborting the roster), as must any non-canonical value
+// (LIKE metacharacters, path traversal). A canonical prefix passes through.
+test('validateRosterPrefix rejects a NULL roster prefix', () => {
+    assert.equal(validateRosterPrefix(null), null);
+});
+
+test('validateRosterPrefix rejects a non-string roster prefix', () => {
+    assert.equal(validateRosterPrefix(42), null);
+    assert.equal(validateRosterPrefix(undefined), null);
+    assert.equal(validateRosterPrefix({}), null);
+});
+
+test('validateRosterPrefix rejects LIKE-wildcard and traversal prefixes', () => {
+    assert.equal(validateRosterPrefix('cons%tance/'), null);
+    assert.equal(validateRosterPrefix('a_b/'), null);
+    assert.equal(validateRosterPrefix('../secrets/'), null);
+    assert.equal(validateRosterPrefix('foo/../bar/'), null);
+});
+
+test('validateRosterPrefix accepts and canonicalizes a valid prefix', () => {
+    assert.equal(validateRosterPrefix('constance-scott/'), 'constance-scott/');
+    // Canonicalizes a missing trailing slash (defensive; distiller writes it).
+    assert.equal(validateRosterPrefix('john-ellis'), 'john-ellis/');
 });

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -276,6 +276,17 @@ test('peopleNotePath throws (builds no path) on an invalid prefix', () => {
     assert.throws(() => peopleNotePath('a%b/', 'jeff'), /invalid slug prefix/);
 });
 
+test('peopleNotePath validates the person slug too (both components)', () => {
+    // The person slug is the OTHER path component — a raw '../secrets' would
+    // traverse out of context/people/. Must throw, not build the path.
+    assert.throws(() => peopleNotePath('', '../secrets'), /invalid person slug/);
+    assert.throws(() => peopleNotePath('constance-scott/', '../secrets'), /invalid person slug/);
+    assert.throws(() => peopleNotePath('', 'Not A Slug'), /invalid person slug/);
+    assert.throws(() => peopleNotePath('', 42), /invalid person slug/);
+    // A canonical slug still passes through unchanged.
+    assert.equal(peopleNotePath('', 'josiah-thorne'), 'context/people/josiah-thorne');
+});
+
 // resolveScopePrefix — the single validated boundary (LLM-519 round 5). It must
 // distinguish ABSENT (undefined/null/'' → dedicated namespace root) from
 // PRESENT-BUT-INVALID (throws), so a malformed shared prefix can never silently

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countActorErrors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -210,15 +210,17 @@ test('runPersonContextUpdate rejects a path-traversal slug prefix', async () => 
     );
 });
 
-// countActorErrors — the shared-VA run-level failure signal (LLM-519 round 2).
-// The subtle case is a failed CHUNK: it lives inside an actor result's chunks[]
-// array, not as an actor-level `error` field, so a naive actor-level filter
-// would report a clean run for an actor whose day actually failed.
-test('countActorErrors counts an actor-level error (invalid prefix / exception)', () => {
-    assert.equal(countActorErrors([{ prefix: 'bad/', error: 'invalid slug prefix' }]), 1);
+// countFailedActors — the shared-VA run-level failure signal: how many
+// villagers saw ANY failure (actor granularity — one villager counts once even
+// with several failed chunks; per-villager plannedChunks/completedChunks carry
+// the finer detail). The subtle case is a failed CHUNK: it lives inside an actor
+// result's chunks[] array, not as an actor-level `error` field, so a naive
+// actor-level filter would miss an actor whose day actually failed.
+test('countFailedActors counts an actor-level error (invalid prefix / exception)', () => {
+    assert.equal(countFailedActors([{ prefix: 'bad/', error: 'invalid slug prefix' }]), 1);
 });
 
-test('countActorErrors counts an actor whose chunk failed (the round-2 regression)', () => {
+test('countFailedActors counts an actor whose chunk failed (the round-2 regression)', () => {
     const actors = [{
         prefix: 'constance-scott/',
         plannedChunks: 2,
@@ -228,25 +230,25 @@ test('countActorErrors counts an actor whose chunk failed (the round-2 regressio
             { chunkDate: '2026-07-16', error: 'model timeout' },
         ],
     }];
-    assert.equal(countActorErrors(actors), 1);
+    assert.equal(countFailedActors(actors), 1);
 });
 
-test('countActorErrors ignores clean actors and skipped (non-error) chunks', () => {
+test('countFailedActors ignores clean actors and skipped (non-error) chunks', () => {
     const actors = [
         { prefix: 'a/', plannedChunks: 1, completedChunks: 1, chunks: [{ processed: true }] },
         { prefix: 'b/', skipped: true, reason: 'no conversation notes' },
         { prefix: 'c/', plannedChunks: 1, completedChunks: 1, chunks: [{ skipped: true, reason: 'no signals' }] },
     ];
-    assert.equal(countActorErrors(actors), 0);
+    assert.equal(countFailedActors(actors), 0);
 });
 
-test('countActorErrors sums actor-level and chunk-level failures across a roster', () => {
+test('countFailedActors counts each failed actor once across a roster (actor granularity)', () => {
     const actors = [
-        { prefix: 'a/', error: 'invalid slug prefix' },
-        { prefix: 'b/', chunks: [{ processed: true }, { error: 'x' }] },
-        { prefix: 'c/', chunks: [{ processed: true }] },
+        { prefix: 'a/', error: 'invalid slug prefix' },              // actor-level error
+        { prefix: 'b/', chunks: [{ processed: true }, { error: 'x' }] }, // one failed chunk
+        { prefix: 'c/', chunks: [{ processed: true }] },             // clean
     ];
-    assert.equal(countActorErrors(actors), 2);
+    assert.equal(countFailedActors(actors), 2);
 });
 
 // peopleNotePath is the exact path runPersonContextUpdate reads and writes, so
@@ -340,14 +342,14 @@ test('resolveScopePrefix throws on a non-canonical string (wildcard / traversal)
 // cross-event persistence ordering is relied upon); a shared-failures event is
 // additionally emitted for error_log monitoring when a shared actor failed.
 test('planCronReport marks a clean run "ok" with only a completion event', () => {
-    assert.deepEqual(planCronReport({ sharedActorErrorCount: 0 }), [
+    assert.deepEqual(planCronReport({ failedSharedActorCount: 0 }), [
         { kind: 'complete', status: 'ok' },
     ]);
     assert.deepEqual(planCronReport(null), [{ kind: 'complete', status: 'ok' }]);
 });
 
 test('planCronReport marks a failed run "completed-with-errors" and adds a failure event', () => {
-    const events = planCronReport({ sharedActorErrorCount: 3 });
+    const events = planCronReport({ failedSharedActorCount: 3 });
     const complete = events.find(e => e.kind === 'complete');
     const failure = events.find(e => e.kind === 'shared-failures');
     // The completion record self-describes the failure via its status field.


### PR DESCRIPTION
Follow-on to LLM-515 Slice 1. Runs the dream/consolidation pipeline **per shared-VA villager**: each `salem-vendor` villager gets its own `dreams/`, `learnings/`, and `context/people/` notes under its slug prefix in the pooled namespace, cursored on its own `sim_shared_actor.last_dream_at`. This produces the durable consolidated fact (e.g. "Josiah paid you 10 coins, settled") that outranks a stale self-authored `memorize` note — the actual close of the LLM-515 phantom-coin drift.

## Design
- Threads a `scope { slugPrefix, selfName }` through `processDreamChunk` and `runPersonContextUpdate`; the dedicated path stays byte-identical (`{ slugPrefix: '', selfName: agent.name }`).
- Extracts the per-day chunk loop into `runChunkLoop`, shared by the dedicated and per-villager paths.
- `processSharedAgent` → `dreamSharedRoster` fans out over the `sim_shared_actor` roster; first run backfills from the villager's earliest conversation note. Soul is not written for shared villagers (LLM-199).

## Security / robustness (code_review)
- `resolveScopePrefix` — single validated boundary: absent prefix → namespace root; present-but-invalid (non-string, LIKE metacharacters, traversal, non-canonical, over-length) → throws. `peopleNotePath` validates BOTH path components.
- `dream_source='notes'` guard (the notes branch is not slug-scoped — would leak cross-villager notes).
- Every shared failure (setup, per-actor, per-chunk) feeds a run-level `failedSharedActorCount`; the scheduler records `cron-shared-actor-failures` and stamps a self-describing `status` on `cron-complete`.
- Per-villager display-name validation; partial-result preservation on a setup throw.

**No migration** (roster + `last_dream_at` exist from MEM-142). Reuses the existing sim dream VAs. **129/129 tests green.** Reviewed across multiple code_review rounds.

Follow-up filed for a `runDream()` end-to-end integration test (blocked on dream.js's destructured-import architecture — needs module-mock support or a DI refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)