### PR TITLE
LLM-532: cross-process advisory-lock guard for runDream()

### DIFF
--- a/node/api/src/services/dream-shared-cron.test.js
+++ b/node/api/src/services/dream-shared-cron.test.js
@@ -24,6 +24,7 @@
 
 const { describe, test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 
 const pool = require('../db');
 const config = require('./config');
@@ -37,6 +38,10 @@ const SYSTEM_ACTOR_ID = 1;
 const POOLED_ACTOR_ID = 42;
 const POOLED_AGENT = 'salem-vendor';
 const CHUNK_FAILURE = 'simulated conversation-log query failure';
+const UNLOCK_FAILURE = 'simulated pg_advisory_unlock failure';
+const ACQUIRE_FAILURE = 'simulated pg_try_advisory_lock failure';
+const CONNECT_FAILURE = 'simulated pool.connect failure';
+const RUN_FAILURE = 'simulated agent-list query failure';
 
 // Midnight-aligned on purpose: computeDailyChunks splits [since, now] on
 // UTC-day boundaries, so an aligned `since` makes the planned chunk count
@@ -179,6 +184,63 @@ function makeQueryStub({ agentRows, rosterRows, chunkResponder, errorLogResponde
     };
 }
 
+// Stand-in for the client runDream checks out to hold the advisory run lock
+// (LLM-532). It answers the two lock statements itself and delegates anything
+// else to the per-test pool.query stub, so a stray query on the lock client
+// still hits that stub's strict unmatched-SQL guard. `granted` false simulates
+// a second run finding the lock already held.
+//
+// Every checkout, lock statement and release is recorded in order, which is
+// what lets the tests below assert the ordering that actually matters: the lock
+// is taken before any run query and released only after the last one.
+// `acquireFails` makes the pg_try_advisory_lock statement throw (an unusable
+// connection); `unlockHeld` false makes pg_advisory_unlock report that this
+// session did not hold the lock. The client is a real EventEmitter so a test
+// can emit 'error' on it mid-run, which is how a dropped connection — and
+// therefore a silently released lock — reaches the code under test.
+function makeLockStub({ granted = true, unlockFails = false, acquireFails = false, unlockHeld = true } = {}) {
+    const events = [];
+    const client = new EventEmitter();
+    client.query = async (sql, params) => {
+        if (sql.includes('pg_try_advisory_lock')) {
+            if (acquireFails) {
+                events.push({ kind: 'acquire-failed' });
+                throw new Error(ACQUIRE_FAILURE);
+            }
+            events.push({ kind: 'acquire', key: params[0], granted });
+            return { rows: [{ ok: granted }] };
+        }
+        if (sql.includes('pg_advisory_unlock')) {
+            events.push({ kind: 'unlock', key: params[0] });
+            if (unlockFails) {
+                throw new Error(UNLOCK_FAILURE);
+            }
+            return { rows: [{ ok: unlockHeld }] };
+        }
+        return pool.query(sql, params);
+    };
+    // release(err) destroys the connection rather than returning it to the
+    // pool; the argument is recorded so the failure paths are checkable.
+    client.release = (err) => {
+        events.push({ kind: 'release', destroyed: Boolean(err) });
+    };
+    return {
+        events,
+        client,
+        // Simulate the connection dropping mid-run. pg's own Pool handler is
+        // what destroys the client in production; here the only listener that
+        // matters is the one the lock installs.
+        killConnection: () => {
+            client.emit('error', new Error('simulated connection loss'));
+        },
+        listenerCount: () => client.listenerCount('error'),
+        connect: async () => {
+            events.push({ kind: 'connect' });
+            return client;
+        },
+    };
+}
+
 // concurrency: 1 is explicit rather than incidental. Every test here swaps
 // process-global state (pool.query, config.get, console.log, cron.schedule), so
 // two of them running at once would corrupt each other. node:test currently
@@ -193,8 +255,12 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
     // fire-and-forget insert reports its own failure.
     let dreamEvents = [];
     let consoleErrors = [];
+    // The default lock stub: granted. A test that needs the contended path
+    // reassigns this and pool.connect before calling runDream.
+    let lockStub;
 
     let originalQuery;
+    let originalConnect;
     let originalConfigGet;
     let originalCronSchedule;
     let originalCronValidate;
@@ -203,6 +269,7 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
 
     beforeEach(() => {
         originalQuery = pool.query;
+        originalConnect = pool.connect;
         originalConfigGet = config.get;
         originalCronSchedule = cron.schedule;
         originalCronValidate = cron.validate;
@@ -210,6 +277,10 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
         originalConsoleError = console.error;
         dreamEvents = [];
         consoleErrors = [];
+        // Without this every test would try to open a real connection for the
+        // run lock, since runDream now takes it before doing anything else.
+        lockStub = makeLockStub();
+        pool.connect = lockStub.connect;
         // Both services cache by actor across calls; a stale entry from a
         // previous test would let a later test pass without its stub consulted.
         actors.clearCache();
@@ -233,6 +304,7 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
 
     afterEach(() => {
         pool.query = originalQuery;
+        pool.connect = originalConnect;
         config.get = originalConfigGet;
         cron.schedule = originalCronSchedule;
         cron.validate = originalCronValidate;
@@ -508,6 +580,238 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
         // The valid villager still dreamed.
         assert.equal(shared.actors[1].prefix, 'josiah-thorne/');
         assert.ok(shared.actors[1].completedChunks > 0);
+    });
+
+    // --- LLM-532: the advisory run lock ---------------------------------
+    //
+    // What the lock buys is negative: a second concurrent run must not read a
+    // cursor, plan a window, or stamp progress. So these assert on what does
+    // NOT happen (no query at all on the contended path) as much as on the
+    // returned summary.
+
+    test('a second run finds the lock held and returns without touching anything', async () => {
+        lockStub = makeLockStub({ granted: false });
+        pool.connect = lockStub.connect;
+        // Any query at all would mean the guard let the run start.
+        pool.query = async (sql) => {
+            throw new Error('no query should run while the lock is held: ' + sql.trim().slice(0, 60));
+        };
+
+        const result = await runDream();
+
+        assert.deepEqual(result, { skipped: true, reason: 'already running' });
+
+        // Nothing to unlock when the lock was never granted — but the checked-out
+        // connection still goes back to the pool intact, not destroyed.
+        assert.deepEqual(
+            lockStub.events.map(e => e.kind),
+            ['connect', 'acquire', 'release']
+        );
+        assert.equal(lockStub.events[1].granted, false);
+        assert.equal(lockStub.events[2].destroyed, false);
+        // No unlock: unlocking a lock this session never held would be a no-op
+        // at best, and at worst hides the contention.
+        assert.equal(lockStub.events.some(e => e.kind === 'unlock'), false);
+        // The listener is gone, so a pooled connection doesn't accumulate one
+        // per contended run.
+        assert.equal(lockStub.listenerCount(), 0);
+
+        const skip = dreamEvents.find(e => e.action === 'skip');
+        assert.ok(skip, 'no skip event emitted');
+        assert.equal(skip.details.reason, 'another dream run holds the lock');
+        // A contended run is not a failed run: nothing lands in error_log.
+        assert.equal(dreamEvents.some(e => e.action === 'error'), false);
+    });
+
+    test('the lock is taken before any run query and released only after the last one', async () => {
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [rosterRow('constance-scott/', 'Constance Scott', midnightAlignedSince(1))],
+            chunkResponder: () => [],
+        });
+        // Fold the run's queries into the lock timeline so the ordering the
+        // guard depends on — lock held across the WHOLE run, not just its first
+        // statement — is directly observable.
+        pool.query = async (sql, params) => {
+            lockStub.events.push({ kind: 'query' });
+            return stub.query(sql, params);
+        };
+
+        const result = await runDream();
+        assert.equal(result.failedSharedActorCount, 0);
+        assert.ok(stub.cursorUpdates.length > 0, 'the run did no work to bracket');
+
+        const kinds = lockStub.events.map(e => e.kind);
+        assert.deepEqual(kinds.slice(0, 2), ['connect', 'acquire']);
+        assert.deepEqual(kinds.slice(-2), ['unlock', 'release']);
+        assert.ok(
+            kinds.indexOf('query') > kinds.indexOf('acquire'),
+            'a run query ran before the lock was acquired'
+        );
+        assert.ok(
+            kinds.lastIndexOf('query') < kinds.indexOf('unlock'),
+            'a run query ran after the lock was released'
+        );
+
+        // Acquire and release must name the same key, or the unlock is a no-op
+        // and the lock leaks for the life of the connection.
+        const acquire = lockStub.events.find(e => e.kind === 'acquire');
+        const unlock = lockStub.events.find(e => e.kind === 'unlock');
+        assert.equal(acquire.key, unlock.key);
+        assert.equal(lockStub.events.find(e => e.kind === 'release').destroyed, false);
+    });
+
+    test('a run that throws still releases the lock', async () => {
+        const stub = makeQueryStub({
+            agentRows: [],
+            rosterRows: [],
+            chunkResponder: () => [],
+        });
+        pool.query = async (sql, params) => {
+            if (sql.includes('FROM agent_configuration agc')) {
+                throw new Error(RUN_FAILURE);
+            }
+            return stub.query(sql, params);
+        };
+
+        await assert.rejects(runDream, new RegExp(RUN_FAILURE));
+
+        // Released in a finally, so the next run — the 04:00 cron after a failed
+        // manual one — is not locked out.
+        assert.deepEqual(
+            lockStub.events.map(e => e.kind),
+            ['connect', 'acquire', 'unlock', 'release']
+        );
+    });
+
+    test('an unlock that fails destroys the connection rather than stranding the lock', async () => {
+        lockStub = makeLockStub({ unlockFails: true });
+        pool.connect = lockStub.connect;
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [],
+            chunkResponder: () => [],
+        });
+        pool.query = stub.query;
+
+        // The run's own result is unaffected — the unlock failure happens after
+        // the work is done and must not turn a clean run into a rejection.
+        const result = await runDream();
+        assert.equal(result.failedSharedActorCount, 0);
+
+        // Destroying the connection ends the session, and Postgres drops
+        // session-scoped advisory locks with it.
+        const release = lockStub.events.find(e => e.kind === 'release');
+        assert.equal(release.destroyed, true);
+
+        const failure = dreamEvents.find(e => e.action === 'lock-release-error');
+        assert.ok(failure, 'no lock-release-error event emitted');
+        assert.equal(failure.details.error, UNLOCK_FAILURE);
+    });
+
+    // The lock's failure mode that matters: if its Postgres session dies the
+    // lock is released while the run is still going, and another run can start
+    // on the same cursors. The run must stop rather than keep writing.
+    test('a lock lost mid-run aborts the run before the next cursor write', async () => {
+        const since = midnightAlignedSince(3);
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [rosterRow('constance-scott/', 'Constance Scott', since)],
+            chunkResponder: () => [],
+        });
+        // Kill the connection after the first chunk's cursor advance. The lock
+        // is checked at the top of each chunk, so the run should stop there —
+        // with the completed chunk's cursor write kept and no further ones.
+        pool.query = async (sql, params) => {
+            const result = await stub.query(sql, params);
+            if (sql.includes('UPDATE sim_shared_actor SET last_dream_at') && stub.cursorUpdates.length === 1) {
+                lockStub.killConnection();
+            }
+            return result;
+        };
+
+        assert.ok(expectedChunkCount(since, Date.now()) > 1, 'need a multi-chunk window to observe the abort');
+        await assert.rejects(runDream, /dream run lock lost/);
+
+        // The whole point: no cursor advanced after the lock was gone.
+        assert.equal(stub.cursorUpdates.length, 1);
+
+        const lostEvent = dreamEvents.find(e => e.action === 'lock-connection-error');
+        assert.ok(lostEvent, 'the connection loss was not logged');
+
+        // Still released — the finally runs on the failure path too, so the
+        // pooled connection is not leaked along with the run.
+        assert.deepEqual(
+            lockStub.events.map(e => e.kind),
+            ['connect', 'acquire', 'unlock', 'release']
+        );
+        assert.equal(lockStub.listenerCount(), 0);
+    });
+
+    test('an unlock reporting the lock was not held is logged, not swallowed', async () => {
+        lockStub = makeLockStub({ unlockHeld: false });
+        pool.connect = lockStub.connect;
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [],
+            chunkResponder: () => [],
+        });
+        pool.query = stub.query;
+
+        await runDream();
+
+        // ok=false means this session did not hold the lock when it unlocked —
+        // i.e. it was lost at some point. Nothing to clean up, but it is the
+        // only evidence of a window where a second run could have started.
+        const notHeld = dreamEvents.find(e => e.action === 'lock-release-not-held');
+        assert.ok(notHeld, 'a false pg_advisory_unlock result was ignored');
+    });
+
+    test('a connection that cannot be checked out fails the run without any query', async () => {
+        pool.connect = async () => {
+            throw new Error(CONNECT_FAILURE);
+        };
+        pool.query = async () => {
+            throw new Error('no query should run when the lock connection is unavailable');
+        };
+
+        await assert.rejects(runDream, new RegExp(CONNECT_FAILURE));
+    });
+
+    test('a failed lock acquisition destroys the connection and fails the run', async () => {
+        lockStub = makeLockStub({ acquireFails: true });
+        pool.connect = lockStub.connect;
+        pool.query = async () => {
+            throw new Error('no query should run when the lock could not be acquired');
+        };
+
+        await assert.rejects(runDream, new RegExp(ACQUIRE_FAILURE));
+
+        // A connection whose lock statement failed is suspect: returning it to
+        // the pool intact would hand the next borrower a broken session.
+        assert.deepEqual(
+            lockStub.events.map(e => e.kind),
+            ['connect', 'acquire-failed', 'release']
+        );
+        assert.equal(lockStub.events[2].destroyed, true);
+        assert.equal(lockStub.listenerCount(), 0);
+    });
+
+    test('a disabled run never checks out a connection for the lock', async () => {
+        config.get = (key) => {
+            if (key === 'dream_processing_enabled') {
+                return 'false';
+            }
+            throw new Error('unexpected config key in test: ' + key);
+        };
+        pool.query = async () => {
+            throw new Error('no query should run when dream processing is disabled');
+        };
+
+        const result = await runDream();
+
+        assert.deepEqual(result, { skipped: true, reason: 'disabled' });
+        assert.deepEqual(lockStub.events, []);
     });
 
     test('a sim-shared agent misconfigured to notes source is rejected without dreaming', async () => {

--- a/node/api/src/services/dream-shared-cron.test.js
+++ b/node/api/src/services/dream-shared-cron.test.js
@@ -201,6 +201,19 @@ function makeQueryStub({ agentRows, rosterRows, chunkResponder, errorLogResponde
 function makeLockStub({ granted = true, unlockFails = false, acquireFails = false, unlockHeld = true } = {}) {
     const events = [];
     const client = new EventEmitter();
+    // Postgres names a result column after the function unless the query
+    // aliases it, so an unaliased `SELECT pg_advisory_unlock($1)` returns
+    // { pg_advisory_unlock: true } and reading `.ok` off it is always
+    // undefined — a silent misread of every lock result. Answering with the
+    // column name the SQL actually asks for is what keeps this stub honest:
+    // drop the alias in dream.js and the lock tests fail rather than pass
+    // against a shape production never returns.
+    function lockRow(sql, functionName, value) {
+        const aliased = /\bAS\s+ok\b/i.test(sql);
+        const column = aliased ? 'ok' : functionName;
+        return { rows: [{ [column]: value }] };
+    }
+
     client.query = async (sql, params) => {
         if (sql.includes('pg_try_advisory_lock')) {
             if (acquireFails) {
@@ -208,14 +221,14 @@ function makeLockStub({ granted = true, unlockFails = false, acquireFails = fals
                 throw new Error(ACQUIRE_FAILURE);
             }
             events.push({ kind: 'acquire', key: params[0], granted });
-            return { rows: [{ ok: granted }] };
+            return lockRow(sql, 'pg_try_advisory_lock', granted);
         }
         if (sql.includes('pg_advisory_unlock')) {
             events.push({ kind: 'unlock', key: params[0] });
             if (unlockFails) {
                 throw new Error(UNLOCK_FAILURE);
             }
-            return { rows: [{ ok: unlockHeld }] };
+            return lockRow(sql, 'pg_advisory_unlock', unlockHeld);
         }
         return pool.query(sql, params);
     };
@@ -746,6 +759,77 @@ describe('shared-VA dream cron', { concurrency: 1 }, () => {
             ['connect', 'acquire', 'unlock', 'release']
         );
         assert.equal(lockStub.listenerCount(), 0);
+    });
+
+    // The window the per-chunk check cannot cover on its own: a chunk spends
+    // minutes in a model call, and the lock can die inside it. The cursor write
+    // that follows is the data-losing operation, so it gets its own check.
+    test('a lock lost during a chunk stops that chunk from advancing the cursor', async () => {
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [rosterRow('constance-scott/', 'Constance Scott', midnightAlignedSince(1))],
+            chunkResponder: () => [],
+        });
+        // Kill the connection during the FIRST chunk's own query — after the
+        // top-of-chunk check has already passed.
+        pool.query = async (sql, params) => {
+            if (sql.includes('FROM documents') && sql.includes('created_at >')) {
+                lockStub.killConnection();
+            }
+            return stub.query(sql, params);
+        };
+
+        await assert.rejects(runDream, /dream run lock lost/);
+        assert.equal(stub.cursorUpdates.length, 0, 'a cursor advanced after the lock was lost');
+    });
+
+    // A clean run must not report a release anomaly. This is the regression
+    // test for the result-column alias: without `AS ok` the unlock result is
+    // keyed pg_advisory_unlock, reads as not-held, and every healthy run would
+    // log a lost lock (see lockRow in makeLockStub).
+    test('a clean run unlocks without reporting the lock as unheld', async () => {
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            rosterRows: [rosterRow('constance-scott/', 'Constance Scott', midnightAlignedSince(1))],
+            chunkResponder: () => [],
+        });
+        pool.query = stub.query;
+
+        const result = await runDream();
+
+        assert.equal(result.failedSharedActorCount, 0);
+        assert.equal(
+            dreamEvents.some(e => e.action === 'lock-release-not-held'),
+            false,
+            'a successful unlock was misread as the lock not being held'
+        );
+        assert.equal(dreamEvents.some(e => e.action === 'lock-release-error'), false);
+    });
+
+    // Loss after the last work boundary: no later check would see it, so the
+    // run would otherwise return a clean summary for work that may have raced
+    // another run.
+    test('a loss observed after the work finishes still fails the run', async () => {
+        const stub = makeQueryStub({
+            agentRows: [sharedAgentRow()],
+            // Empty roster: the roster query is the run's last statement, so
+            // nothing but the final check can catch a loss here.
+            rosterRows: [],
+            chunkResponder: () => [],
+        });
+        pool.query = async (sql, params) => {
+            const result = await stub.query(sql, params);
+            if (sql.includes('FROM sim_shared_actor')) {
+                lockStub.killConnection();
+            }
+            return result;
+        };
+
+        await assert.rejects(runDream, /dream run lock lost/);
+        assert.deepEqual(
+            lockStub.events.map(e => e.kind),
+            ['connect', 'acquire', 'unlock', 'release']
+        );
     });
 
     test('an unlock reporting the lock was not held is logged, not swallowed', async () => {

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -1800,6 +1800,15 @@ async function acquireDreamRunLock() {
 // silently loses a day. Failing loudly here is the point — a run that keeps
 // going without its lock is the bug this ticket fixes, wearing a lock's
 // clothes. It cannot interrupt an in-flight query, only stop the next one.
+//
+// The exact guarantee, so nobody reads more into it than it gives: NO further
+// unit of work or cursor write is started after a lock loss THIS PROCESS HAS
+// OBSERVED. The check and the cursor write are not atomic with lock ownership
+// — a session that dies in the microseconds between them still lets that one
+// write through. Making that impossible would mean issuing the cursor UPDATE
+// on the lock-holding client itself (a write on the session that holds the
+// lock either happens under the lock or fails with the session), which is a
+// larger change than the guard and is deliberately not done here.
 function throwIfRunLockLost(lock) {
     if (lock && lock.lost()) {
         throw new RunLockLostError('dream run lock lost: its Postgres session ended mid-run, so another run may already hold the lock');

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -1726,9 +1726,14 @@ async function acquireDreamRunLock() {
     // If this connection dies mid-run its session ends and Postgres releases
     // the lock — at which point another run can acquire it while this one is
     // still advancing cursors, which is exactly the race the lock exists to
-    // prevent. pg's Pool attaches its own error handler and destroys the
-    // client, so this listener's job is to record that the lock is GONE.
+    // prevent. So the listener records that the lock is GONE, and
     // throwIfRunLockLost() below turns that into an aborted run.
+    //
+    // It is also what keeps that event handled at all: pg's Pool REMOVES its
+    // own idle error listener for as long as a client is checked out
+    // (pg-pool's _acquireClient / _release pair), and an 'error' event with no
+    // listener is thrown by EventEmitter — which on a checked-out connection
+    // would take the API service process down, not just the run.
     function onConnectionError(err) {
         lockLost = true;
         logDream('lock-connection-error', { error: err.message });

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -1364,12 +1364,17 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
 // earlier work; a failed chunk stops this identity's remaining chunks (so we
 // never skip past unprocessed logs) and the next cron retries it. Returns the
 // per-chunk result array.
-async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor) {
+async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor, lock) {
     const interChunkDelay = parseInt(config.get('dream_interchunk_delay')) || 1000;
     const chunkResults = [];
 
     for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
+        // Outside the try on purpose: a lost lock aborts the run rather than
+        // being recorded as this chunk's error. Checked here because the next
+        // statements are a model call and a cursor advance — the two things
+        // that must not happen while another run may be doing the same.
+        throwIfRunLockLost(lock);
         try {
             const r = await processDreamChunk(agent, agentNames, chunk, scope);
             chunkResults.push(r);
@@ -1438,7 +1443,7 @@ function countFailedActors(actorResults) {
 // actor_narrative_state.about_me (LLM-199), not a note. The roster only holds
 // villagers that have landed at least one non-empty day (the distiller
 // enrolls on first material), so no empty-namespace villager reaches here.
-async function processSharedAgent(agent, simAgents, results) {
+async function processSharedAgent(agent, simAgents, results, lock) {
     const { simAgentName, simPeopleAgentName, simLearningsAgentName } = simAgents;
     if (!simAgentName) {
         results.push({ agent: agent.name, mode: 'sim-shared', failedActorCount: 1, error: 'dream-sim agent not available' });
@@ -1480,8 +1485,11 @@ async function processSharedAgent(agent, simAgents, results) {
     let setupError = null;
     let rosterSize = 0;
     try {
-        rosterSize = await dreamSharedRoster(agent, agentNames, actorResults);
+        rosterSize = await dreamSharedRoster(agent, agentNames, actorResults, lock);
     } catch (err) {
+        if (err instanceof RunLockLostError) {
+            throw err;
+        }
         // A roster-query or other setup failure — record it and fall through so
         // any partial actorResults are still reported, not discarded.
         logDream('shared-agent-error', { agent: agent.name, error: err.message });
@@ -1521,7 +1529,7 @@ async function processSharedAgent(agent, simAgents, results) {
 // reference). Separated from processSharedAgent so a roster/setup failure here
 // is caught by the caller — which still emits one aggregate result preserving
 // whatever villagers were already processed. Returns the roster size.
-async function dreamSharedRoster(agent, agentNames, actorResults) {
+async function dreamSharedRoster(agent, agentNames, actorResults, lock) {
     const roster = await pool.query(
         `SELECT slug_prefix, display_name, last_dream_at
          FROM sim_shared_actor
@@ -1540,6 +1548,9 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
         const rowPrefix = actorRow.slug_prefix;
         // Declared before the try so the catch below can still reference it.
         let slugPrefix = '';
+        // Before the try, so a lost lock aborts the roster instead of being
+        // filed as this villager's error (see runChunkLoop).
+        throwIfRunLockLost(lock);
         try {
             // Validate the roster prefix at this boundary — DB/operator-
             // controlled state, not trusted just because the distiller normally
@@ -1624,7 +1635,8 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
                     `UPDATE sim_shared_actor SET last_dream_at = $1
                      WHERE shared_actor_id = $2 AND slug_prefix = $3`,
                     [chunkTo, agent.actor_id, rowPrefix]
-                )
+                ),
+                lock
             );
             // Report planned vs completed separately — runChunkLoop stops on the
             // first failed chunk, so chunks.length alone would overstate progress
@@ -1637,6 +1649,9 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
                 chunks: chunkResults,
             });
         } catch (actorErr) {
+            if (actorErr instanceof RunLockLostError) {
+                throw actorErr;
+            }
             const prefix = slugPrefix || rowPrefix;
             logDream('shared-actor-error', { agent: agent.name, prefix, error: actorErr.message });
             logError('dream', 'shared-actor-error', {
@@ -1658,15 +1673,146 @@ async function dreamSharedRoster(agent, agentNames, actorResults) {
     return roster.rows.length;
 }
 
-// Run the dream processing job.
-// Returns a summary object with counts and any errors.
+// Losing the run lock aborts the WHOLE run, so it needs its own type: every
+// loop below catches per-item errors and carries on to the next agent/villager/
+// chunk, which is right for a bad roster row and wrong for a lost lock. Each of
+// those catches rethrows this one.
+class RunLockLostError extends Error {}
+
+// Advisory lock key for the dream run (LLM-532). Advisory lock keys are
+// arbitrary integers, but each lock needs its own and a key must never be
+// reused — two jobs sharing a key would exclude each other for no reason.
+// Convention for new locks: <ticket number>001. Registry for this database:
+//   532001 — the dream run (LLM-532). The only advisory lock in the app.
+const DREAM_RUN_LOCK_KEY = 532001;
+
+// Take the dream-run lock. Returns a handle with release(), or null when
+// another run already holds it.
+//
+// The lock is what stops two overlapping runs from racing on the same
+// last_dream_at cursors: both would read the same cursor, plan overlapping day
+// windows, and whichever wrote last would advance the cursor past days the
+// other run never processed — permanently outside every future window, with no
+// error raised. The nightly cron runs inside the API service process while
+// operator/verification runs are separate processes, so the guard has to be
+// cross-process; an in-process flag would not see the other run.
+//
+// Advisory rather than a `running` flag column, deliberately: Postgres drops
+// the lock when the session ends, so a crashed or killed run leaves nothing
+// stuck and needs no stale-lock sweep.
+//
+// The subtlety worth knowing: advisory locks are SESSION-scoped, and this app
+// talks to Postgres through a connection pool. The lock therefore lives on a
+// client checked out explicitly with pool.connect() and held for the entire
+// run. Taking it via pool.query() would hand that connection straight back to
+// the pool and drop the lock with it, leaving a guard that silently does
+// nothing.
+async function acquireDreamRunLock() {
+    const client = await pool.connect();
+    let lockLost = false;
+    let released = false;
+
+    // If this connection dies mid-run its session ends and Postgres releases
+    // the lock — at which point another run can acquire it while this one is
+    // still advancing cursors, which is exactly the race the lock exists to
+    // prevent. pg's Pool attaches its own error handler and destroys the
+    // client, so this listener's job is to record that the lock is GONE.
+    // throwIfRunLockLost() below turns that into an aborted run.
+    function onConnectionError(err) {
+        lockLost = true;
+        logDream('lock-connection-error', { error: err.message });
+    }
+    client.on('error', onConnectionError);
+
+    // Idempotent: a second call is a no-op rather than a second unlock on a
+    // connection that has already gone back to the pool (and may by then
+    // belong to someone else).
+    async function release() {
+        if (released) {
+            return;
+        }
+        released = true;
+        let releaseError = null;
+        try {
+            const result = await client.query('SELECT pg_advisory_unlock($1)', [DREAM_RUN_LOCK_KEY]);
+            if (!result.rows[0] || result.rows[0].ok !== true) {
+                // false means this session did not hold the lock — it was lost
+                // mid-run. Nothing to clean up, but it explains how a second run
+                // could have started, so it must not pass silently.
+                lockLost = true;
+                logDream('lock-release-not-held', {});
+            }
+        } catch (err) {
+            logDream('lock-release-error', { error: err.message });
+            releaseError = err;
+        }
+        // Removed only now, so a connection error DURING the unlock is still
+        // reported as lock-connection-error rather than swallowed.
+        client.removeListener('error', onConnectionError);
+        // A truthy argument makes pg destroy the connection instead of
+        // returning it to the pool: the session state after a failed unlock is
+        // unknown, and ending the session is itself a guaranteed lock release.
+        client.release(releaseError);
+    }
+
+    try {
+        const result = await client.query('SELECT pg_try_advisory_lock($1) AS ok', [DREAM_RUN_LOCK_KEY]);
+        if (result.rows[0] && result.rows[0].ok === true) {
+            return { lost: () => lockLost, release };
+        }
+        // Not granted: nothing to unlock, and the connection is healthy, so it
+        // goes back to the pool intact.
+        client.removeListener('error', onConnectionError);
+        client.release();
+        return null;
+    } catch (err) {
+        client.removeListener('error', onConnectionError);
+        // The acquisition statement failed, so this connection is suspect —
+        // destroy it rather than hand a possibly-broken one to the next
+        // borrower.
+        client.release(err);
+        throw err;
+    }
+}
+
+// Abort the run if its lock is gone. Called at every point where the run is
+// about to start a new unit of work or write a cursor: once the lock is lost a
+// second run can be underway, and two runs racing on last_dream_at is what
+// silently loses a day. Failing loudly here is the point — a run that keeps
+// going without its lock is the bug this ticket fixes, wearing a lock's
+// clothes. It cannot interrupt an in-flight query, only stop the next one.
+function throwIfRunLockLost(lock) {
+    if (lock && lock.lost()) {
+        throw new RunLockLostError('dream run lock lost: its Postgres session ended mid-run, so another run may already hold the lock');
+    }
+}
+
+// Run the dream processing job, serialized against any other run (see
+// acquireDreamRunLock). Returns a summary object with counts and any errors.
 async function runDream() {
-    // Check global switch
+    // Check global switch. Before the lock: a disabled run has nothing to
+    // exclude and shouldn't check out a connection to discover that.
     if (config.get('dream_processing_enabled') !== 'true') {
         logDream('skip', { reason: 'dream_processing_enabled is false' });
         return { skipped: true, reason: 'disabled' };
     }
 
+    const lock = await acquireDreamRunLock();
+    if (!lock) {
+        logDream('skip', { reason: 'another dream run holds the lock' });
+        return { skipped: true, reason: 'already running' };
+    }
+
+    try {
+        return await runDreamAgents(lock);
+    } finally {
+        await lock.release();
+    }
+}
+
+// The run itself — every cursor read and write below is serialized by the
+// caller's run lock, and aborts if that lock is lost mid-run.
+async function runDreamAgents(lock) {
     // Find dream agents by expertise tag
     const companionAgentName = await findDreamAgent('dream-companion');
     const technicalAgentName = await findDreamAgent('dream-technical');
@@ -1705,6 +1851,9 @@ async function runDream() {
     const results = [];
 
     for (const agent of agents.rows) {
+        // Before the try: a lost lock ends the run rather than being recorded
+        // as this agent's error (see runChunkLoop).
+        throwIfRunLockLost(lock);
         try {
             if (agent.dream_mode === 'sim-shared') {
                 // Pooled shared-VA agent: fan out over its villager roster on a
@@ -1714,7 +1863,8 @@ async function runDream() {
                 await processSharedAgent(
                     agent,
                     { simAgentName, simPeopleAgentName, simLearningsAgentName },
-                    results
+                    results,
+                    lock
                 );
                 continue;
             }
@@ -1803,7 +1953,8 @@ async function runDream() {
                 (chunkTo) => pool.query(
                     'UPDATE agent_configuration SET last_dream_at = $1 WHERE actor_id = $2',
                     [chunkTo, agent.actor_id]
-                )
+                ),
+                lock
             );
 
             results.push({
@@ -1813,6 +1964,9 @@ async function runDream() {
                 chunks: chunkResults,
             });
         } catch (err) {
+            if (err instanceof RunLockLostError) {
+                throw err;
+            }
             logDream('error', { agent: agent.name, error: err.message });
             // Also surface in the admin error_log so per-agent failures aren't
             // silently swallowed (the outer cron-level catch only fires if

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -1378,8 +1378,19 @@ async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor, loc
         try {
             const r = await processDreamChunk(agent, agentNames, chunk, scope);
             chunkResults.push(r);
+            // Re-checked here because the chunk above spends minutes in a model
+            // call, which is ample time for the lock's session to die. The
+            // cursor write is the one operation that loses data when two runs
+            // race, so it gets the check closest to it. (The model call itself
+            // can't be interrupted — only the write can be withheld.)
+            throwIfRunLockLost(lock);
             await advanceCursor(chunk.to);
         } catch (chunkErr) {
+            // The post-model check above throws from INSIDE this try — a lost
+            // lock is an aborted run, not this chunk's failure.
+            if (chunkErr instanceof RunLockLostError) {
+                throw chunkErr;
+            }
             const chunkDate = chunk.from.toISOString().slice(0, 10);
             const errDetail = { agent: agent.name, chunkDate, error: chunkErr.message };
             if (scope.slugPrefix) {
@@ -1734,7 +1745,10 @@ async function acquireDreamRunLock() {
         released = true;
         let releaseError = null;
         try {
-            const result = await client.query('SELECT pg_advisory_unlock($1)', [DREAM_RUN_LOCK_KEY]);
+            // AS ok is load-bearing: unaliased, Postgres names the column
+            // after the function, and every successful unlock would read as
+            // "not held".
+            const result = await client.query('SELECT pg_advisory_unlock($1) AS ok', [DREAM_RUN_LOCK_KEY]);
             if (!result.rows[0] || result.rows[0].ok !== true) {
                 // false means this session did not hold the lock — it was lost
                 // mid-run. Nothing to clean up, but it explains how a second run
@@ -1804,7 +1818,12 @@ async function runDream() {
     }
 
     try {
-        return await runDreamAgents(lock);
+        const result = await runDreamAgents(lock);
+        // A loss between the last work boundary and here would otherwise be
+        // reported as a clean run. Any observed loss fails the run: the cursors
+        // this run wrote may have raced another run's.
+        throwIfRunLockLost(lock);
+        return result;
     } finally {
         await lock.release();
     }


### PR DESCRIPTION
Closes [LLM-532](https://jeffdafoe.atlassian.net/browse/LLM-532).

Two concurrent dream runs both read the same `last_dream_at` cursors, plan overlapping day windows, and race on the cursor `UPDATE`. The later write can advance the cursor past days the other run never processed, putting that day permanently outside every future window — with no error, and both runs reporting success. It is reachable today: the nightly cron runs inside the API service process while operator/verification runs are separate processes, so the guard has to be cross-process.

## The guard

`runDream()` takes a session-scoped Postgres advisory lock (key `532001`) on a client checked out with `pool.connect()` and held for the whole run; a second run returns `{ skipped: true, reason: 'already running' }` without reading a cursor or writing a note. Advisory rather than a `running` flag column because Postgres drops the lock when the session ends, so a killed run leaves nothing stuck and needs no stale-lock sweep.

The lock lives on an explicitly checked-out client because advisory locks are session-scoped: taking one via `pool.query()` would hand the connection straight back to the pool and drop the lock with it.

## A lost lock aborts the run

If the lock's session dies mid-run Postgres releases it, and another run can start while this one is still advancing cursors. `RunLockLostError` is checked at each agent, villager and chunk boundary, and again immediately before each cursor write; the per-item catches rethrow it rather than filing it as one agent's or villager's failure.

The guarantee, stated in the code: no further unit of work or cursor write is started after a lock loss this process has observed. The check and the write are not atomic with lock ownership — closing that would mean issuing the cursor `UPDATE` on the lock-holding client, which is a larger change than the guard and deliberately not done here.

## Notes

- `SELECT pg_advisory_unlock($1) AS ok` — the alias is load-bearing: unaliased, Postgres names the column after the function and every successful unlock reads as "not held". The test stub derives the result column from the SQL it is handed, so dropping the alias fails the tests instead of passing against a shape production never returns.
- The connection `error` listener is also what keeps that event handled: pg-pool detaches its own idle listener while a client is checked out, and an unhandled `error` event would take the service process down.
- `release()` is idempotent (pg-pool throws on double release) and passes the error through on failure, so the connection is destroyed rather than returned in an unknown session state.

## Tests

12 cases over the guard in `dream-shared-cron.test.js`: contention, the lock bracket around the whole run, release on a throwing run, a lock lost before/during a chunk, a loss observed after the last work boundary, and the connect/acquire/unlock failure paths. `npm test`: 172/172.

The lost-lock guard and the unlock alias were both mutation-verified — removed, test fails; restored, passes.

Reviewed by code_review (GPT-5.4) over four rounds; it found the alias bug and the post-model cursor window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)