### PR TITLE
LLM-570: wire thinking_effort through to OpenRouter's reasoning parameter

### DIFF
--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -127,7 +127,7 @@ const defaultCapabilities = {
     thinking_effort: {
         type: 'select',
         label: 'Thinking Effort',
-        description: 'Controls how much the model reasons before responding. "off" disables reasoning entirely. Only hybrid reasoning models honour this; others ignore it. Reasoning tokens are billed as output tokens even though they are not stored in the response, so leaving this unset on a reasoning-capable model means paying for text you never see.',
+        description: 'Controls how much the model reasons before responding. "off" disables reasoning entirely. Only hybrid reasoning models honour this; others ignore it. LEAVING THIS UNSET IS NOT THE SAME AS "off" — unset sends nothing and the model keeps its own default, which for deepseek-v4-flash and Gemini 2.5 means it reasons. Reasoning tokens are billed as output tokens but are NOT stored in the response, so any setting other than "off" pays for text that is never kept (LLM-570 follow-up).',
         default: 'off',
         options: ['off', 'low', 'medium', 'high', 'max']
     }
@@ -210,6 +210,13 @@ function createCall(model, apiKey, configuration) {
         // extractor below does not store, but they ARE counted in
         // usage.completion_tokens and billed. The observed result was calls
         // charged more output tokens than the stored response had characters.
+        // ABSENT IS NOT 'off', deliberately. An absent key sends no reasoning
+        // field, leaving the model's own default — the pre-LLM-570 behaviour.
+        // Defaulting absence to 'none' would silently disable thinking on the
+        // two Gemini dream agents (dream-technical, dream-technical-soul), which
+        // is a change to home's and work's soul documents that nobody asked for.
+        // Opting an agent out is therefore an explicit "thinking_effort":"off".
+        //
         // An unrecognized value is ignored rather than passed through, so a
         // typo in agent configuration cannot ship a malformed reasoning field.
         // hasOwnProperty rather than a bare lookup: configuration is operator-
@@ -392,12 +399,21 @@ function createCall(model, apiKey, configuration) {
         // truncation path — surface it for the persist guards.
         const finish_reason = normalizeOpenAIChatFinish(choice.finish_reason);
 
+        // reasoning_chars makes discarded reasoning visible (LLM-570). The
+        // response body below keeps only content + tool_calls, so reasoning the
+        // model returned is billed inside completion_tokens and then dropped.
+        // Storing it properly is a follow-up; logging its size means an agent
+        // configured to a non-off effort is at least not silently burning
+        // output tokens. 0 on the expected path, where effort is 'none'.
+        const reasoningText = typeof choice.message.reasoning === 'string' ? choice.message.reasoning : '';
+
         logProvider('api-response', {
             provider: 'openrouter', model,
             input: uncachedInput, cached: cachedTokens,
             output: completionTokens, cost: cost != null ? cost.toFixed(8) : 'unknown',
             cost_source: cost != null ? costSource : 'unknown',
             served_by: usage.served_by || null,
+            reasoning_chars: reasoningText.length,
             tool_calls: tool_calls.length, finish_reason
         });
 

--- a/node/api/src/services/providers/openrouter.js
+++ b/node/api/src/services/providers/openrouter.js
@@ -123,7 +123,28 @@ const defaultCapabilities = {
         default: 4096,
         min: 1,
         max: 32768
+    },
+    thinking_effort: {
+        type: 'select',
+        label: 'Thinking Effort',
+        description: 'Controls how much the model reasons before responding. "off" disables reasoning entirely. Only hybrid reasoning models honour this; others ignore it. Reasoning tokens are billed as output tokens even though they are not stored in the response, so leaving this unset on a reasoning-capable model means paying for text you never see.',
+        default: 'off',
+        options: ['off', 'low', 'medium', 'high', 'max']
     }
+};
+
+// Our thinking_effort vocabulary (shared with the Anthropic provider) mapped to
+// OpenRouter's `reasoning.effort` scale. OpenRouter's scale is a superset —
+// it also accepts 'xhigh' and 'minimal', which we deliberately do not expose so
+// the setting means the same thing whichever provider an agent is pointed at.
+// 'off' maps to 'none', which suppresses reasoning rather than merely hiding it
+// (`reasoning.exclude` hides the output but still generates and bills it).
+const REASONING_EFFORT_BY_THINKING_EFFORT = {
+    off: 'none',
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    max: 'max'
 };
 
 const models = {};
@@ -180,6 +201,24 @@ function createCall(model, apiKey, configuration) {
         const temperature = asNumber(conf.temperature);
         if (temperature !== undefined) {
             body.temperature = temperature;
+        }
+
+        // Reasoning control (LLM-570). Until this landed the provider sent no
+        // reasoning field at all, so every model ran at its own default — and a
+        // hybrid reasoning model like deepseek-v4-flash reasons by default. Those
+        // tokens arrive on `choice.message.reasoning`, which the response
+        // extractor below does not store, but they ARE counted in
+        // usage.completion_tokens and billed. The observed result was calls
+        // charged more output tokens than the stored response had characters.
+        // An unrecognized value is ignored rather than passed through, so a
+        // typo in agent configuration cannot ship a malformed reasoning field.
+        // hasOwnProperty rather than a bare lookup: configuration is operator-
+        // supplied, and a value like "constructor" or "toString" would otherwise
+        // resolve up the prototype chain to a function and ship as the effort.
+        const configuredEffort = conf.thinking_effort;
+        if (typeof configuredEffort === 'string'
+            && Object.prototype.hasOwnProperty.call(REASONING_EFFORT_BY_THINKING_EFFORT, configuredEffort)) {
+            body.reasoning = { effort: REASONING_EFFORT_BY_THINKING_EFFORT[configuredEffort] };
         }
 
         // Per-call stop sequences. OpenRouter proxies to many upstreams;

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -249,3 +249,54 @@ test('a padded provider name is trimmed, and an overlong one is capped', async (
         longStub.restore();
     }
 });
+
+// ── Reasoning control (LLM-570) ─────────────────────────────────────────────
+// Before this, no reasoning field was ever sent, so a hybrid reasoning model
+// reasoned by default and billed the tokens as output without them appearing in
+// the stored response. These assert the mapping actually reaches the wire.
+
+test('thinking_effort "off" sends reasoning.effort "none" (suppress, not merely hide)', async () => {
+    const stub = stubFetch();
+    try {
+        const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { thinking_effort: 'off' });
+        await call('sys', 'hi', {});
+        assert.deepEqual(stub.lastBody().reasoning, { effort: 'none' });
+        // `exclude` would still generate and bill the tokens — assert we never
+        // reach for it, since that is indistinguishable from the bug being fixed.
+        assert.equal('exclude' in stub.lastBody().reasoning, false);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('the remaining thinking_effort levels map 1:1 onto reasoning.effort', async () => {
+    for (const level of ['low', 'medium', 'high', 'max']) {
+        const stub = stubFetch();
+        try {
+            const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { thinking_effort: level });
+            await call('sys', 'hi', {});
+            assert.deepEqual(stub.lastBody().reasoning, { effort: level }, `level ${level}`);
+        } finally {
+            stub.restore();
+        }
+    }
+});
+
+test('an absent or unrecognized thinking_effort leaves body.reasoning unset', async () => {
+    // Absent: the model keeps its own default, which is the pre-LLM-570
+    // behaviour and the right thing for an agent that has not opted in.
+    // Unrecognized: a typo must not ship a malformed field to the wire.
+    // 'constructor' and 'toString' resolve up Object's prototype chain on a bare
+    // lookup, which would ship a function as the effort value.
+    for (const conf of [{}, { thinking_effort: 'none' }, { thinking_effort: 'xhigh' }, { thinking_effort: '' },
+        { thinking_effort: 'constructor' }, { thinking_effort: 'toString' }, { thinking_effort: 3 }]) {
+        const stub = stubFetch();
+        try {
+            const call = openrouter.createCall('deepseek/deepseek-v4-flash', 'k', conf);
+            await call('sys', 'hi', {});
+            assert.equal('reasoning' in stub.lastBody(), false, JSON.stringify(conf));
+        } finally {
+            stub.restore();
+        }
+    }
+});

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -319,10 +319,15 @@ test('discarded reasoning is surfaced as reasoning_chars on the response log', a
         };
     };
     try {
-        await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { thinking_effort: 'high' })('sys', 'hi', {});
+        const res = await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { thinking_effort: 'high' })('sys', 'hi', {});
         const responseLine = lines.find(l => l.includes('api-response'));
         assert.ok(responseLine, 'expected an api-response log line');
         assert.match(responseLine, /"reasoning_chars":1234/);
+        // The reasoning must not leak into the returned content -- the stored
+        // response format is parsed downstream (the dream distiller, and spend
+        // queries matching on the tool_calls block).
+        assert.equal(res.text, 'ok');
+        assert.equal(res.usage.output_tokens, 400);
     } finally {
         globalThis.fetch = original;
         console.log = originalLog;

--- a/node/api/src/services/providers/openrouter.test.js
+++ b/node/api/src/services/providers/openrouter.test.js
@@ -300,3 +300,31 @@ test('an absent or unrecognized thinking_effort leaves body.reasoning unset', as
         }
     }
 });
+
+test('discarded reasoning is surfaced as reasoning_chars on the response log', async () => {
+    // Storing reasoning is a follow-up; until then an agent configured to a
+    // non-off effort must not burn output tokens invisibly.
+    const original = globalThis.fetch;
+    const lines = [];
+    const originalLog = console.log;
+    console.log = function (...args) { lines.push(args.join(' ')); };
+    globalThis.fetch = async function (url) {
+        if (String(url).includes('/models')) return { ok: true, json: async () => ({ data: [] }) };
+        return {
+            ok: true,
+            json: async () => ({
+                choices: [{ message: { content: 'ok', tool_calls: [], reasoning: 'x'.repeat(1234) } }],
+                usage: { prompt_tokens: 10, completion_tokens: 400 },
+            }),
+        };
+    };
+    try {
+        await openrouter.createCall('deepseek/deepseek-v4-flash', 'k', { thinking_effort: 'high' })('sys', 'hi', {});
+        const responseLine = lines.find(l => l.includes('api-response'));
+        assert.ok(responseLine, 'expected an api-response log line');
+        assert.match(responseLine, /"reasoning_chars":1234/);
+    } finally {
+        globalThis.fetch = original;
+        console.log = originalLog;
+    }
+});


### PR DESCRIPTION
`thinking_effort` was implemented only in the Anthropic provider. `openrouter.js` never read it and never sent any reasoning field, so every OpenRouter model ran at its own default — and `deepseek-v4-flash`, a hybrid reasoning model, reasons by default. Four dream agents have carried `"thinking_effort":"off"` with no effect.

Reasoning arrives on `choice.message.reasoning`, which the response extractor does not store, but it is counted in `usage.completion_tokens` and billed. Measured 2026-07-30: **225 of 719 `salem-vendor` calls were billed more output tokens than the stored response had characters** — impossible unless tokens were generated and discarded. Worst case: a `dream-sim-soul` call billed 9,866 output tokens for a 1,077-character response.

## What this does

- Maps our `thinking_effort` vocabulary onto OpenRouter's `reasoning.effort` scale, which is a superset. `off` → `none` (suppress), not `exclude: true` (which still generates and bills — indistinguishable from the bug).
- An unrecognized or non-string value ships nothing. The lookup uses `hasOwnProperty` because configuration is operator-supplied and `"constructor"` would otherwise resolve up the prototype chain to a function.
- `reasoning_chars` on the api-response log line, so a non-`off` configuration is visible rather than silently burning output tokens. Reads 0 on the expected path.

## Absent is deliberately not `off`

An absent key sends nothing and keeps the model default. Normalizing absence to `none` would silently disable thinking on `dream-technical` and `dream-technical-soul` — the two Gemini agents that write home's and work's soul documents. Opting out is an explicit `"thinking_effort":"off"`. Stated in the capability description and in the code.

## Known gap, accepted

Reasoning is still not stored when a non-`off` effort is configured. That path is unreachable today: all 15 OpenRouter deepseek agents get an explicit `off`, and the two Gemini agents use absent rather than an explicit non-`off` value. The capability description warns operators that any setting other than `off` pays for text that is never kept. Storage is a follow-up.

## Config half (applied separately, after deploy)

`thinking_effort: "off"` on all 15 OpenRouter `deepseek-v4-flash` agents. The two Gemini agents are deliberately untouched.

Tests: 184/184 pass (`node --test` in `node/api`). Two rounds of code_review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)