### PR TITLE
LLM-558: log client-declared MCP capabilities on initialize

### DIFF
--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -1645,7 +1645,18 @@ router.post('/mcp', mcpAuth, async (req, res) => {
         origin: req.headers['origin'] || null,
         referer: req.headers['referer'] || null,
         host: req.headers['host'] || null,
-        allHeaders: Object.keys(req.headers).sort()
+        allHeaders: Object.keys(req.headers).sort(),
+        // DIAG: which protocol revision and capabilities each client negotiates.
+        // Gates whether MCP Tasks is worth implementing server-side — Tasks is
+        // capability-negotiated, so if no client advertises it, server-side task
+        // plumbing would be dead weight. `method` is logged too because a request
+        // with no session ID is *usually* an initialize but isn't guaranteed to be
+        // one; without it, three nulls are ambiguous between "client declared
+        // nothing" and "this wasn't an initialize at all".
+        method: req.body?.method || null,
+        protocolVersion: req.body?.params?.protocolVersion || null,
+        clientInfo: req.body?.params?.clientInfo || null,
+        capabilities: req.body?.params?.capabilities || null
     }));
 
     const transport = new StreamableHTTPServerTransport({

--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -1598,6 +1598,26 @@ router.head('/mcp', (req, res) => {
     res.status(200).end();
 });
 
+// Cap a client-supplied value before it goes into the journal (DIAG-001).
+// The MCP body is client-controlled and express.json allows 5mb, so logging
+// these objects verbatim lets one client write multi-megabyte log lines on a
+// reconnect loop. A real clientInfo/capabilities pair is a few hundred bytes,
+// so anything past the cap is a malformed or hostile client and the prefix is
+// all the diagnostic needs.
+const DIAG_VALUE_MAX_LENGTH = 2000;
+
+function capForLog(value) {
+    const serialized = JSON.stringify(value);
+    // undefined for a missing field, and also for values JSON drops entirely.
+    if (serialized === undefined) {
+        return null;
+    }
+    if (serialized.length <= DIAG_VALUE_MAX_LENGTH) {
+        return value;
+    }
+    return { truncated: true, length: serialized.length, prefix: serialized.slice(0, DIAG_VALUE_MAX_LENGTH) };
+}
+
 // Handle POST /mcp (new request or existing session message)
 router.post('/mcp', mcpAuth, async (req, res) => {
     const sessionId = req.headers['mcp-session-id'];
@@ -1647,16 +1667,15 @@ router.post('/mcp', mcpAuth, async (req, res) => {
         host: req.headers['host'] || null,
         allHeaders: Object.keys(req.headers).sort(),
         // DIAG: which protocol revision and capabilities each client negotiates.
-        // Gates whether MCP Tasks is worth implementing server-side — Tasks is
-        // capability-negotiated, so if no client advertises it, server-side task
-        // plumbing would be dead weight. `method` is logged too because a request
-        // with no session ID is *usually* an initialize but isn't guaranteed to be
-        // one; without it, three nulls are ambiguous between "client declared
-        // nothing" and "this wasn't an initialize at all".
-        method: req.body?.method || null,
-        protocolVersion: req.body?.params?.protocolVersion || null,
-        clientInfo: req.body?.params?.clientInfo || null,
-        capabilities: req.body?.params?.capabilities || null
+        // A sessionless request is normally initialize, but may be a retry or a
+        // batch, so log method — otherwise missing fields read the same whether
+        // the client declared nothing or never sent an initialize.
+        // ?? rather than || so a present-but-falsy value stays distinguishable
+        // from an absent one.
+        method: req.body?.method ?? null,
+        protocolVersion: req.body?.params?.protocolVersion ?? null,
+        clientInfo: capForLog(req.body?.params?.clientInfo),
+        capabilities: capForLog(req.body?.params?.capabilities)
     }));
 
     const transport = new StreamableHTTPServerTransport({

--- a/node/api/src/routes/mcp.js
+++ b/node/api/src/routes/mcp.js
@@ -1604,6 +1604,10 @@ router.head('/mcp', (req, res) => {
 // reconnect loop. A real clientInfo/capabilities pair is a few hundred bytes,
 // so anything past the cap is a malformed or hostile client and the prefix is
 // all the diagnostic needs.
+// This bounds log VOLUME only, not the work: an oversized body is still parsed
+// by express.json and serialized here before being cut. Acceptable for a
+// temporary diagnostic on an authenticated endpoint; it would not be for a
+// permanent one.
 const DIAG_VALUE_MAX_LENGTH = 2000;
 
 function capForLog(value) {


### PR DESCRIPTION
## What

Extends the existing `[DIAG-001]` log block in the no-session-id branch of `POST /mcp` — the path a fresh `initialize` takes — with the JSON-RPC message's `method`, `protocolVersion`, `clientInfo` and `capabilities`.

Log-only. No change to request handling, session creation, or the negotiated protocol version.

## Why

We want to know whether any connected MCP client (Claude Code, the claude.ai connector, ChatGPT) declares the `tasks` capability. MCP Tasks is capability-negotiated, so that single fact gates whether a server-side Tasks implementation would do anything at all — the motivating use case being virtual-agent mail, which is fire-and-forget today (`services/mail.js:34`) and forces the calling agent to poll for replies.

We can't answer it from existing data: `request_log` records metadata only, never bodies, so `initialize` params are not retained anywhere.

## Notes

- `method` is logged alongside the three ticket-specified fields because a sessionless request is *normally* an `initialize` but may be a retry or a batch. Without it, missing fields read the same whether the client declared nothing or never sent an initialize — which would undercut the ticket's whole acceptance criterion.
- `capForLog` caps `clientInfo`/`capabilities` at 2000 serialized chars before they reach the journal. The MCP body is client-controlled under a 5mb limit, so logging them verbatim would let one client write multi-megabyte log lines on a reconnect loop. Real ones are a few hundred bytes.
- The **whole** capabilities map is logged rather than just `capabilities.tasks`. The 2026-07-28 spec moves Tasks to an `io.modelcontextprotocol/tasks` extension key, so narrowing to `tasks` risks logging "no Tasks support" for a client that declares it under the extension key — the exact wrong answer from a diagnostic built to answer that question.

Reviewed by `code_review` over two rounds; size cap, `?? null` over `|| null`, and the comment trim came out of it. Declined its suggestions for a defensive `JSON.stringify` wrapper (no code path produces the failure), a redundant `isInitialize` boolean, and HTTP-level route tests (the repo has no route test harness, and this diagnostic is temporary by design).

Suite: `node --test` — 172/172 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)