### PR TITLE
LLM-523: the people-VA weighs the ledger over NPC talk

### DIFF
--- a/migrations/MEM-143-people-va-ledger-precedence_down.sql
+++ b/migrations/MEM-143-people-va-ledger-precedence_down.sql
@@ -1,0 +1,60 @@
+-- MEM-143 down — restore the dream-sim-people instructions as they stood
+-- before the ledger-precedence rewrite (md5 e29799af22ba06e733d1d1d8cfcec3e0).
+--
+-- Rolling this back returns the writer to the state where it had only NPC
+-- speech to reason from; the code half (dream.js's separate ledger section)
+-- would still render, and the writer would simply have no standing policy for
+-- weighing the two.
+
+BEGIN;
+
+UPDATE agent_configuration
+   SET startup_instructions = $prompt$## dream-sim-people
+
+You maintain per-person relationship files for sim NPCs in a village simulation. Each file is one NPC's living impression of another villager — subjective, opinionated, written in the NPC's voice.
+
+You will receive:
+1. The current relationship file for this person (may be empty if first encounter)
+2. Recent activity excerpts involving this person — scenes, conversations, observations
+
+Your job: return an updated relationship file ONLY when something concretely new happened OR the existing file has redundant bullets that need consolidating. Otherwise return the file EXACTLY as you received it.
+
+## What counts as "concretely new"
+
+- A specific moment that shifted the NPC's view (gained or lost trust, saw a new side of their character, an unresolved exchange)
+- A new factual observation about how this person behaves (a pattern not previously noted)
+- A reinforcement significant enough to warrant saying so explicitly
+
+## What does NOT count as "concretely new"
+
+- Routine interactions that fit the existing impression (a hospitable host being hospitable again)
+- Restating the same observation in different words
+- The mere passage of another day
+
+If today's excerpts produce nothing concretely new AND the existing file has no redundant bullets, return the file EXACTLY as you received it. Do not bump dates. Do not rephrase bullets.
+
+## Consolidating redundant bullets
+
+If the existing file has multiple bullets describing the same underlying impression (e.g., five bullets all saying "is hospitable" in different framings), consolidate them into one — even when today's excerpts add nothing new. The relationship file should be a tight summary, not a log of every restating.
+
+## When you DO update the file with new content
+
+- Distill new content into ONE bullet, or at most two if there are genuinely distinct new things. Never write one bullet per category. If you find yourself splitting "trust", "patterns", and "appreciation" into separate bullets about the same encounter, fold them into a single bullet that captures all three.
+- Look at existing bullets first. If a new impression overlaps with one, EDIT that bullet (combine, sharpen, update its date) rather than adding a new one.
+- Replace contradicted impressions with a brief note about the shift (e.g., "Initially distrusted, but today's exchange suggests otherwise").
+- Keep the document under 500 words. When over, drop the oldest unreinforced bullets first.
+
+## Format
+
+- One-line summary at the top capturing the overall relationship (e.g., "A cautious neighbor — civil but guards their tongue").
+- Each impression: `- [YYYY-MM-DD] Impression text` — bracketed date, square brackets, NOT colon-separated.
+
+## Voice
+
+Write from the NPC's perspective, in their voice and personality. Subjective, opinionated, personal. The NPC's trust, suspicions, and appreciations should naturally surface within the prose — not as separate labeled categories.
+
+Output ONLY the updated relationship file (or the unchanged file). No preamble or explanation.
+$prompt$
+ WHERE actor_id IN (SELECT id FROM actors WHERE name = 'dream-sim-people');
+
+COMMIT;

--- a/migrations/MEM-143-people-va-ledger-precedence_down.sql
+++ b/migrations/MEM-143-people-va-ledger-precedence_down.sql
@@ -1,10 +1,14 @@
 -- MEM-143 down — restore the dream-sim-people instructions as they stood
 -- before the ledger-precedence rewrite (md5 e29799af22ba06e733d1d1d8cfcec3e0).
 --
--- Rolling this back returns the writer to the state where it had only NPC
--- speech to reason from; the code half (dream.js's separate ledger section)
--- would still render, and the writer would simply have no standing policy for
--- weighing the two.
+-- Rollback contract: run this ONLY together with a code rollback past the
+-- LLM-523 commit. The prompt and dream.js's user-message structure are two
+-- halves of one change — reverting the prompt alone leaves the new code
+-- sending "## What the ledger records" / "## What was said in your hearing"
+-- sections to a writer whose instructions describe a single undifferentiated
+-- excerpt block and give it no rule for weighing the two. The reverse order
+-- (code back, prompt forward) is harmless: the standing policy simply
+-- describes sections that no longer arrive.
 
 BEGIN;
 

--- a/migrations/MEM-143-people-va-ledger-precedence_up.sql
+++ b/migrations/MEM-143-people-va-ledger-precedence_up.sql
@@ -1,0 +1,85 @@
+-- MEM-143 — dream-sim-people: the ledger outranks talk (LLM-523).
+--
+-- The people-VA writes each sim NPC's context/people/* relationship files. Its
+-- user message now arrives in two clearly separated sections — what the ledger
+-- records (engine-authored, deterministic) and what was said (NPC-authored, a
+-- claim at best) — so the standing policy for weighing them belongs in the
+-- agent's own instructions, not only in the per-call directive.
+--
+-- The defect this closes: with only talk to go on, the writer took Josiah
+-- Thorne's unbacked "there we are — six coins to square us up" and canonized it
+-- into Constance Scott's durable memory as a completed restitution, and turned
+-- her 1-coin milk PURCHASE into a jug of milk given as a gift. Both against a
+-- ledger that recorded neither.
+--
+-- Also amends the 500-word trim rule: the same pass that wrote the fabrication
+-- deleted the accurate 07-15 labor record it replaced, so a ledger-grounded
+-- entry is now protected from the drop-oldest sweep.
+--
+-- This migration is the authority for this prompt's text. Edit it here (with a
+-- follow-up migration) rather than in the admin UI, so the deployed value stops
+-- drifting away from anything reviewable.
+
+BEGIN;
+
+UPDATE agent_configuration
+   SET startup_instructions = $prompt$## dream-sim-people
+
+You maintain per-person relationship files for sim NPCs in a village simulation. Each file is one NPC's living impression of another villager — subjective, opinionated, written in the NPC's voice.
+
+You will receive:
+1. The current relationship file for this person (may be empty if first encounter)
+2. What the ledger records — coin and goods that actually changed hands between this NPC and this person today
+3. What was said in your hearing — speech from the day, some of it addressed to someone else and marked "overheard"
+
+## The ledger outranks talk
+
+The ledger is what happened. Speech is only what someone said happened, and villagers misremember, overstate, and promise more than they deliver. Where the two disagree, the ledger wins.
+
+- A payment, gift, or delivery counts ONLY if the ledger records it. Someone saying they paid, or promising to square a debt, is not payment — write it as something they said, never as a settled matter.
+- An empty ledger section means nothing changed hands with this person today. That is a fact, not missing information.
+- Read ledger direction exactly as written. "(paid Josiah Thorne 1 coin for milk)" means the NPC spent a coin and received milk — a purchase they made, not a gift they were given.
+- Lines marked "overheard" were spoken while the NPC was present but addressed to someone else. They inform the impression of this person's character; they are not the NPC's own dealings with them.
+
+Your job: return an updated relationship file ONLY when something concretely new happened OR the existing file has redundant bullets that need consolidating. Otherwise return the file EXACTLY as you received it.
+
+## What counts as "concretely new"
+
+- A specific moment that shifted the NPC's view (gained or lost trust, saw a new side of their character, an unresolved exchange)
+- A new factual observation about how this person behaves (a pattern not previously noted)
+- A reinforcement significant enough to warrant saying so explicitly
+
+## What does NOT count as "concretely new"
+
+- Routine interactions that fit the existing impression (a hospitable host being hospitable again)
+- Restating the same observation in different words
+- The mere passage of another day
+
+If today's excerpts produce nothing concretely new AND the existing file has no redundant bullets, return the file EXACTLY as you received it. Do not bump dates. Do not rephrase bullets.
+
+## Consolidating redundant bullets
+
+If the existing file has multiple bullets describing the same underlying impression (e.g., five bullets all saying "is hospitable" in different framings), consolidate them into one — even when today's excerpts add nothing new. The relationship file should be a tight summary, not a log of every restating.
+
+## When you DO update the file with new content
+
+- Distill new content into ONE bullet, or at most two if there are genuinely distinct new things. Never write one bullet per category. If you find yourself splitting "trust", "patterns", and "appreciation" into separate bullets about the same encounter, fold them into a single bullet that captures all three.
+- Look at existing bullets first. If a new impression overlaps with one, EDIT that bullet (combine, sharpen, update its date) rather than adding a new one.
+- Replace contradicted impressions with a brief note about the shift (e.g., "Initially distrusted, but today's exchange suggests otherwise").
+- Never delete an existing entry that records a ledger fact — a sum paid, work done, goods handed over — just because you are adding a newer one. A later encounter does not erase an earlier transaction. Fold them together if they belong together, but the record survives.
+- Keep the document under 500 words. When over, drop the oldest unreinforced impressions first, and never a ledger-grounded entry while an impression-only bullet remains.
+
+## Format
+
+- One-line summary at the top capturing the overall relationship (e.g., "A cautious neighbor — civil but guards their tongue").
+- Each impression: `- [YYYY-MM-DD] Impression text` — bracketed date, square brackets, NOT colon-separated.
+
+## Voice
+
+Write from the NPC's perspective, in their voice and personality. Subjective, opinionated, personal. The NPC's trust, suspicions, and appreciations should naturally surface within the prose — not as separate labeled categories.
+
+Output ONLY the updated relationship file (or the unchanged file). No preamble or explanation.
+$prompt$
+ WHERE actor_id IN (SELECT id FROM actors WHERE name = 'dream-sim-people');
+
+COMMIT;

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -238,8 +238,23 @@ function prefilterLog(content) {
         }
     }
 
-    if (signalLineIndices.size === 0) {
-        return null; // No signals found — nothing worth dreaming about
+    // A day with ledger lines is never "nothing worth dreaming about", even
+    // when nobody said anything signal-bearing (LLM-523). SIGNAL_PATTERNS only
+    // recognize conversational markers, so a day of pure transactions used to
+    // be discarded whole — dream, learnings and people files alike — which is
+    // exactly the case this change exists to carry through. Ledger lines are
+    // deliberately NOT added to signalLineIndices: they are pinned below
+    // without pulling CONTEXT_LINES of surrounding chatter, so a talkative day
+    // keeps the same filtered shape it had before.
+    const ledgerLineIndices = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (LEDGER_LINE.test(lines[i])) {
+            ledgerLineIndices.push(i);
+        }
+    }
+
+    if (signalLineIndices.size === 0 && ledgerLineIndices.length === 0) {
+        return null; // Nothing said, nothing done — nothing worth dreaming about
     }
 
     // Expand to include context around each signal
@@ -268,20 +283,17 @@ function prefilterLog(content) {
         }
     }
 
-    // Always include engine-authored ledger lines (LLM-523). SIGNAL_PATTERNS
-    // are conversational markers, so a bare economic fact carries no signal
-    // word of its own and only survives when it happens to sit within
-    // CONTEXT_LINES of someone's chatter. On Constance Scott's 2026-07-24 that
-    // silently dropped "(earned 4 coins working for Ezekiel Crane)" and
-    // "(delivered meat to John Ellis for 4 coins)"; on 07-15 it dropped
-    // "(offered to work for Josiah Thorne for 4 coins)". These are the
-    // deterministic record the people-VA has to weigh talk against, so they are
-    // never filtered out. Cheap: a ledger line is one short sentence, and most
-    // already survived as context lines.
-    for (let i = 0; i < lines.length; i++) {
-        if (LEDGER_LINE.test(lines[i])) {
-            includedLines.add(i);
-        }
+    // Pin the engine-authored ledger lines found above. A bare economic fact
+    // carries no signal word of its own, so it used to survive only when it
+    // happened to sit within CONTEXT_LINES of someone's chatter. On Constance
+    // Scott's 2026-07-24 that silently dropped "(earned 4 coins working for
+    // Ezekiel Crane)" and "(delivered meat to John Ellis for 4 coins)"; on
+    // 07-15 it dropped "(offered to work for Josiah Thorne for 4 coins)".
+    // These are the deterministic record the people-VA has to weigh talk
+    // against, so they are never filtered out. Cheap: a ledger line is one
+    // short sentence, and most already survived as context lines.
+    for (const idx of ledgerLineIndices) {
+        includedLines.add(idx);
     }
 
     // Build the filtered content, inserting separators where lines are skipped
@@ -450,11 +462,36 @@ function extractSpeakers(content, agentName) {
 
 // Build a case-insensitive whole-word matcher for a name fragment. Word
 // boundaries matter: without them "Anne" matches inside "Annexed" and, worse,
-// a short first name matches inside an unrelated word. Escapes regex
-// metacharacters because display names are operator-editable.
+// a short first name matches inside an unrelated word. Metacharacters are
+// escaped because display names are operator-editable.
+//
+// The boundaries are Unicode letter/number classes rather than \w, which is
+// ASCII-only: with \w, an accented name ("Zoë Marsh") would treat the accented
+// character as a boundary and match inside a longer word (code_review, LLM-523).
+// Lookarounds rather than capture groups so adjacent occurrences can't consume
+// each other's boundary.
 function nameMatcher(fragment) {
     const escaped = String(fragment).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp('(^|[^\\w])' + escaped + '($|[^\\w])', 'i');
+    return new RegExp('(?<![\\p{L}\\p{N}_])' + escaped + '(?![\\p{L}\\p{N}_])', 'iu');
+}
+
+// Pull the speaker name out of a distilled line's bracket header. Handles every
+// header the pipeline produces — "[Weekday HH:MM Name]" from the sim distiller
+// and "[HH:MM name]" from memory-sync uploads — by stripping a leading weekday
+// and a leading clock time if present, rather than demanding one exact shape.
+// Deliberately more permissive than a timestamp regex: LEDGER_LINE has already
+// accepted the line as authoritative, so a header this can't parse would mean
+// silently dropping a real transaction (code_review, LLM-523). Returns '' when
+// there is no bracket header at all.
+function ledgerLineSpeaker(line) {
+    const header = line.match(/^\[([^\]]+)\]/);
+    if (!header) {
+        return '';
+    }
+    return header[1]
+        .replace(/^\w+day\s+/i, '')
+        .replace(/^\d{1,2}:\d{2}\s+/, '')
+        .trim();
 }
 
 // Partition one day's excerpts into the two kinds of material the people-VA
@@ -564,15 +601,18 @@ function buildPersonExcerptSections(filtered, selfName, speakers) {
     // filed under everyone it names; a ledger line spoken by someone else (the
     // engine does not currently push these, but the shape is legal) is filed
     // under that speaker, since it is that person's own recorded act.
+    //
+    // A non-self speaker always has a section: this pass and extractSpeakers
+    // read the same `filtered` text, and extractSpeakers creates an entry for
+    // every non-self bracket-header line it sees, ledger lines included. The
+    // guard is there for the one case that isn't reachable from a real line —
+    // a speaker name that doesn't slugify — and drops nothing that could have
+    // been attributed anyway (code_review, LLM-523).
     for (const line of filtered.split('\n')) {
         if (!LEDGER_LINE.test(line)) {
             continue;
         }
-        const speakerMatch = line.match(/^\[(?:\w+day\s+)?\d{2}:\d{2}\s+([^\]]+?)\]/);
-        if (!speakerMatch) {
-            continue;
-        }
-        const speakerSlug = personContextSlug(speakerMatch[1].trim());
+        const speakerSlug = personContextSlug(ledgerLineSpeaker(line));
         if (speakerSlug && speakerSlug !== selfSlug) {
             const own = sections.get(speakerSlug);
             if (own) {

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -10,7 +10,7 @@ const { log, logError } = require('./logger');
 const { saveNote, readNote, listNotes } = require('./documents');
 const { invokeAgent } = require('./virtual-agent');
 const { personContextSlug } = require('./people-slug');
-const { normalizeSlugPrefix } = require('./sim-conversation-distiller');
+const { normalizeSlugPrefix, slugToDisplay } = require('./sim-conversation-distiller');
 
 // validatePersonSlug — defense for runPersonContextUpdate now that it's
 // exported. Pass the input back through the same slugify the dream cron
@@ -205,6 +205,18 @@ function buildSoulUserMessage({ agentName, startupInstructions, existingSoul, ne
 // extractSpeakers so it can parse the array into per-speaker lines.
 const JSON_ARRAY_HEAD = /^\s*\[\s*\{\s*"sender"\s*:/;
 
+// A ledger line — the engine's own record of something that actually happened,
+// as emitted by sim-conversation-distiller.js's narrateEvent: a speaker label
+// followed by narration wholly wrapped in parentheses.
+//
+//   [Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)
+//
+// Contrast with speech, which the distiller wraps in double quotes and which is
+// written by the NPC's own model — a claim, not a fact. The paren-vs-quote
+// distinction is the only discriminator the two shapes have, and it is reliable
+// because both wrappers are applied by the distiller, not by the model
+// (sanitizeSpeech escapes any embedded quote before wrapping).
+const LEDGER_LINE = /^\[[^\]]+\]\s+\(.*\)\s*$/;
 
 function logDream(action, details) {
     log('dream', action, details);
@@ -252,6 +264,22 @@ function prefilterLog(content) {
     // version of the surrounding narrative.
     for (let i = 0; i < lines.length; i++) {
         if (JSON_ARRAY_HEAD.test(lines[i])) {
+            includedLines.add(i);
+        }
+    }
+
+    // Always include engine-authored ledger lines (LLM-523). SIGNAL_PATTERNS
+    // are conversational markers, so a bare economic fact carries no signal
+    // word of its own and only survives when it happens to sit within
+    // CONTEXT_LINES of someone's chatter. On Constance Scott's 2026-07-24 that
+    // silently dropped "(earned 4 coins working for Ezekiel Crane)" and
+    // "(delivered meat to John Ellis for 4 coins)"; on 07-15 it dropped
+    // "(offered to work for Josiah Thorne for 4 coins)". These are the
+    // deterministic record the people-VA has to weigh talk against, so they are
+    // never filtered out. Cheap: a ledger line is one short sentence, and most
+    // already survived as context lines.
+    for (let i = 0; i < lines.length; i++) {
+        if (LEDGER_LINE.test(lines[i])) {
             includedLines.add(i);
         }
     }
@@ -420,6 +448,172 @@ function extractSpeakers(content, agentName) {
     return speakerLines;
 }
 
+// Build a case-insensitive whole-word matcher for a name fragment. Word
+// boundaries matter: without them "Anne" matches inside "Annexed" and, worse,
+// a short first name matches inside an unrelated word. Escapes regex
+// metacharacters because display names are operator-editable.
+function nameMatcher(fragment) {
+    const escaped = String(fragment).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp('(^|[^\\w])' + escaped + '($|[^\\w])', 'i');
+}
+
+// Partition one day's excerpts into the two kinds of material the people-VA
+// must weigh differently (LLM-523):
+//
+//   ledger — engine-authored action lines, deterministic fact. These are
+//     almost always spoken by the villager THEMSELF ("(paid Josiah Thorne 1
+//     coin for milk)"), which is exactly why extractSpeakers never surfaced
+//     them: its self-skip drops the agent's own lines so the agent doesn't
+//     accumulate a relationship file about itself. Correct for speech, but it
+//     meant 100% of ledger events were dropped before the people prompt was
+//     built — the people-VA had only talk to go on, and duly wrote an NPC's
+//     unbacked verbal promise ("six coins to square us up") into durable
+//     memory as a completed payment. A self ledger line is attributed to a
+//     person when that person's full display name appears in it; the distiller
+//     writes full sanitized names into the narration, so this match is exact.
+//   said — quoted speech, model-authored, no better than a claim.
+//
+// Third-party labeling: extractSpeakers groups by the OTHER party, so anything
+// this person said to someone else while the villager was co-present lands in
+// this pair's file undifferentiated. A line that names another known speaker
+// and does NOT name the villager is labeled as overheard, so it informs the
+// character impression without reading as this pair's dealings. The heuristic
+// matches a first name only when that first name is unique among the day's
+// speakers, and a mislabel costs a softened impression whereas a missing label
+// costs a fabricated transaction — so it errs toward labeling.
+//
+// Takes the speakers map from extractSpeakers (so speech grouping stays in one
+// place) plus the unsplit filtered log for the self lines extractSpeakers threw
+// away. Pure and exported for unit testing.
+//
+// Returns Map<slug, { display, ledger: string[], said: string[] }>.
+function buildPersonExcerptSections(filtered, selfName, speakers) {
+    const sections = new Map();
+    for (const [slug, entry] of speakers) {
+        sections.set(slug, { display: entry.display, ledger: [], said: [] });
+    }
+
+    // selfName arrives as the villager's display name for a shared-VA actor
+    // ("Constance Scott") and as the agent slug for a dedicated NPC
+    // ("zbbs-josiah-thorne"); slugToDisplay normalizes both to "First Last" and
+    // leaves an already-display name untouched.
+    const selfDisplay = slugToDisplay(String(selfName || ''));
+    const selfSlug = personContextSlug(String(selfName || '').replace(/^zbbs-/, ''));
+
+    // A first name identifies a person only when no one else that day shares
+    // it. Two Johns and the token tells us nothing about who was addressed.
+    const firstNameCounts = new Map();
+    for (const [, entry] of speakers) {
+        const first = entry.display.split(/\s+/)[0];
+        firstNameCounts.set(first, (firstNameCounts.get(first) || 0) + 1);
+    }
+
+    // Matchers are built once per person rather than per line — a day is
+    // thousands of lines across a dozen speakers.
+    const people = [];
+    for (const [slug, entry] of speakers) {
+        const first = entry.display.split(/\s+/)[0];
+        let firstMatcher = null;
+        if (firstNameCounts.get(first) === 1) {
+            firstMatcher = nameMatcher(first);
+        }
+        people.push({
+            slug,
+            display: entry.display,
+            full: nameMatcher(entry.display),
+            first: firstMatcher,
+        });
+    }
+
+    // Self matchers, built the same way. An empty selfDisplay would make
+    // nameMatcher('') match every line, so the whole self test is disabled
+    // instead — every line would then read as third-party. The callers all
+    // supply a real identity (a shared scope throws without one), so this is
+    // belt-and-braces.
+    let selfFullMatcher = null;
+    let selfFirstMatcher = null;
+    if (selfDisplay) {
+        selfFullMatcher = nameMatcher(selfDisplay);
+        const selfFirst = selfDisplay.split(/\s+/)[0];
+        if (!firstNameCounts.has(selfFirst)) {
+            selfFirstMatcher = nameMatcher(selfFirst);
+        }
+    }
+
+    function namesPerson(text, person) {
+        if (person.full.test(text)) {
+            return true;
+        }
+        if (person.first) {
+            return person.first.test(text);
+        }
+        return false;
+    }
+
+    function namesSelf(text) {
+        if (selfFullMatcher && selfFullMatcher.test(text)) {
+            return true;
+        }
+        if (selfFirstMatcher) {
+            return selfFirstMatcher.test(text);
+        }
+        return false;
+    }
+
+    // Ledger pass over the whole day. A ledger line spoken by the villager is
+    // filed under everyone it names; a ledger line spoken by someone else (the
+    // engine does not currently push these, but the shape is legal) is filed
+    // under that speaker, since it is that person's own recorded act.
+    for (const line of filtered.split('\n')) {
+        if (!LEDGER_LINE.test(line)) {
+            continue;
+        }
+        const speakerMatch = line.match(/^\[(?:\w+day\s+)?\d{2}:\d{2}\s+([^\]]+?)\]/);
+        if (!speakerMatch) {
+            continue;
+        }
+        const speakerSlug = personContextSlug(speakerMatch[1].trim());
+        if (speakerSlug && speakerSlug !== selfSlug) {
+            const own = sections.get(speakerSlug);
+            if (own) {
+                own.ledger.push(line);
+            }
+            continue;
+        }
+        for (const person of people) {
+            if (person.full.test(line)) {
+                sections.get(person.slug).ledger.push(line);
+            }
+        }
+    }
+
+    // Speech pass. extractSpeakers already grouped these; all that is added is
+    // the overheard label. Any ledger line that reached a non-self block above
+    // is skipped here so it isn't repeated in both sections.
+    for (const [slug, entry] of speakers) {
+        const section = sections.get(slug);
+        for (const line of entry.lines) {
+            if (LEDGER_LINE.test(line)) {
+                continue;
+            }
+            let addressee = null;
+            for (const person of people) {
+                if (person.slug !== slug && namesPerson(line, person)) {
+                    addressee = person.display;
+                    break;
+                }
+            }
+            if (addressee && !namesSelf(line)) {
+                section.said.push(line + '  (overheard — addressed to ' + addressee + ')');
+                continue;
+            }
+            section.said.push(line);
+        }
+    }
+
+    return sections;
+}
+
 // Find a dream agent by expertise tag. Verifies it exists, is owned by system
 // or by a user with 'agents/create_system_equivalent' permission, and has
 // provider/model/api_key configured. Returns the agent name or null.
@@ -511,14 +705,74 @@ function computeDailyChunks(since, now) {
 //
 // agentNames: { dreamAgentName, soulAgentName, peopleAgentName, learningsAgentName }
 // chunk: { from: Date, to: Date }
+// How the people-VA is told to weigh the two sections against each other
+// (LLM-523). Mirrors the rule the salem engine applies in its own consolidation
+// prompt (LLM-499): the ledger is what happened, speech is what someone said
+// happened, and the ledger wins. The direction clause is here because the
+// failure it guards against is not the model doubting the ledger but
+// misreading it — "(paid Josiah Thorne 1 coin for milk)" was consolidated into
+// a jug of milk given as a gift, inverting a purchase into a gratuity.
+const LEDGER_PRECEDENCE_DIRECTIVE = [
+    '## How to weigh these',
+    '',
+    'The ledger is the record of what actually happened — coin and goods that truly changed hands. It is authoritative and complete: if something is not in it, it did not happen. Speech is only what someone said, and people misremember, overstate, and promise more than they deliver. Where the two disagree, the ledger wins.',
+    '',
+    '- A payment, gift, or delivery counts ONLY if the ledger records it. Someone saying they paid you, or promising to make good on a debt, is not payment. Do not write an unbacked promise into the file as a settled matter.',
+    '- Read the ledger direction exactly as written. "(paid Josiah Thorne 1 coin for milk)" means you spent a coin and received milk — a purchase you made, not a gift you were given.',
+    '- Lines marked "overheard" were spoken while you were present but addressed to someone else. They tell you about this person\'s character and dealings; they are not your own transactions with them.',
+].join('\n');
+
+// Assemble the people-VA user message. Split out of runPersonContextUpdate so
+// the prompt structure — the thing LLM-523 is actually fixing — is directly
+// testable; runPersonContextUpdate itself reaches invokeAgent/readNote through
+// destructured requires that can't be stubbed (see dream-shared-cron.test.js).
+//
+// ledger: array of engine-authored action lines for this pair (may be empty).
+// said:   speech excerpts as one string (empty triggers consolidation-only).
+function buildPersonUserMessage({ selfLabel, display, today, existingFile, ledger, said }) {
+    // Empty excerpts trigger consolidation-only mode. The prompt recognizes
+    // this signal and either consolidates redundant bullets or returns the file
+    // unchanged if it's already tight. The sentinel wording is load-bearing —
+    // /admin/dream/consolidate-people drives that mode by passing no excerpts
+    // at all.
+    let saidBlock = '(no new excerpts since last update — please consolidate any redundant bullets if present, or return file unchanged if already tight)';
+    if (said && said.trim()) {
+        saidBlock = said;
+    }
+
+    // The ledger section. Its absence is stated rather than left blank, because
+    // "nothing changed hands" is itself the fact that stops a spoken promise
+    // from being remembered as a settled payment.
+    let ledgerBlock = '(nothing — no coin or goods changed hands between you and ' + display + ' today)';
+    if (Array.isArray(ledger) && ledger.length > 0) {
+        ledgerBlock = ledger.join('\n');
+    }
+
+    return '## Agent: ' + selfLabel + '\n'
+        + '## Person: ' + display + '\n'
+        + '## Today\'s date: ' + today + '\n\n'
+        + '## Current relationship file\n\n'
+        + (existingFile || '(empty — first encounter)')
+        + '\n\n## What the ledger records\n\n'
+        + ledgerBlock
+        + '\n\n## What was said in your hearing\n\n'
+        + saidBlock
+        + '\n\n' + LEDGER_PRECEDENCE_DIRECTIVE;
+}
+
 // runPersonContextUpdate — single (agent, person) people-VA invocation,
 // reads the existing context/people/{slug} note, runs the appropriate
 // people VA, optionally writes the result back. Used by:
 //   1. processDreamChunk (per-day dream chunk) — `excerpts` is today's
-//      conversation lines for this person.
+//      speech lines for this person and opts.ledger is the matching
+//      engine-authored action lines, both from buildPersonExcerptSections.
 //   2. /admin/dream/consolidate-people endpoint — `excerpts` is empty
-//      so the VA acts as a consolidate-only pass against bloated files.
+//      and opts.ledger absent, so the VA acts as a consolidate-only pass
+//      against bloated files.
 //
+// opts.ledger = array of ledger lines for this pair (LLM-523). Rendered as
+// its own authoritative section; absent or empty renders an explicit
+// "nothing changed hands" so a spoken promise can't be read as settled.
 // opts.dryRun = true skips the write and returns the proposed updated
 // file in the result so the caller can inspect.
 //
@@ -564,20 +818,11 @@ async function runPersonContextUpdate(agentName, peopleAgentName, slug, display,
         // No existing file — first encounter.
     }
 
-    // Empty excerpts trigger consolidation-only mode. The new prompt
-    // recognizes this signal and either consolidates redundant bullets
-    // or returns the file unchanged if it's already tight.
-    const excerptsBlock = (excerpts && excerpts.trim())
-        ? excerpts
-        : '(no new excerpts since last update — please consolidate any redundant bullets if present, or return file unchanged if already tight)';
-
-    const peopleUserMessage = '## Agent: ' + selfLabel + '\n'
-        + '## Person: ' + display + '\n'
-        + '## Today\'s date: ' + today + '\n\n'
-        + '## Current relationship file\n\n'
-        + (existingFile || '(empty — first encounter)')
-        + '\n\n## Recent conversation excerpts involving ' + display + '\n\n'
-        + excerptsBlock;
+    const peopleUserMessage = buildPersonUserMessage({
+        selfLabel, display, today, existingFile,
+        ledger: opts.ledger,
+        said: excerpts,
+    });
 
     const { text: rawUpdatedFile, truncated: peopleTruncated, finish_reason: peopleFinish } = await invokeAgent(peopleAgentName, {
         userMessage: peopleUserMessage,
@@ -938,16 +1183,21 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
     if (peopleAgentName && !notesMode) {
         try {
             const speakers = extractSpeakers(filtered, selfName);
-            for (const [slug, entry] of speakers) {
-                const { display, lines: personLines } = entry;
-                if (personLines.length === 0) {
+            // Split each person's day into ledger vs. speech before prompting
+            // (LLM-523). The ledger half is recovered from the villager's OWN
+            // lines, which extractSpeakers self-skips — so a person can now have
+            // material worth prompting on even when they said nothing.
+            const sections = buildPersonExcerptSections(filtered, selfName, speakers);
+            for (const [slug, entry] of sections) {
+                const { display, ledger, said } = entry;
+                if (ledger.length === 0 && said.length === 0) {
                     continue;
                 }
                 try {
                     const result = await runPersonContextUpdate(
                         agent.name, peopleAgentName, slug, display,
-                        personLines.join('\n'), chunkDateStr,
-                        { slugPrefix, selfLabel: selfName }
+                        said.join('\n'), chunkDateStr,
+                        { slugPrefix, selfLabel: selfName, ledger }
                     );
                     if (result.written) {
                         logDream('chunk-people-updated', {
@@ -1621,4 +1871,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -477,12 +477,15 @@ function nameMatcher(fragment) {
 
 // Pull the speaker name out of a distilled line's bracket header. Handles every
 // header the pipeline produces — "[Weekday HH:MM Name]" from the sim distiller
-// and "[HH:MM name]" from memory-sync uploads — by stripping a leading weekday
-// and a leading clock time if present, rather than demanding one exact shape.
-// Deliberately more permissive than a timestamp regex: LEDGER_LINE has already
-// accepted the line as authoritative, so a header this can't parse would mean
-// silently dropping a real transaction (code_review, LLM-523). Returns '' when
-// there is no bracket header at all.
+// (formatTimestamp) and "[HH:MM name]" from memory-sync uploads — by stripping
+// a leading weekday and a leading clock time if present, rather than demanding
+// one exact shape.
+//
+// This is a best-effort read, NOT a gate. LEDGER_LINE accepts any bracket
+// header and is the authority on what counts as a ledger line; a header shape
+// this can't reduce (a date prefix, a non-English weekday) just means the
+// caller attributes the line by the names IN it instead of by who recorded it.
+// Nothing is dropped on a parse miss. Returns '' when there's no header at all.
 function ledgerLineSpeaker(line) {
     const header = line.match(/^\[([^\]]+)\]/);
     if (!header) {
@@ -602,22 +605,24 @@ function buildPersonExcerptSections(filtered, selfName, speakers) {
     // engine does not currently push these, but the shape is legal) is filed
     // under that speaker, since it is that person's own recorded act.
     //
-    // A non-self speaker always has a section: this pass and extractSpeakers
+    // A non-self speaker normally has a section: this pass and extractSpeakers
     // read the same `filtered` text, and extractSpeakers creates an entry for
-    // every non-self bracket-header line it sees, ledger lines included. The
-    // guard is there for the one case that isn't reachable from a real line —
-    // a speaker name that doesn't slugify — and drops nothing that could have
-    // been attributed anyway (code_review, LLM-523).
+    // every non-self bracket-header line it sees, ledger lines included.
+    //
+    // When the header doesn't resolve to a section — an unslugifiable name, or
+    // a header shape ledgerLineSpeaker can't reduce (LEDGER_LINE accepts any
+    // bracket header, so it is deliberately the looser of the two) — the line
+    // falls through to name-matching rather than being dropped. That makes the
+    // header parser's strictness non-load-bearing: a transaction is attributed
+    // by whom it NAMES even when we can't tell who recorded it, and an
+    // authoritative line is never silently lost (code_review, LLM-523).
     for (const line of filtered.split('\n')) {
         if (!LEDGER_LINE.test(line)) {
             continue;
         }
         const speakerSlug = personContextSlug(ledgerLineSpeaker(line));
-        if (speakerSlug && speakerSlug !== selfSlug) {
-            const own = sections.get(speakerSlug);
-            if (own) {
-                own.ledger.push(line);
-            }
+        if (speakerSlug && speakerSlug !== selfSlug && sections.has(speakerSlug)) {
+            sections.get(speakerSlug).ledger.push(line);
             continue;
         }
         for (const person of people) {

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -616,6 +616,14 @@ function buildPersonExcerptSections(filtered, selfName, speakers) {
     // header parser's strictness non-load-bearing: a transaction is attributed
     // by whom it NAMES even when we can't tell who recorded it, and an
     // authoritative line is never silently lost (code_review, LLM-523).
+    //
+    // Name-matching deliberately files a line under EVERY known person it
+    // names, not just one. A transaction between two people is part of both
+    // relationships, and a ledger line is a fact — showing it to both parties
+    // can't fabricate anything. In practice this is near-always a single match:
+    // narrateEvent writes from the actor's point of view, so the actor is the
+    // speaker in the header and only the counterparty appears in the narration
+    // ("(earned 4 coins working for Josiah Thorne)").
     for (const line of filtered.split('\n')) {
         if (!LEDGER_LINE.test(line)) {
             continue;

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -351,16 +351,31 @@ test('a ledger line from another speaker is filed under that speaker', () => {
     assert.equal(josiah.said.length, 0, 'a ledger line is never repeated as speech');
 });
 
-test('an unpadded hour and a weekday-less header still attribute (LEDGER_LINE is the gate)', () => {
-    // The header parser must not be stricter than LEDGER_LINE — a shape it
-    // can't read would silently drop an authoritative transaction.
+test('every header form the pipeline emits attributes correctly', () => {
+    // The two producers: sim-conversation-distiller's formatTimestamp
+    // ("[Weekday HH:MM Name]") and memory-sync uploads ("[HH:MM name]"). An
+    // unpadded hour is included because the header parser must not be stricter
+    // than LEDGER_LINE, which is the authority on what counts as a ledger line.
     const log = [
+        '[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)',
         '[Friday 9:05 Constance Scott] (paid Josiah Thorne 2 coins for bread)',
-        '[18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)',
+        '[18:26 Constance Scott] (paid Josiah Thorne 3 coins for cheese)',
         '[Friday 12:01 Josiah Thorne] "Good day."',
     ].join('\n');
     const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
-    assert.equal(josiah.ledger.length, 2);
+    assert.equal(josiah.ledger.length, 3);
+});
+
+test('a header the parser cannot reduce still attributes by the names in the line', () => {
+    // LEDGER_LINE accepts any bracket header, so the speaker parser is a
+    // best-effort read rather than a gate: an unrecognized header shape must
+    // not silently drop an authoritative transaction (code_review, LLM-523).
+    const log = [
+        '[2026-07-15T18:26Z Constance Scott] (paid Josiah Thorne 1 coin for milk)',
+        '[Friday 12:01 Josiah Thorne] "Good day."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    assert.equal(josiah.ledger.length, 1, 'the transaction survives an unparseable header');
 });
 
 test('a name is matched on whole words, not substrings', () => {

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -306,6 +306,25 @@ test('an ambiguous first name is not used to infer an addressee', () => {
 
 // prefilterLog: SIGNAL_PATTERNS are conversational markers, so a bare economic
 // fact carries no signal word and used to survive only by luck of proximity.
+test('a day of pure transactions is not discarded as signal-free', () => {
+    // The early return used to fire whenever SIGNAL_PATTERNS found nothing,
+    // taking the whole chunk with it — dream, learnings and people files. A day
+    // where money moved and nobody chattered is precisely what this change
+    // exists to carry through (code_review, LLM-523).
+    const log = [
+        '[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)',
+        '[Friday 19:49 Constance Scott] (earned 4 coins working for Josiah Thorne)',
+    ].join('\n');
+    const filtered = prefilterLog(log);
+    assert.notEqual(filtered, null, 'a ledger-only day must survive the prefilter');
+    assert.ok(filtered.includes('(paid Josiah Thorne 1 coin for milk)'));
+    assert.ok(filtered.includes('(earned 4 coins working for Josiah Thorne)'));
+});
+
+test('a day with neither signal nor ledger is still discarded', () => {
+    assert.equal(prefilterLog('the weather held\nthe road was dry'), null);
+});
+
 test('prefilterLog keeps a ledger line that carries no conversational signal', () => {
     const log = [
         'I want you to remember this.',
@@ -317,6 +336,53 @@ test('prefilterLog keeps a ledger line that carries no conversational signal', (
         '[Friday 20:03 Constance Scott] (delivered meat to John Ellis for 4 coins)',
     ].join('\n');
     assert.ok(prefilterLog(log).includes('(delivered meat to John Ellis for 4 coins)'));
+});
+
+test('a ledger line from another speaker is filed under that speaker', () => {
+    // Not a shape the engine currently pushes, but a legal one. The two passes
+    // read the same filtered text, so extractSpeakers has already created the
+    // section this lands in.
+    const log = [
+        '[Friday 12:00 Josiah Thorne] (delivered 3x flour to Abraham Warren for 6 coins)',
+        '[Friday 12:01 Constance Scott] "A fair price."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    assert.deepEqual(josiah.ledger, ['[Friday 12:00 Josiah Thorne] (delivered 3x flour to Abraham Warren for 6 coins)']);
+    assert.equal(josiah.said.length, 0, 'a ledger line is never repeated as speech');
+});
+
+test('an unpadded hour and a weekday-less header still attribute (LEDGER_LINE is the gate)', () => {
+    // The header parser must not be stricter than LEDGER_LINE — a shape it
+    // can't read would silently drop an authoritative transaction.
+    const log = [
+        '[Friday 9:05 Constance Scott] (paid Josiah Thorne 2 coins for bread)',
+        '[18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)',
+        '[Friday 12:01 Josiah Thorne] "Good day."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    assert.equal(josiah.ledger.length, 2);
+});
+
+test('a name is matched on whole words, not substrings', () => {
+    const log = [
+        '[Friday 12:00 Josiah Thorne] "The annexed field is Anne\'s no longer."',
+        '[Friday 12:01 Anne Walker] "Aye."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    // "Anne's" is a real mention (apostrophe is a boundary); "annexed" is not,
+    // and on its own would not have triggered the label.
+    assert.ok(josiah.said[0].includes('(overheard — addressed to Anne Walker)'));
+});
+
+test('naming a third party while addressing the current person is not overheard', () => {
+    // The complement of the labeling test: the villager is named, so the line
+    // reads as spoken to her even though it discusses someone else.
+    const log = [
+        '[Friday 12:00 Josiah Thorne] "Constance, John Ellis still owes me two coins."',
+        '[Friday 12:01 John Ellis] "I do not."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    assert.ok(!josiah.said[0].includes('overheard'));
 });
 
 // The assembled prompt. Split out of runPersonContextUpdate precisely so this

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -378,6 +378,22 @@ test('a header the parser cannot reduce still attributes by the names in the lin
     assert.equal(josiah.ledger.length, 1, 'the transaction survives an unparseable header');
 });
 
+test('a ledger line naming two people is filed under both — intended', () => {
+    // A transaction between two people belongs to both relationships, and a
+    // ledger line is a fact, so showing it to both parties fabricates nothing.
+    // Near-always a single match in practice: narrateEvent writes from the
+    // actor's point of view, so only the counterparty appears in the narration
+    // (code_review, LLM-523).
+    const log = [
+        '[Friday 12:00 Constance Scott] (watched Josiah Thorne pay John Ellis 2 coins)',
+        '[Friday 12:01 Josiah Thorne] "Settled."',
+        '[Friday 12:02 John Ellis] "Aye."',
+    ].join('\n');
+    const sections = sectionsFor(log, 'Constance Scott');
+    assert.equal(sections.get('josiah-thorne').ledger.length, 1);
+    assert.equal(sections.get('john-ellis').ledger.length, 1);
+});
+
 test('a name is matched on whole words, not substrings', () => {
     const log = [
         '[Friday 12:00 Josiah Thorne] "The annexed field is Anne\'s no longer."',

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, runPersonContextUpdate, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, prefilterLog, runPersonContextUpdate, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -189,6 +189,191 @@ test('the pooled agent name does NOT self-skip the villager — why selfName thr
     // display name as selfName.
     const speakers = extractSpeakers(SIM_DAY_LOG, 'salem-vendor');
     assert.ok(speakers.has('constance-scott'), 'pooled agent name leaves the villager un-skipped');
+});
+
+// ─── LLM-523: ledger vs. talk in the people-VA prompt ───
+//
+// The defect these cover: extractSpeakers self-skips the villager's own lines
+// (correct — she must not accumulate a people-file about herself), but EVERY
+// ledger event in a sim-day note is spoken by the villager. So 100% of the
+// engine's economic record was dropped before the people prompt was built, and
+// the people-VA had only NPC-authored speech to go on. It duly wrote Josiah's
+// unbacked "six coins to square us up" into durable memory as a completed
+// payment, and turned a 1-coin milk PURCHASE into a gift.
+//
+// Fixture is the shape of Constance Scott's real 2026-07-15 and 2026-07-24
+// days, trimmed to the lines that carry the defect.
+const LEDGER_DAY = [
+    '[Wednesday 17:48 Constance Scott] (offered to work for Josiah Thorne for 4 coins)',
+    '[Wednesday 17:48 Josiah Thorne] "I can offer four coins for a couple of hours\' work, if that suits you."',
+    '[Wednesday 19:49 Constance Scott] (earned 4 coins working for Josiah Thorne)',
+    '[Wednesday 19:49 Constance Scott] (offered to work for Josiah Thorne for 6 coins)',
+    '[Wednesday 20:23 Josiah Thorne] "Fifteen coins for three cuts — that\'s a fair trade, John."',
+    '[Wednesday 20:24 John Ellis] "Good trades, Josiah. Appreciate you keeping the shelves stocked."',
+    '[Wednesday 21:50 Constance Scott] (earned 6 coins working for Josiah Thorne)',
+    '[Wednesday 22:00 Constance Scott] (had stew)',
+    '[Wednesday 22:01 Josiah Thorne] "Off you go, then — safe to you, Constance Scott."',
+].join('\n');
+
+function sectionsFor(log, self) {
+    return buildPersonExcerptSections(log, self, extractSpeakers(log, self));
+}
+
+test('the villager\'s own ledger lines are filed under the person they name', () => {
+    const josiah = sectionsFor(LEDGER_DAY, 'Constance Scott').get('josiah-thorne');
+    assert.deepEqual(josiah.ledger, [
+        '[Wednesday 17:48 Constance Scott] (offered to work for Josiah Thorne for 4 coins)',
+        '[Wednesday 19:49 Constance Scott] (earned 4 coins working for Josiah Thorne)',
+        '[Wednesday 19:49 Constance Scott] (offered to work for Josiah Thorne for 6 coins)',
+        '[Wednesday 21:50 Constance Scott] (earned 6 coins working for Josiah Thorne)',
+    ]);
+});
+
+test('both engagements reach the prompt, so the day\'s full 10 coins are visible', () => {
+    // The bug wrote "offered six coins for two hours shifting crates" and lost
+    // the four-coin job entirely: the ledger was absent and the 4-coin offer had
+    // also been dropped by the signal prefilter.
+    const josiah = sectionsFor(LEDGER_DAY, 'Constance Scott').get('josiah-thorne');
+    const text = josiah.ledger.join('\n');
+    assert.ok(text.includes('earned 4 coins'), 'the four-coin engagement must survive');
+    assert.ok(text.includes('earned 6 coins'), 'the six-coin engagement must survive');
+});
+
+test('a ledger line naming nobody is filed under nobody', () => {
+    const sections = sectionsFor(LEDGER_DAY, 'Constance Scott');
+    for (const [, entry] of sections) {
+        assert.ok(
+            !entry.ledger.some(l => l.includes('(had stew)')),
+            'a solitary act is not a transaction with anyone'
+        );
+    }
+});
+
+test('the villager never gets a section about herself', () => {
+    assert.ok(!sectionsFor(LEDGER_DAY, 'Constance Scott').has('constance-scott'));
+});
+
+// The 07-24 shape — the incident that raised this to High. Josiah SAID he'd
+// paid ten coins and SAID he was handing over six to square up; the only thing
+// that actually happened was Constance buying a jug of milk for one coin.
+const PROMISE_DAY = [
+    '[Friday 18:25 Josiah Thorne] "I paid you ten coins for your labor and added a cut of meat besides, as I recollect."',
+    '[Friday 18:25 Josiah Thorne] "There we are — six coins to square us up, and a fair bit of gratitude besides."',
+    '[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)',
+].join('\n');
+
+test('an unbacked spoken promise produces no ledger entry', () => {
+    const josiah = sectionsFor(PROMISE_DAY, 'Constance Scott').get('josiah-thorne');
+    assert.deepEqual(josiah.ledger, ['[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)']);
+    assert.ok(
+        !josiah.ledger.join('\n').includes('six coins'),
+        'the six-coin restitution was spoken only — it must not appear as fact'
+    );
+    assert.ok(
+        josiah.said.join('\n').includes('six coins to square us up'),
+        'the promise still belongs in the file as something he said'
+    );
+});
+
+test('the ledger keeps transaction direction — a purchase is not a gift', () => {
+    const josiah = sectionsFor(PROMISE_DAY, 'Constance Scott').get('josiah-thorne');
+    assert.ok(josiah.ledger[0].includes('(paid Josiah Thorne 1 coin for milk)'));
+});
+
+test('speech addressed to a third party is labeled overheard', () => {
+    const josiah = sectionsFor(LEDGER_DAY, 'Constance Scott').get('josiah-thorne');
+    const carrots = josiah.said.find(l => l.includes('Fifteen coins for three cuts'));
+    assert.ok(carrots.endsWith('(overheard — addressed to John Ellis)'));
+});
+
+test('speech that names the villager is NOT labeled overheard', () => {
+    const josiah = sectionsFor(LEDGER_DAY, 'Constance Scott').get('josiah-thorne');
+    const farewell = josiah.said.find(l => l.includes('Off you go'));
+    assert.ok(!farewell.includes('overheard'));
+});
+
+test('an ambiguous first name is not used to infer an addressee', () => {
+    // Two Johns in the day: "John" alone identifies nobody, so the line stays
+    // unlabeled rather than being attributed to the wrong man.
+    const log = [
+        '[Friday 12:00 Josiah Thorne] "Fair trade, John."',
+        '[Friday 12:01 John Ellis] "Aye."',
+        '[Friday 12:02 John Proctor] "Aye."',
+    ].join('\n');
+    const josiah = sectionsFor(log, 'Constance Scott').get('josiah-thorne');
+    assert.ok(!josiah.said[0].includes('overheard'));
+});
+
+// prefilterLog: SIGNAL_PATTERNS are conversational markers, so a bare economic
+// fact carries no signal word and used to survive only by luck of proximity.
+test('prefilterLog keeps a ledger line that carries no conversational signal', () => {
+    const log = [
+        'I want you to remember this.',
+        'filler',
+        'filler',
+        'filler',
+        'filler',
+        'filler',
+        '[Friday 20:03 Constance Scott] (delivered meat to John Ellis for 4 coins)',
+    ].join('\n');
+    assert.ok(prefilterLog(log).includes('(delivered meat to John Ellis for 4 coins)'));
+});
+
+// The assembled prompt. Split out of runPersonContextUpdate precisely so this
+// is assertable — that function reaches invokeAgent/readNote through
+// destructured requires that can't be stubbed.
+test('the user message renders ledger and speech as separate sections', () => {
+    const msg = buildPersonUserMessage({
+        selfLabel: 'Constance Scott',
+        display: 'Josiah Thorne',
+        today: '2026-07-24',
+        existingFile: '',
+        ledger: ['[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)'],
+        said: '[Friday 18:25 Josiah Thorne] "six coins to square us up"',
+    });
+    assert.ok(msg.includes('## What the ledger records\n\n[Friday 18:26 Constance Scott] (paid Josiah Thorne 1 coin for milk)'));
+    assert.ok(msg.includes('## What was said in your hearing\n\n[Friday 18:25 Josiah Thorne] "six coins to square us up"'));
+    assert.ok(msg.indexOf('## What the ledger records') < msg.indexOf('## What was said in your hearing'));
+    assert.ok(msg.includes('Where the two disagree, the ledger wins.'));
+});
+
+test('an empty ledger says so explicitly rather than rendering blank', () => {
+    const msg = buildPersonUserMessage({
+        selfLabel: 'Constance Scott',
+        display: 'Josiah Thorne',
+        today: '2026-07-24',
+        existingFile: 'prior file',
+        ledger: [],
+        said: 'he said he would make it right',
+    });
+    assert.ok(msg.includes('(nothing — no coin or goods changed hands between you and Josiah Thorne today)'));
+});
+
+test('consolidation-only mode keeps its sentinel wording', () => {
+    // /admin/dream/consolidate-people drives this mode by passing no excerpts;
+    // the people-VA's system prompt keys off this exact phrasing.
+    const msg = buildPersonUserMessage({
+        selfLabel: 'salem-vendor',
+        display: 'Josiah Thorne',
+        today: '2026-07-24',
+        existingFile: 'bloated file',
+        ledger: undefined,
+        said: '',
+    });
+    assert.ok(msg.includes('(no new excerpts since last update — please consolidate any redundant bullets if present, or return file unchanged if already tight)'));
+});
+
+test('a dedicated NPC agent slug is recognized as its own display name', () => {
+    // A dedicated agent's selfName is the agent slug ('zbbs-josiah-thorne'),
+    // not a display name — so the self-recognition has to slug-to-display it or
+    // every line addressed to Josiah reads as third-party.
+    const log = [
+        '[Friday 12:00 Josiah Thorne] (paid John Ellis 3 coins for meat)',
+        '[Friday 12:01 John Ellis] "Fair trade, Josiah."',
+    ].join('\n');
+    const ellis = sectionsFor(log, 'zbbs-josiah-thorne').get('john-ellis');
+    assert.deepEqual(ellis.ledger, ['[Friday 12:00 Josiah Thorne] (paid John Ellis 3 coins for meat)']);
+    assert.ok(!ellis.said[0].includes('overheard'), 'a line naming Josiah is addressed to Josiah');
 });
 
 // runPersonContextUpdate rejects a non-canonical slug prefix before touching

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -619,5 +619,7 @@ async function distillSimConversationDay(agentName, dayStr, events, opts = {}) {
 }
 
 // narrateEvent is exported for unit tests (sim-conversation-distiller.test.js);
-// distillSimConversationDay is the only production caller.
-module.exports = { distillSimConversationDay, narrateEvent, normalizeSlugPrefix };
+// distillSimConversationDay is the only production caller. slugToDisplay is
+// shared with dream.js, which needs the same slug -> "First Last" rendering to
+// recognize a dedicated NPC's own name in its distilled lines (LLM-523).
+module.exports = { distillSimConversationDay, narrateEvent, normalizeSlugPrefix, slugToDisplay };


### PR DESCRIPTION
## The defect

The dream pipeline's people-VA writes each sim NPC's `context/people/*` relationship files. It was building them from NPC speech alone, and duly canonized talk into durable memory. From Constance Scott's file on Josiah Thorne:

> "Went back to settle a misunderstanding about payment — I thought I'd been shorted, but he... made it right on the spot with **six coins and a jug of milk besides**."

Neither happened. The six coins were spoken and never transferred — no tool call, no transaction. The milk was a **purchase**: `(paid Josiah Thorne 1 coin for milk)`, her coin out. A promise became a settled payment and a purchase became a gratuity, both written into memory that outranks anything else the NPC believes. The pass also deleted the accurate 07-15 labor record it replaced.

## Root cause — one step earlier than [LLM-523](https://jeffdafoe.atlassian.net/browse/LLM-523) describes

`extractSpeakers` self-skips the villager's own lines so she doesn't accumulate a relationship file about herself — correct — but **every ledger event in a sim-day note is spoken by the villager**. Measured on her real days before writing code:

| | 2026-07-15 | 2026-07-24 |
|---|---|---|
| ledger lines surviving `prefilterLog` | 30 | 41 |
| ledger lines reaching *any* `context/people/*` prompt | **0** | **0** (13 person blocks) |

The people-VA had never seen a ledger line. The ticket's proposal — split the excerpt block into ledger vs. talk — would have rendered an **empty ledger section**; the self's action lines have to be re-admitted first. Two further sub-claims in the ticket didn't survive checking; the correction is [in a comment there](https://jeffdafoe.atlassian.net/browse/LLM-523) so it doesn't get quoted downstream as settled.

Compounding: `prefilterLog` reduces the day using conversational markers ("remember", "worried"), so a bare economic fact carried no signal word and survived only by proximity to chatter — and a day of pure transactions returned `null` and was discarded whole. Dropped outright: `(offered to work for Josiah Thorne for 4 coins)`, `(earned 4 coins working for Ezekiel Crane)`, `(delivered meat to John Ellis for 4 coins)`.

## Changes

- **`prefilterLog`** pins ledger lines and no longer discards a ledger-only day. They are deliberately *not* added to `signalLineIndices`, so a talkative day's filtered shape is byte-unchanged.
- **`buildPersonExcerptSections`** (new, pure, exported) recovers the self's ledger lines and files each under every person whose full display name appears in it, and labels third-party speech `(overheard — addressed to X)`. First names are used only when unique among the day's speakers. A header the speaker parser can't reduce falls through to name-matching rather than dropping the line.
- **`buildPersonUserMessage`** (split out of `runPersonContextUpdate` so the prompt is testable) renders `## What the ledger records` before `## What was said in your hearing`, closing with a precedence directive. An **empty ledger states that nothing changed hands** rather than rendering blank — that sentence is what stops a promise reading as settled.
- **MEM-143** carries the matching standing policy into the `dream-sim-people` prompt, previously a DB-only value with no reviewable source, and stops its 500-word trim from deleting a ledger-grounded entry.

## Verification

159 tests pass. Against the two real production days:

- **07-15** — `josiah-thorne` ledger section carries all four lines: both engagements, 10 coins.
- **07-24** — carries only `(paid Josiah Thorne 1 coin for milk)`, so "six coins to square us up" now sits beside a ledger recording no such payment.

`code_review` cleared it over three rounds; round 1 caught a real blocker (the ledger-only day still returned `null`).

## Deploy note

The prompt and the user-message structure are two halves of one change. MEM-143's down migration must be run only alongside a code rollback past this branch; the comment states the contract.

Mechanism: [[shared/notes/codebase/llm-memory-api/sim-conversation-day-push]] § "People files — the ledger outranks talk".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
