### PR TITLE
LLM-564: narrate the engine's new offered_work rows in the dream distiller

### DIFF
--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -44,8 +44,8 @@
 // the v2 rewrite renamed the verbs and added a few, so narrateEvent also
 // handles 'spoke' / 'paid' / 'walked' / 'delivered' / 'consumed' /
 // 'took_break' (ZBBS-WORK-376) / 'labored' (LLM-162) / 'solicited_work' /
-// 'hired' (LLM-213). Unknown kinds get a generic narration so a new engine
-// action_type doesn't silently drop frames.
+// 'hired' (LLM-213) / 'offered_work' (LLM-564). Unknown kinds get a generic
+// narration so a new engine action_type doesn't silently drop frames.
 
 const pool = require('../db');
 const { saveNote } = require('./documents');
@@ -352,6 +352,16 @@ function narrateEvent(event, actorName) {
             // unsafe employer still renders a clean line.
             const employer = sanitizeLabel(p.employer || p.recipient || '') || 'someone';
             return '(offered to work for ' + employer + ' for ' + formatLaborReward(p) + ')';
+        }
+        case 'offered_work': {
+            // LLM-564: an employer offered a worker a job (offer_work minted a
+            // live pending offer). Employer-side row — before this type existed
+            // these mints logged as 'solicited_work' attributed to the worker,
+            // reading in the log as the worker having asked. payload: { worker,
+            // amount, duration_min } (the 'hired' shape). No coins move at the
+            // offer; the beat is the arrangement proposed.
+            const worker = sanitizeLabel(p.worker || p.recipient || '') || 'someone';
+            return '(offered ' + worker + ' a job for ' + formatLaborReward(p) + ')';
         }
         case 'hired': {
             // LLM-213: an employer took a worker on (accept_work flipped the offer

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -86,6 +86,18 @@ test('labored renders the reward earned and the employer (LLM-162)', () => {
     );
 });
 
+test('offered_work renders the employer-side job offer (LLM-564)', () => {
+    assert.equal(
+        narrateEvent({ kind: 'offered_work', payload: { worker: 'Patience', amount: 4, duration_min: 240 } }, ACTOR),
+        '(offered Patience a job for 4 coins)'
+    );
+    // amount 1 singularizes; a missing worker degrades to "someone".
+    assert.equal(
+        narrateEvent({ kind: 'offered_work', payload: { amount: 1 } }, ACTOR),
+        '(offered someone a job for 1 coin)'
+    );
+});
+
 test('solicited_work renders the offer to the employer for the reward (LLM-213)', () => {
     assert.equal(
         narrateEvent({ kind: 'solicited_work', payload: { employer: 'Hannah', amount: 4, duration_min: 240 } }, ACTOR),


### PR DESCRIPTION
Paired with salem PR https://github.com/jeffdafoe/llm-memory-plugin-salem-1692/pull/996 — the engine now logs employer-initiated offer_work as its own `offered_work` action type attributed to the employer (previously both labor mints logged as `solicited_work` attributed to the worker). Ticket: https://jeffdafoe.atlassian.net/browse/LLM-564

The distiller's unknown-kind default deliberately drops unmapped types from narration, so without this case the new rows would silently vanish from dream memories. Payload is the `hired` shape ({ worker, amount, duration_min }); same sanitize-then-fallback posture as its siblings. Deploy alongside (or before) the engine change.

Tests: offered_work narration cases (named worker, singular coin, missing-worker degrade). 180/180 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)