### PR TITLE
LLM-560: log billed cost and serving upstream on OpenRouter calls

### DIFF
--- a/migrations/MEM-144-va-calls-served-by_down.sql
+++ b/migrations/MEM-144-va-calls-served-by_down.sql
@@ -1,0 +1,15 @@
+-- MEM-144 down — drop virtual_agent_calls.served_by (LLM-560).
+--
+-- Rollback contract: safe to run ahead of or behind a code rollback. The
+-- LLM-560 code writes served_by as an ordinary INSERT column, so rolling the
+-- column back while the new code is still deployed breaks logCall's insert —
+-- run this only together with, or after, reverting the code. The reverse order
+-- (code back, column left in place) is harmless: the column simply stops being
+-- written and reads NULL from then on.
+--
+-- Dropping this discards the recorded upstream attribution for every call
+-- logged since the migration. That data is not reconstructible — OpenRouter
+-- does not report it retroactively — so the accounting question that motivated
+-- LLM-560 becomes unanswerable again for the affected window.
+
+ALTER TABLE virtual_agent_calls DROP COLUMN IF EXISTS served_by;

--- a/migrations/MEM-144-va-calls-served-by_up.sql
+++ b/migrations/MEM-144-va-calls-served-by_up.sql
@@ -1,0 +1,31 @@
+-- MEM-144 — record which upstream host served each OpenRouter call (LLM-560).
+--
+-- virtual_agent_calls.cost used to be an estimate priced from OpenRouter's
+-- /api/v1/models catalog: one listed price per model id. But OpenRouter fronts
+-- many upstream hosts per model at differing prices, and LLM-328 pins the sim
+-- agents to one of them (Baidu). So the listed price and the billed price can
+-- diverge, and on 2026-07-26 they did — the deepseek-v4-flash listing stepped
+-- ~$0.096 -> $0.14/Mtok between 00:00 and 01:00 UTC, logged village spend
+-- appeared to jump ~50% overnight, and none of it was real. The pinned traffic
+-- was still being billed at Baidu's rate the whole time. Establishing that cost
+-- three days later took live test calls and the credits balance, because our
+-- own DB could not answer it.
+--
+-- The code half of the fix takes the billed cost off the response (which has
+-- always carried it) instead of pricing the call ourselves. This column is the
+-- other half: without knowing WHICH host served a call, a per-call cost is a
+-- number with no explanation, and the next routing or pricing shift is again
+-- undiagnosable from the DB. With it, a daily cost query can separate
+-- pinned-upstream traffic from traffic that fell back elsewhere.
+--
+-- NULL for every provider we call directly (Anthropic, OpenAI, Google, xAI,
+-- Perplexity) — they serve their own models, so there is no distinct upstream
+-- to name. NULL also on rows written before this migration, and on failed calls
+-- where no response body was parsed. TEXT rather than a constrained type
+-- because the value is OpenRouter's free-form display name for the host
+-- ("Baidu", "DeepInfra", "Together"), and their roster changes without notice.
+
+ALTER TABLE virtual_agent_calls ADD COLUMN IF NOT EXISTS served_by TEXT;
+
+COMMENT ON COLUMN virtual_agent_calls.served_by IS
+    'OpenRouter upstream host that served this call (response .provider). NULL for direct providers and pre-LLM-560 rows.';

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -304,8 +304,17 @@ function createCall(model, apiKey, configuration) {
         // incident is diagnosable from our own DB instead of live test calls.
         // Carried on `usage` because that object is the one thing every logCall
         // site already forwards from the provider unchanged.
-        if (typeof data.provider === 'string' && data.provider !== '') {
-            usage.served_by = data.provider;
+        // Trimmed and capped because this is provider-controlled text landing in
+        // a column meant for grouping spend queries: a whitespace-only name would
+        // persist as a distinct non-NULL bucket that reads as blank, and an
+        // overlong one would bloat every row for a value that is in practice a
+        // short display name ("Baidu", "DeepInfra"). Left unset rather than
+        // stored empty, so logCall writes NULL.
+        if (typeof data.provider === 'string') {
+            var servedBy = data.provider.trim();
+            if (servedBy !== '') {
+                usage.served_by = servedBy.slice(0, 100);
+            }
         }
 
         // Tool calls in OpenAI-compatible shape on choice.message.tool_calls.

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -7,8 +7,10 @@
 // supports typing arbitrary model IDs for models not yet in the catalog.
 //
 // OpenRouter pricing is per-token in their API; we convert to per-1M for
-// consistency with other providers. Cost is computed provider-side in createCall
-// using catalog pricing, so index.js calculateCost always gets usage.cost.
+// consistency with other providers. Cost is resolved provider-side in createCall
+// so index.js calculateCost always gets usage.cost — preferring the billed cost
+// OpenRouter reports on the response, falling back to catalog pricing only when
+// the response omits it. The catalog remains the source for display pricing.
 
 const { log } = require('../logger');
 const { asNumber, coerceToolArgs } = require('./coerce');
@@ -71,6 +73,15 @@ async function fetchCatalog() {
         logProvider('catalog-fetch-error', { error: err.message });
         return catalogCache || new Map();
     }
+}
+
+// Test seam. The catalog cache is module-level with a 4-hour TTL, so within one
+// process the first fetch wins for the rest of the run — a test that needs a
+// differently-priced catalog than an earlier test cannot get one. Not called by
+// application code.
+function _resetCatalogCache() {
+    catalogCache = null;
+    catalogFetchedAt = 0;
 }
 
 // Look up pricing for a model ID from the cached catalog.
@@ -261,10 +272,40 @@ function createCall(model, apiKey, configuration) {
             cache_read_input_tokens: cachedTokens
         };
 
-        // Compute cost from catalog pricing
-        var cost = await computeCost(model, promptTokens, cachedTokens, completionTokens);
+        // Cost: prefer OpenRouter's own billed figure over the catalog estimate
+        // (LLM-560). Every chat completion carries usage.cost — what our account
+        // was actually charged — with no request flag needed. The catalog holds
+        // one listed price per model id, but OpenRouter fronts many upstream
+        // hosts per model at differing prices, and a listed price can step while
+        // a pinned upstream keeps serving at the old one. That is exactly what
+        // happened on 2026-07-26: the deepseek-v4-flash listing went ~$0.096 →
+        // $0.14/Mtok, logged village spend jumped ~50% overnight, and none of it
+        // was real — the pinned traffic was still being billed at Baidu's rate.
+        // Catalog pricing is now only the fallback, for responses omitting cost.
+        var billedCost = null;
+        if (data.usage && data.usage.cost != null) {
+            var reportedCost = Number(data.usage.cost);
+            if (Number.isFinite(reportedCost) && reportedCost >= 0) {
+                billedCost = reportedCost;
+            }
+        }
+        var costSource = 'billed';
+        var cost = billedCost;
+        if (cost == null) {
+            costSource = 'catalog-estimate';
+            cost = await computeCost(model, promptTokens, cachedTokens, completionTokens);
+        }
         if (cost != null) {
             usage.cost = cost;
+        }
+
+        // Which upstream host actually served the request, persisted to
+        // virtual_agent_calls.served_by (MEM-144) so a future price or routing
+        // incident is diagnosable from our own DB instead of live test calls.
+        // Carried on `usage` because that object is the one thing every logCall
+        // site already forwards from the provider unchanged.
+        if (typeof data.provider === 'string' && data.provider !== '') {
+            usage.served_by = data.provider;
         }
 
         // Tool calls in OpenAI-compatible shape on choice.message.tool_calls.
@@ -306,7 +347,9 @@ function createCall(model, apiKey, configuration) {
         logProvider('api-response', {
             provider: 'openrouter', model,
             input: uncachedInput, cached: cachedTokens,
-            output: completionTokens, cost: cost != null ? cost.toFixed(6) : 'unknown',
+            output: completionTokens, cost: cost != null ? cost.toFixed(8) : 'unknown',
+            cost_source: cost != null ? costSource : 'unknown',
+            served_by: usage.served_by || null,
             tool_calls: tool_calls.length, finish_reason
         });
 
@@ -349,5 +392,6 @@ module.exports = {
     formatPricing,
     lookupPricing,
     fetchCatalog,
-    getCapabilities
+    getCapabilities,
+    _resetCatalogCache
 };

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -115,3 +115,117 @@ test('finish_reason "stop" surfaces truncated:false', async () => {
         stub.restore();
     }
 });
+
+// LLM-560 — billed cost and serving upstream. The catalog here prices the model
+// at $10/Mtok so a catalog-derived cost is unmistakably distinct from any billed
+// figure the response carries: 10 prompt + 2 completion tokens = 0.00012.
+const CATALOG_PRICED = {
+    data: [{
+        id: 'deepseek/deepseek-v4-flash',
+        pricing: { prompt: '0.00001', completion: '0.00001' },
+    }],
+};
+
+// Stub returning a chat completion with the given usage/provider fields. Pass
+// `usage` verbatim so a test can omit `cost` entirely.
+function stubCompletion(responseFields) {
+    const original = globalThis.fetch;
+    // The earlier tests in this file leave an empty catalog cached for 4 hours,
+    // so without a reset the priced catalog below would never be fetched and
+    // every fallback assertion would silently measure "pricing unknown" instead.
+    openrouter._resetCatalogCache();
+    globalThis.fetch = async function (url) {
+        if (String(url).includes('/models')) return { ok: true, json: async () => CATALOG_PRICED };
+        return {
+            ok: true,
+            json: async () => Object.assign({
+                choices: [{ message: { content: 'ok', tool_calls: [] }, finish_reason: 'stop' }],
+                usage: { prompt_tokens: 10, completion_tokens: 2 },
+            }, responseFields),
+        };
+    };
+    return { restore() { globalThis.fetch = original; } };
+}
+
+test('usage.cost comes from the billed figure on the response, not the catalog', async () => {
+    const stub = stubCompletion({
+        provider: 'Baidu',
+        usage: { prompt_tokens: 10, completion_tokens: 2, cost: 0.000001365 },
+    });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        assert.equal(res.usage.cost, 0.000001365);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('a response without a billed cost falls back to the catalog estimate', async () => {
+    const stub = stubCompletion({ provider: 'Baidu' });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        // 10 uncached prompt + 2 completion tokens at $10/Mtok
+        assert.equal(res.usage.cost, 0.00012);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('a malformed billed cost is rejected in favour of the catalog estimate', async () => {
+    // NaN, negative, and non-numeric must not reach usage.cost — a bad billed
+    // figure would otherwise be trusted over a sane estimate and poison the
+    // spend totals, which is the exact class of error this ticket exists to fix.
+    for (const bad of ['not-a-number', -1, null]) {
+        const stub = stubCompletion({
+            provider: 'Baidu',
+            usage: { prompt_tokens: 10, completion_tokens: 2, cost: bad },
+        });
+        try {
+            const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+            assert.equal(res.usage.cost, 0.00012, 'bad cost ' + JSON.stringify(bad) + ' should fall back');
+        } finally {
+            stub.restore();
+        }
+    }
+});
+
+test('a zero billed cost is honoured, not treated as missing', async () => {
+    // Free-tier and promotional routes legitimately bill 0; falling back to the
+    // catalog there would invent spend that never happened.
+    const stub = stubCompletion({
+        provider: 'Chutes',
+        usage: { prompt_tokens: 10, completion_tokens: 2, cost: 0 },
+    });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        assert.equal(res.usage.cost, 0);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('the serving upstream is surfaced as usage.served_by', async () => {
+    const stub = stubCompletion({
+        provider: 'Baidu',
+        usage: { prompt_tokens: 10, completion_tokens: 2, cost: 0.000001365 },
+    });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        assert.equal(res.usage.served_by, 'Baidu');
+    } finally {
+        stub.restore();
+    }
+});
+
+test('a response with no provider name leaves served_by unset', async () => {
+    // logCall coalesces a missing served_by to NULL; it must never write ''.
+    for (const bad of [undefined, '', 42]) {
+        const stub = stubCompletion(bad === undefined ? {} : { provider: bad });
+        try {
+            const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+            assert.equal('served_by' in res.usage, false, 'provider ' + JSON.stringify(bad) + ' should not set served_by');
+        } finally {
+            stub.restore();
+        }
+    }
+});

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -217,9 +217,11 @@ test('the serving upstream is surfaced as usage.served_by', async () => {
     }
 });
 
-test('a response with no provider name leaves served_by unset', async () => {
-    // logCall coalesces a missing served_by to NULL; it must never write ''.
-    for (const bad of [undefined, '', 42]) {
+test('a response with no usable provider name leaves served_by unset', async () => {
+    // logCall coalesces a missing served_by to NULL; it must never write a blank.
+    // Whitespace-only counts as blank — otherwise it persists as a distinct
+    // non-NULL bucket that reads as empty in a spend-by-upstream query.
+    for (const bad of [undefined, '', '   ', '\t\n', 42]) {
         const stub = stubCompletion(bad === undefined ? {} : { provider: bad });
         try {
             const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
@@ -227,5 +229,23 @@ test('a response with no provider name leaves served_by unset', async () => {
         } finally {
             stub.restore();
         }
+    }
+});
+
+test('a padded provider name is trimmed, and an overlong one is capped', async () => {
+    const stub = stubCompletion({ provider: '  Baidu \n' });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        assert.equal(res.usage.served_by, 'Baidu');
+    } finally {
+        stub.restore();
+    }
+
+    const longStub = stubCompletion({ provider: 'x'.repeat(500) });
+    try {
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', {})('sys', 'hi', {});
+        assert.equal(res.usage.served_by.length, 100);
+    } finally {
+        longStub.restore();
     }
 });

--- a/node/api/src/services/virtual-agent.js
+++ b/node/api/src/services/virtual-agent.js
@@ -777,7 +777,10 @@ async function logTranscript(agentName, systemPrompt, userMessage, response, usa
 //   systemPrompt   — system prompt (string or { static, dynamic } object)
 //   userMessage    — user/input message
 //   response       — response text (or null on failure)
-//   usage          — token usage object from provider (or null on failure)
+//   usage          — token usage object from provider (or null on failure).
+//                    usage.served_by (LLM-560) names the upstream host that
+//                    actually served the call — set by the OpenRouter provider
+//                    only; NULL for providers we call directly.
 //   cost           — calculated cost (or 0 on failure)
 //   durationMs     — wall-clock time for the call
 //   error          — error object (if the call failed)
@@ -810,8 +813,8 @@ async function logCall(options) {
               response, status, status_code, error_message,
               input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
               cost, duration_ms, usage_id, scene_id, conversation_id,
-              sim_actor_id, sim_actor_name)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+              sim_actor_id, sim_actor_name, served_by)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
             [
                 options.actorId,
                 options.context || null,
@@ -835,6 +838,7 @@ async function logCall(options) {
                 options.conversationId || null,
                 options.simActorId || null,
                 options.simActorName || null,
+                usage.served_by || null,
             ]
         );
     } catch (err) {


### PR DESCRIPTION
[LLM-560](https://jeffdafoe.atlassian.net/browse/LLM-560)

## The problem

`virtual_agent_calls.cost` was an estimate we priced ourselves from OpenRouter's `/api/v1/models` catalog. That catalog lists **one price per model id** — but OpenRouter is a broker fronting many upstream hosts per model at differing prices, and LLM-328 pins the sim agents to one of them (Baidu). Listed price and billed price can therefore diverge.

On 2026-07-26 they did. The `deepseek/deepseek-v4-flash` listing stepped ~$0.096 → $0.14/Mtok between 00:00 and 01:00 UTC, logged village spend appeared to jump ~50% overnight, and none of it was real — the pinned traffic was still billed at Baidu's rate throughout. Establishing that took live test calls and the credits balance three days later, because our own database could not answer the question.

The response has always carried the answer and we discarded it.

## Verified before building

A real call against production's pinned config, with no `usage: {include: true}` flag sent:

```
top-level provider = "Baidu"
usage = {
  "prompt_tokens": 5, "completion_tokens": 5,
  "cost": 0.000001365,
  "cost_details": { "upstream_inference_prompt_cost": 4.55e-7, ... }
}
```

5 prompt tokens × Baidu's $0.091/M = 4.55e-7, exactly as reported — while the catalog now lists $0.14. The divergence is real, and the billed figure is present without asking for it.

## The change

- `createCall()` prefers `data.usage.cost`, falling back to the catalog estimate only when a response omits it, logging which path it took via `cost_source`. A malformed figure (NaN, negative, non-numeric) falls back rather than poisoning the totals; a legitimate `0` is honoured, since free-tier routes really do bill nothing.
- The serving host is captured from top-level `data.provider` onto `usage.served_by` — trimmed, capped at 100, left unset rather than stored blank. It rides on the `usage` object because that is the one thing all eight `logCall` sites already forward from the provider unchanged, and `recordUsage`/`calculateCost` read only named fields off it.
- `logCall()` persists it to a new nullable `virtual_agent_calls.served_by`. NULL for providers we call directly — they serve their own models, so there is no distinct upstream to name.
- `_resetCatalogCache()` test seam: the catalog cache is module-level with a 4-hour TTL, so within one process the first fetch wins for the whole run and a test cannot get a differently-priced catalog than an earlier one asked for.

Accounting only — no behavioural change to any LLM call.

## Migration

`MEM-144` adds the nullable column. Verified **up and down** against the production database inside a rolled-back transaction. The down migration documents its ordering contract: dropping the column ahead of a code revert breaks `logCall`'s insert.

## Testing

179/179 pass. Seven new tests: billed-cost preferred over catalog, catalog fallback when absent, malformed cost falls back, zero honoured, `served_by` surfaced, no-usable-name (`undefined` / `''` / `'   '` / `'\t\n'` / `42`) leaves it unset, and padded/overlong names trimmed and capped.

## Reviewed

Sent to `code_review`, two rounds. It flagged `usage.served_by || null` as an unguarded dereference that could throw on a failed call — rejected with evidence: `logCall` normalizes at `virtual-agent.js:805` (`const usage = options.usage || {}`) and this is the fifth line in a row reading that local binding, so if it were unsafe the four pre-existing token columns would have been throwing since they were written. Finding withdrawn. Its whitespace/length point on the provider name was valid and is fixed in the second commit. No remaining blocking concerns.

## Known gaps, deliberate

- **No `cost_source` assertion.** The field exists only on the log line, and the logger is destructured at module load, so asserting it would mean restructuring production code for testability — for a logging-only field whose underlying branch is already covered by the cost assertions on both paths.
- **Read paths untouched.** `admin.js` call-detail and `sim.js` turns both select columns explicitly, so `served_by` will not surface in either until added. The ticket's acceptance is "diagnosable from the DB alone", which this meets; making it visible in the admin UI is a one-word change to each if wanted.
- **`served_by` is NULL on failed calls** — the `!response.ok` branch throws before extraction. Intended.

## Post-deploy watch

The acceptance criterion "spot-check a day's sum against the credits-balance delta" needs a deployed day of data and cannot be satisfied at merge. The live probe above is the evidence the mechanism is correct; the day-sum check is a watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
