### PR TITLE
LLM-565: memory-sync --prune-remote so a consolidation retires remote notes

### DIFF
--- a/go/client/cmd/memory-sync/main.go
+++ b/go/client/cmd/memory-sync/main.go
@@ -11,6 +11,12 @@
 //	            [--config <path-to-.agent.json>]
 //	            [--user <username>]
 //	            [--notes-only]
+//	            [--prune-remote]
+//
+// --prune-remote makes the local memory directory authoritative for which
+// notes exist: any remote note under the agent's memory prefix with no local
+// file is soft-deleted. Use it after a memory consolidation, when the local
+// files are the intended state. Deletions are recoverable via restore_note.
 package main
 
 import (
@@ -33,6 +39,7 @@ func main() {
     configPath := flag.String("config", "", "Path to .agent.json (default: .agent.json in current directory)")
     userName := flag.String("user", "user", "Label for user messages in conversation logs")
     notesOnly := flag.Bool("notes-only", false, "Skip memory sync and conversation upload; only run note directory sync")
+    pruneRemote := flag.Bool("prune-remote", false, "Soft-delete remote memory notes that have no local file (local wins on existence; use after a memory consolidation)")
     showVersion := flag.Bool("version", false, "Print version and exit")
     noUpdate := flag.Bool("no-update", false, "Skip automatic update check")
 
@@ -61,7 +68,15 @@ func main() {
     }
 
     if *projectDir == "" {
-        fmt.Fprintln(os.Stderr, "Usage: memory-sync --project-dir <path> [--config <path>] [--user <name>] [--notes-only]")
+        fmt.Fprintln(os.Stderr, "Usage: memory-sync --project-dir <path> [--config <path>] [--user <name>] [--notes-only] [--prune-remote]")
+        os.Exit(1)
+    }
+
+    // --notes-only skips Phase 1, which is where pruning happens. Combining
+    // them would report a clean run having deleted nothing — fail instead, so
+    // nobody walks away believing a consolidation was propagated.
+    if *pruneRemote && *notesOnly {
+        fmt.Fprintln(os.Stderr, "--prune-remote cannot be used with --notes-only: pruning happens during memory sync, which --notes-only skips")
         os.Exit(1)
     }
 
@@ -102,7 +117,7 @@ func main() {
 
     if !*notesOnly {
         // Phase 1: Memory sync
-        retentionDays, err := memsync.MemorySyncWithConvConfig(client, *projectDir)
+        retentionDays, err := memsync.MemorySyncWithConvConfig(client, *projectDir, *pruneRemote)
         if err != nil {
             fmt.Fprintf(os.Stderr, "Memory sync error: %s\n", err)
             os.Exit(1)

--- a/go/client/internal/memsync/memory.go
+++ b/go/client/internal/memsync/memory.go
@@ -89,6 +89,18 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string, pruneRemote
     pruned := 0
 
     for _, action := range result.Memory.Actions {
+        // Prune is settled server-side and touches nothing locally, so it is
+        // handled before the filename guard — that guard exists to stop a
+        // server-supplied name from steering a local write, and there is no
+        // write here. Checking it first would report an already-completed
+        // deletion as "skipped" for any slug the server derives to a non-.md
+        // filename.
+        if action.Action == "prune" {
+            fmt.Printf("  PRUNE (remote deleted) %s\n", action.Filename)
+            pruned++
+            continue
+        }
+
         if !isSafeFilename(action.Filename) || !strings.HasSuffix(action.Filename, ".md") {
             fmt.Fprintf(os.Stderr, "  SKIP unsafe filename from server: %s\n", action.Filename)
             skipped++
@@ -115,12 +127,6 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string, pruneRemote
             }
             fmt.Printf("  PUSH %s\n", action.Filename)
             pushed++
-
-        case "prune":
-            // Server already soft-deleted the remote note. Nothing to do
-            // locally — the file's absence is what asked for this.
-            fmt.Printf("  PRUNE (remote deleted) %s\n", action.Filename)
-            pruned++
 
         default:
             unchanged++

--- a/go/client/internal/memsync/memory.go
+++ b/go/client/internal/memsync/memory.go
@@ -34,10 +34,14 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string, pruneRemote
         return 0, fmt.Errorf("create memory dir: %w", err)
     }
 
-    // Stamped before the scan, not after: the server treats a remote note
+    // Marked before the scan, not after: the server treats a remote note
     // updated later than this as a concurrent session's creation and pulls it
-    // instead of pruning. Taking the time first keeps that window conservative.
-    scannedAt := time.Now().UTC().Format(time.RFC3339Nano)
+    // instead of pruning. Taking the mark first keeps that window conservative.
+    // We send the server how long ago this was rather than when it was — the
+    // elapsed time is the gap between two readings of one clock (monotonic, so
+    // it also survives a wall-clock adjustment mid-run), which lets the server
+    // place the cutoff on its own clock instead of trusting ours.
+    scanStart := time.Now()
 
     // Scan local .md files
     entries, err := os.ReadDir(memoryDir)
@@ -70,8 +74,9 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string, pruneRemote
     var result memorySyncResponse
     memory := memoryPayload{Files: localFiles}
     if pruneRemote {
+        scanAgeMs := time.Since(scanStart).Milliseconds()
         memory.Prune = true
-        memory.ScannedAt = scannedAt
+        memory.ScanAgeMs = &scanAgeMs
     }
     err = client.Post("/agent/memory/sync", memorySyncRequest{
         Memory:        memory,
@@ -163,8 +168,13 @@ type memoryPayload struct {
     Files []memoryFile `json:"files"`
     // Omitted entirely unless --prune-remote is set, so an older server that
     // doesn't know the field sees exactly the request it saw before.
-    Prune     bool   `json:"prune,omitempty"`
-    ScannedAt string `json:"scanned_at,omitempty"`
+    Prune bool `json:"prune,omitempty"`
+    // Milliseconds between the local directory scan and this request. A
+    // pointer, not a plain int64: a scan fast enough to round to 0 ms is the
+    // ordinary case, and omitempty on a value type would drop exactly that
+    // field and fail the server's prune validation. Nil omits it entirely,
+    // which is what an unflagged run needs.
+    ScanAgeMs *int64 `json:"scan_age_ms,omitempty"`
 }
 
 type memorySyncRequest struct {

--- a/go/client/internal/memsync/memory.go
+++ b/go/client/internal/memsync/memory.go
@@ -20,13 +20,24 @@ import (
 // are aligned after each operation so future syncs see them as equal.
 // Returns the conversation retention_days from the server response
 // (used by Phase 2 to decide whether to sync conversations).
-func MemorySyncWithConvConfig(client *api.Client, projectDir string) (int, error) {
+//
+// pruneRemote makes the local directory authoritative for existence: a remote
+// note with no local file is soft-deleted rather than pulled back down, so a
+// memory consolidation that retires files propagates without a manual
+// delete_note per slug. The server performs the deletion (it owns the
+// namespace and slug prefix) and reports it back as a "prune" action.
+func MemorySyncWithConvConfig(client *api.Client, projectDir string, pruneRemote bool) (int, error) {
     memoryDir := filepath.Join(projectDir, "memory")
 
     // Ensure memory directory exists
     if err := os.MkdirAll(memoryDir, 0755); err != nil {
         return 0, fmt.Errorf("create memory dir: %w", err)
     }
+
+    // Stamped before the scan, not after: the server treats a remote note
+    // updated later than this as a concurrent session's creation and pulls it
+    // instead of pruning. Taking the time first keeps that window conservative.
+    scannedAt := time.Now().UTC().Format(time.RFC3339Nano)
 
     // Scan local .md files
     entries, err := os.ReadDir(memoryDir)
@@ -57,8 +68,13 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string) (int, error
 
     // Call sync endpoint
     var result memorySyncResponse
+    memory := memoryPayload{Files: localFiles}
+    if pruneRemote {
+        memory.Prune = true
+        memory.ScannedAt = scannedAt
+    }
     err = client.Post("/agent/memory/sync", memorySyncRequest{
-        Memory:        memoryPayload{Files: localFiles},
+        Memory:        memory,
         Conversations: map[string]interface{}{},
     }, &result)
     if err != nil {
@@ -70,6 +86,7 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string) (int, error
     pushed := 0
     unchanged := 0
     skipped := 0
+    pruned := 0
 
     for _, action := range result.Memory.Actions {
         if !isSafeFilename(action.Filename) || !strings.HasSuffix(action.Filename, ".md") {
@@ -99,12 +116,21 @@ func MemorySyncWithConvConfig(client *api.Client, projectDir string) (int, error
             fmt.Printf("  PUSH %s\n", action.Filename)
             pushed++
 
+        case "prune":
+            // Server already soft-deleted the remote note. Nothing to do
+            // locally — the file's absence is what asked for this.
+            fmt.Printf("  PRUNE (remote deleted) %s\n", action.Filename)
+            pruned++
+
         default:
             unchanged++
         }
     }
 
     summary := fmt.Sprintf("Memory sync complete: %d pulled, %d pushed, %d unchanged", pulled, pushed, unchanged)
+    if pruned > 0 {
+        summary += fmt.Sprintf(", %d pruned", pruned)
+    }
     if skipped > 0 {
         summary += fmt.Sprintf(", %d skipped (unsafe filenames)", skipped)
     }
@@ -129,6 +155,10 @@ type memoryFile struct {
 
 type memoryPayload struct {
     Files []memoryFile `json:"files"`
+    // Omitted entirely unless --prune-remote is set, so an older server that
+    // doesn't know the field sees exactly the request it saw before.
+    Prune     bool   `json:"prune,omitempty"`
+    ScannedAt string `json:"scanned_at,omitempty"`
 }
 
 type memorySyncRequest struct {

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -531,7 +531,7 @@ router.post('/agent/instructions/save', apiRoute('agent', 'instructions-save', a
 //   prefix: string (remote slug prefix, e.g. "instructions/memory/"),
 //   files: [{ filename: string, content: string, mtime: ISO8601 string }],
 //   prune: boolean (optional — see below),
-//   scanned_at: ISO8601 string (required when prune is true)
+//   scan_age_ms: number (required when prune is true)
 // }
 //
 // Prune mode (LLM-565) makes the LOCAL directory authoritative for existence:
@@ -541,10 +541,12 @@ router.post('/agent/instructions/save', apiRoute('agent', 'instructions-save', a
 // delete_note call per slug. It is off by default; without it a remote-only
 // note pulls exactly as before.
 //
-// scanned_at is when the client listed its local directory. A remote note
-// updated after that instant is NOT pruned — a concurrent session may have
-// created it after our scan, and deleting it would destroy work we never saw.
-// Such a note pulls as usual and the next run reconciles it.
+// scan_age_ms is how long before this request the client listed its local
+// directory. A remote note updated after that instant is NOT pruned — a
+// concurrent session may have created it after our scan, and deleting it would
+// destroy work we never saw. Such a note pulls as usual and the next run
+// reconciles it. The client sends an elapsed duration rather than a timestamp
+// so the comparison never crosses two clocks; see resolvePruneCutoff.
 //
 // Response: {
 //   actions: [{
@@ -568,18 +570,26 @@ function isSafeFilename(name) {
 }
 
 // Resolve the instant a prune run compares remote notes against — the moment
-// the client listed its local directory. Returns null when the value is missing
-// or unparseable, which the route turns into a 400: prune mode without a scan
-// time cannot tell a retired note from a concurrent session's new one.
+// the client listed its local directory, expressed on THIS server's clock.
+// Returns null when the input is unusable, which the route turns into a 400:
+// prune mode without a scan time cannot tell a retired note from a concurrent
+// session's new one.
 //
-// The result is clamped to now. A client clock running ahead would otherwise
-// produce a cutoff later than every remote timestamp, satisfying the guard
-// universally and pruning exactly the concurrent creations it exists to spare.
-function resolvePruneCutoff(scannedAt, now) {
-    if (!scannedAt) return null;
-    const parsed = new Date(scannedAt).getTime();
-    if (isNaN(parsed)) return null;
-    return Math.min(parsed, now);
+// The client reports how long ago it scanned, not when. That elapsed figure is
+// the difference between two readings of one clock, so it survives any offset
+// between the client's clock and ours — and subtracting it from our own now
+// keeps the whole comparison in server time, which is what remote updated_at
+// is stamped in. An absolute client timestamp cannot do this: a client running
+// behind produces a cutoff later than concurrent writes and prunes them.
+const MAX_SCAN_AGE_MS = 60 * 60 * 1000;
+
+function resolvePruneCutoff(scanAgeMs, now) {
+    if (typeof scanAgeMs !== 'number' || !Number.isFinite(scanAgeMs)) return null;
+    // Negative means the client scanned in its own future — nonsense we won't
+    // guess at. Beyond the ceiling the run is too stale to reason about: the
+    // cutoff would sit far enough back to spare notes that really were retired.
+    if (scanAgeMs < 0 || scanAgeMs > MAX_SCAN_AGE_MS) return null;
+    return now - scanAgeMs;
 }
 
 // Decide what to do with a note that exists remotely but has no local file.
@@ -675,10 +685,10 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
         const prune = req.body.memory.prune === true;
         let pruneCutoff = null;
         if (prune) {
-            pruneCutoff = resolvePruneCutoff(req.body.memory.scanned_at, Date.now());
+            pruneCutoff = resolvePruneCutoff(req.body.memory.scan_age_ms, Date.now());
             if (pruneCutoff === null) {
                 return res.status(400).json({
-                    error: { code: 'BAD_REQUEST', message: 'memory.scanned_at must be a valid ISO8601 timestamp when memory.prune is true' }
+                    error: { code: 'BAD_REQUEST', message: 'memory.scan_age_ms must be a non-negative number of milliseconds no greater than ' + MAX_SCAN_AGE_MS + ' when memory.prune is true' }
                 });
             }
         }
@@ -764,7 +774,7 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
                     // window between the listing and this delete.
                     let deleted = true;
                     try {
-                        await deleteNote(namespace, remote.slug, remote.updated_at);
+                        await deleteNote(namespace, remote.slug, remote.updated_at_exact);
                     } catch (pruneErr) {
                         if (pruneErr.statusCode === 409) {
                             // Rewritten under us. Fall through and pull it —
@@ -788,7 +798,20 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
                         continue;
                     }
                 }
-                const fullNote = await readNote(namespace, remote.slug);
+                // The note can disappear between the listing and this read —
+                // ordinarily a concurrent delete, and on the 409 path above,
+                // one that raced our own. Remote-absent is a state the next run
+                // reconciles, so emit no action rather than failing the sync
+                // over an outcome nobody minds.
+                let fullNote;
+                try {
+                    fullNote = await readNote(namespace, remote.slug);
+                } catch (readErr) {
+                    if (readErr.statusCode === 404) {
+                        continue;
+                    }
+                    throw readErr;
+                }
                 actions.push({
                     filename,
                     action: 'pull',

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -7,7 +7,7 @@ const auth = require('../middleware/auth');
 const { hash: hashToken, generateSalt, verify, tokenLookupHash } = require('../services/hashing');
 const { SESSION_KIND } = require('../constants');
 const { broadcast } = require('../services/events');
-const { listNotes, readNote, saveNote } = require('../services/documents');
+const { listNotes, readNote, saveNote, deleteNote } = require('../services/documents');
 const sanitize = require('../sanitize');
 const { requireAccess, validateNamespace } = require('../services/namespace-permissions');
 const config = require('../services/config');
@@ -529,13 +529,27 @@ router.post('/agent/instructions/save', apiRoute('agent', 'instructions-save', a
 // Body: {
 //   namespace: string (optional, defaults to agent name),
 //   prefix: string (remote slug prefix, e.g. "instructions/memory/"),
-//   files: [{ filename: string, content: string, mtime: ISO8601 string }]
+//   files: [{ filename: string, content: string, mtime: ISO8601 string }],
+//   prune: boolean (optional — see below),
+//   scanned_at: ISO8601 string (required when prune is true)
 // }
+//
+// Prune mode (LLM-565) makes the LOCAL directory authoritative for existence:
+// a remote note with no local file is soft-deleted instead of pulled back down.
+// This is what the memory-sync --prune-remote flag drives, so that retiring a
+// file during a memory consolidation propagates to remote without a manual
+// delete_note call per slug. It is off by default; without it a remote-only
+// note pulls exactly as before.
+//
+// scanned_at is when the client listed its local directory. A remote note
+// updated after that instant is NOT pruned — a concurrent session may have
+// created it after our scan, and deleting it would destroy work we never saw.
+// Such a note pulls as usual and the next run reconciles it.
 //
 // Response: {
 //   actions: [{
 //     filename: string,
-//     action: "pull" | "push" | "unchanged",
+//     action: "pull" | "push" | "unchanged" | "prune",
 //     content?: string (included for "pull" actions),
 //     title?: string (included for "pull" actions),
 //     remote_updated_at?: string
@@ -551,6 +565,38 @@ function isSafeFilename(name) {
     if (name === '.' || name === '..') return false;
     if (name.startsWith('.')) return false;
     return true;
+}
+
+// Resolve the instant a prune run compares remote notes against — the moment
+// the client listed its local directory. Returns null when the value is missing
+// or unparseable, which the route turns into a 400: prune mode without a scan
+// time cannot tell a retired note from a concurrent session's new one.
+//
+// The result is clamped to now. A client clock running ahead would otherwise
+// produce a cutoff later than every remote timestamp, satisfying the guard
+// universally and pruning exactly the concurrent creations it exists to spare.
+function resolvePruneCutoff(scannedAt, now) {
+    if (!scannedAt) return null;
+    const parsed = new Date(scannedAt).getTime();
+    if (isNaN(parsed)) return null;
+    return Math.min(parsed, now);
+}
+
+// Decide what to do with a note that exists remotely but has no local file.
+// Outside prune mode it always pulls (the historical behavior). In prune mode
+// it prunes, unless the note was updated after the client's scan — that note
+// belongs to a session we couldn't see, and pulling lets the next run
+// reconcile it instead of destroying it.
+function remoteOnlyAction(prune, remoteUpdatedAt, pruneCutoff) {
+    if (!prune) return 'pull';
+    // An absent or unparseable remote timestamp fails closed: we can't prove
+    // the note predates the scan, so we keep it. The falsy check is load-bearing
+    // and not redundant with isNaN — new Date(null) is epoch 0, not NaN, which
+    // would read as "older than any scan" and prune the note.
+    if (!remoteUpdatedAt) return 'pull';
+    const updated = new Date(remoteUpdatedAt).getTime();
+    if (isNaN(updated)) return 'pull';
+    return updated > pruneCutoff ? 'pull' : 'prune';
 }
 
 // Extract title from markdown frontmatter (name field) or fall back to filename
@@ -622,6 +668,20 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
             }
         }
 
+        // Prune mode requires a scan timestamp — without it there is no way to
+        // tell a locally-retired note from one a concurrent session just created,
+        // so we refuse rather than guess.
+        const prune = req.body.memory.prune === true;
+        let pruneCutoff = null;
+        if (prune) {
+            pruneCutoff = resolvePruneCutoff(req.body.memory.scanned_at, Date.now());
+            if (pruneCutoff === null) {
+                return res.status(400).json({
+                    error: { code: 'BAD_REQUEST', message: 'memory.scanned_at must be a valid ISO8601 timestamp when memory.prune is true' }
+                });
+            }
+        }
+
         await requireAccess(req.actorId, agent, 'agent', namespace, 'read');
 
         // Get all remote notes under the prefix
@@ -680,11 +740,41 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
             }
         }
 
+        let hasDeleteAccess = false;
+        async function ensureDeleteAccess() {
+            if (!hasDeleteAccess) {
+                await requireAccess(req.actorId, agent, 'agent', namespace, 'delete');
+                hasDeleteAccess = true;
+            }
+        }
+
         for (const filename of allFilenames) {
             const remote = remoteByFilename[filename];
             const local = localByFilename[filename];
 
             if (remote && !local) {
+                // Remote-only. In prune mode this is a note the local side
+                // retired, unless it landed after the client's scan — then it
+                // belongs to a concurrent session and still pulls.
+                if (remoteOnlyAction(prune, remote.updated_at, pruneCutoff) === 'prune') {
+                    await ensureDeleteAccess();
+                    try {
+                        await deleteNote(namespace, remote.slug);
+                    } catch (pruneErr) {
+                        // 404 means someone deleted it between our list and now.
+                        // The note is gone either way, which is the outcome we
+                        // wanted; anything else is a real failure and propagates.
+                        if (pruneErr.statusCode !== 404) {
+                            throw pruneErr;
+                        }
+                    }
+                    actions.push({
+                        filename,
+                        action: 'prune',
+                        remote_updated_at: remote.updated_at
+                    });
+                    continue;
+                }
                 const fullNote = await readNote(namespace, remote.slug);
                 actions.push({
                     filename,
@@ -1104,5 +1194,11 @@ router.post('/agent/tick', apiRoute('agent', 'tick', async (req, res) => {
         cost: result.cost,
     });
 }));
+
+// Exposed for tests — the prune decision is pure, but the route it lives in
+// isn't reachable without a request harness this repo doesn't have. Mirrors
+// sim.js attaching requireSalemEngine to its exported router.
+router.resolvePruneCutoff = resolvePruneCutoff;
+router.remoteOnlyAction = remoteOnlyAction;
 
 module.exports = router;

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -759,22 +759,34 @@ router.post('/agent/memory/sync', apiRoute('agent', 'memory-sync', async (req, r
                 // belongs to a concurrent session and still pulls.
                 if (remoteOnlyAction(prune, remote.updated_at, pruneCutoff) === 'prune') {
                     await ensureDeleteAccess();
+                    // Conditional on the version we listed. scanned_at only
+                    // covers writes visible in that listing; this covers the
+                    // window between the listing and this delete.
+                    let deleted = true;
                     try {
-                        await deleteNote(namespace, remote.slug);
+                        await deleteNote(namespace, remote.slug, remote.updated_at);
                     } catch (pruneErr) {
-                        // 404 means someone deleted it between our list and now.
-                        // The note is gone either way, which is the outcome we
-                        // wanted; anything else is a real failure and propagates.
-                        if (pruneErr.statusCode !== 404) {
+                        if (pruneErr.statusCode === 409) {
+                            // Rewritten under us. Fall through and pull it —
+                            // the next run reconciles against a fresh listing.
+                            deleted = false;
+                        } else if (pruneErr.statusCode !== 404) {
+                            // 404 means someone deleted it first: gone either
+                            // way, which is the outcome we wanted. Anything
+                            // else is a real failure and propagates. These are
+                            // deleteNote's own errors — the service is called
+                            // in-process, so no HTTP layer can inject a 404.
                             throw pruneErr;
                         }
                     }
-                    actions.push({
-                        filename,
-                        action: 'prune',
-                        remote_updated_at: remote.updated_at
-                    });
-                    continue;
+                    if (deleted) {
+                        actions.push({
+                            filename,
+                            action: 'prune',
+                            remote_updated_at: remote.updated_at
+                        });
+                        continue;
+                    }
                 }
                 const fullNote = await readNote(namespace, remote.slug);
                 actions.push({

--- a/node/api/src/routes/agent.js
+++ b/node/api/src/routes/agent.js
@@ -596,7 +596,8 @@ function remoteOnlyAction(prune, remoteUpdatedAt, pruneCutoff) {
     if (!remoteUpdatedAt) return 'pull';
     const updated = new Date(remoteUpdatedAt).getTime();
     if (isNaN(updated)) return 'pull';
-    return updated > pruneCutoff ? 'pull' : 'prune';
+    if (updated > pruneCutoff) return 'pull';
+    return 'prune';
 }
 
 // Extract title from markdown frontmatter (name field) or fall back to filename

--- a/node/api/src/routes/agent.test.js
+++ b/node/api/src/routes/agent.test.js
@@ -1,0 +1,71 @@
+// Tests for the /agent/memory/sync prune decision (LLM-565). Run with:
+// node --test (from node/api). Uses node:test + node:assert, matching
+// sim.test.js — no test-framework dep.
+//
+// Prune mode makes the local memory directory authoritative for existence, so
+// the branch that decides prune-vs-pull is the one place a bug destroys notes.
+// There's no route/supertest harness in this repo, so the decision is extracted
+// into two pure functions on the router and exercised directly here.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// agent.js pulls in the db pool and several services at require time; none of
+// them connect until a query runs, and these helpers touch neither.
+const agentRouter = require('./agent');
+const { resolvePruneCutoff, remoteOnlyAction } = agentRouter;
+
+const NOW = Date.parse('2026-07-30T12:00:00.000Z');
+
+test('resolvePruneCutoff parses an ISO timestamp from the client', () => {
+    const cutoff = resolvePruneCutoff('2026-07-30T11:59:00.000Z', NOW);
+    assert.equal(cutoff, Date.parse('2026-07-30T11:59:00.000Z'));
+});
+
+test('resolvePruneCutoff clamps a client clock running ahead of the server', () => {
+    // Unclamped, this cutoff would sit past every remote updated_at and make
+    // the concurrency guard vacuously true.
+    const cutoff = resolvePruneCutoff('2026-07-30T18:00:00.000Z', NOW);
+    assert.equal(cutoff, NOW);
+});
+
+test('resolvePruneCutoff returns null for a missing or unparseable value', () => {
+    assert.equal(resolvePruneCutoff(undefined, NOW), null);
+    assert.equal(resolvePruneCutoff('', NOW), null);
+    assert.equal(resolvePruneCutoff('not a date', NOW), null);
+});
+
+test('remote-only note pulls when prune is off', () => {
+    // The historical behavior, and what every sync without the flag must keep
+    // doing — an older note is still pulled, not deleted.
+    const action = remoteOnlyAction(false, '2026-07-30T09:00:00.000Z', null);
+    assert.equal(action, 'pull');
+});
+
+test('remote-only note prunes when it predates the local scan', () => {
+    // The consolidation case: the file was retired locally, so its remote copy
+    // is the stale side.
+    const action = remoteOnlyAction(true, '2026-07-30T09:00:00.000Z', NOW);
+    assert.equal(action, 'prune');
+});
+
+test('remote-only note prunes when it is exactly as old as the scan', () => {
+    // Boundary: equal timestamps mean the note existed at scan time, so its
+    // absence locally is a deletion, not a race.
+    const action = remoteOnlyAction(true, '2026-07-30T12:00:00.000Z', NOW);
+    assert.equal(action, 'prune');
+});
+
+test('remote-only note pulls when it was created after the local scan', () => {
+    // A concurrent session wrote it in the window between our scan and this
+    // request. Deleting it would destroy work we never saw.
+    const action = remoteOnlyAction(true, '2026-07-30T12:00:01.000Z', NOW);
+    assert.equal(action, 'pull');
+});
+
+test('remote-only note pulls when its remote timestamp is unusable', () => {
+    // Fail closed: without a readable timestamp we cannot prove the note
+    // predates the scan, so we keep it.
+    assert.equal(remoteOnlyAction(true, null, NOW), 'pull');
+    assert.equal(remoteOnlyAction(true, 'garbage', NOW), 'pull');
+});

--- a/node/api/src/routes/agent.test.js
+++ b/node/api/src/routes/agent.test.js
@@ -17,22 +17,35 @@ const { resolvePruneCutoff, remoteOnlyAction } = agentRouter;
 
 const NOW = Date.parse('2026-07-30T12:00:00.000Z');
 
-test('resolvePruneCutoff parses an ISO timestamp from the client', () => {
-    const cutoff = resolvePruneCutoff('2026-07-30T11:59:00.000Z', NOW);
-    assert.equal(cutoff, Date.parse('2026-07-30T11:59:00.000Z'));
+test('resolvePruneCutoff places the cutoff on the server clock', () => {
+    // 60s ago per the client's own elapsed measurement, subtracted from OUR now
+    // — the client's absolute clock never enters the comparison, so an offset
+    // in either direction cannot move the cutoff.
+    const cutoff = resolvePruneCutoff(60000, NOW);
+    assert.equal(cutoff, NOW - 60000);
 });
 
-test('resolvePruneCutoff clamps a client clock running ahead of the server', () => {
-    // Unclamped, this cutoff would sit past every remote updated_at and make
-    // the concurrency guard vacuously true.
-    const cutoff = resolvePruneCutoff('2026-07-30T18:00:00.000Z', NOW);
-    assert.equal(cutoff, NOW);
+test('resolvePruneCutoff accepts a scan age of zero', () => {
+    // A scan fast enough to round to 0 ms is the ordinary case, not a missing
+    // value — it must not be confused with one.
+    assert.equal(resolvePruneCutoff(0, NOW), NOW);
 });
 
-test('resolvePruneCutoff returns null for a missing or unparseable value', () => {
+test('resolvePruneCutoff rejects a missing or non-numeric scan age', () => {
     assert.equal(resolvePruneCutoff(undefined, NOW), null);
-    assert.equal(resolvePruneCutoff('', NOW), null);
-    assert.equal(resolvePruneCutoff('not a date', NOW), null);
+    assert.equal(resolvePruneCutoff(null, NOW), null);
+    assert.equal(resolvePruneCutoff('60000', NOW), null);
+    assert.equal(resolvePruneCutoff(NaN, NOW), null);
+    assert.equal(resolvePruneCutoff(Infinity, NOW), null);
+});
+
+test('resolvePruneCutoff rejects a negative or absurdly old scan age', () => {
+    // Negative means the client scanned in its own future. Past the ceiling the
+    // cutoff would sit far enough back to spare notes that really were retired,
+    // so we refuse rather than prune against a stale premise.
+    assert.equal(resolvePruneCutoff(-1, NOW), null);
+    assert.equal(resolvePruneCutoff(60 * 60 * 1000 + 1, NOW), null);
+    assert.equal(resolvePruneCutoff(60 * 60 * 1000, NOW), NOW - 60 * 60 * 1000);
 });
 
 test('remote-only note pulls when prune is off', () => {

--- a/node/api/src/services/documents.js
+++ b/node/api/src/services/documents.js
@@ -462,19 +462,51 @@ function paginateContent(content, offset, limit) {
     };
 }
 
-async function deleteNote(namespace, slug) {
+// expectedUpdatedAt makes the delete conditional on the row still holding the
+// version the caller read. memory-sync's prune (LLM-565) needs this: it decides
+// what to delete from a listing taken moments earlier, and a concurrent write
+// landing in that window must not be destroyed. Callers that legitimately
+// delete whatever is there omit it and get the unconditional delete.
+async function deleteNote(namespace, slug, expectedUpdatedAt) {
     // Soft delete the document and hard-delete its vector chunks.
     // The document row is kept (with deleted_at set) so restoreNote can
     // re-ingest from the preserved content. Chunks are cheap to regenerate
     // but expensive to leave behind — stale chunks leak into RAG context.
+    const conditional = expectedUpdatedAt !== undefined && expectedUpdatedAt !== null;
+    const params = [namespace, slug];
+    let versionClause = '';
+    if (conditional) {
+        params.push(expectedUpdatedAt);
+        // Truncated to milliseconds on both sides. updated_at is timestamptz(6)
+        // but the pg driver hands callers a JS Date, which holds only
+        // milliseconds — so a plain `updated_at = $3` compares .259294 against
+        // .259 and never matches, silently turning every conditional delete
+        // into a conflict. The residual blind spot is a rewrite landing in the
+        // same millisecond as the one we read, which is not a window a
+        // caller can act inside anyway.
+        versionClause = " AND date_trunc('milliseconds', updated_at) = $3";
+    }
+
     const result = await pool.query(`
         UPDATE documents
         SET deleted_at = NOW()
-        WHERE namespace = $1 AND LOWER(slug) = LOWER($2) AND deleted_at IS NULL
+        WHERE namespace = $1 AND LOWER(slug) = LOWER($2) AND deleted_at IS NULL${versionClause}
         RETURNING id, LENGTH(content) AS content_length
-    `, [namespace, slug]);
+    `, params);
 
     if (result.rows.length === 0) {
+        // A conditional delete matches nothing for two very different reasons,
+        // and the caller acts differently on each: the note is already gone
+        // (accept), or someone rewrote it since we looked (leave it alone).
+        if (conditional) {
+            const live = await pool.query(
+                'SELECT 1 FROM documents WHERE namespace = $1 AND LOWER(slug) = LOWER($2) AND deleted_at IS NULL',
+                [namespace, slug]
+            );
+            if (live.rows.length > 0) {
+                throw Object.assign(new Error(`Note changed since it was read: ${slug}`), { statusCode: 409 });
+            }
+        }
         throw Object.assign(new Error(`Note not found: ${slug}`), { statusCode: 404 });
     }
 

--- a/node/api/src/services/documents.js
+++ b/node/api/src/services/documents.js
@@ -331,7 +331,9 @@ async function listNotes(namespace, limit, offset, prefix, opts) {
             SELECT d.id, d.slug, d.title,
                    LEFT(d.content, 200) AS snippet,
                    MD5(d.content) AS content_hash,
-                   ac.name AS created_by, d.created_at, d.updated_at, d.last_accessed${deletedCol}
+                   ac.name AS created_by, d.created_at, d.updated_at,
+                   to_char(d.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at_exact,
+                   d.last_accessed${deletedCol}
             FROM documents d
             LEFT JOIN actors ac ON ac.id = d.created_by_actor_id
             WHERE d.namespace = $1 AND LOWER(d.slug) LIKE LOWER($4)${deletedFilter}
@@ -344,7 +346,9 @@ async function listNotes(namespace, limit, offset, prefix, opts) {
             SELECT d.id, d.slug, d.title,
                    LEFT(d.content, 200) AS snippet,
                    MD5(d.content) AS content_hash,
-                   ac.name AS created_by, d.created_at, d.updated_at, d.last_accessed${deletedCol}
+                   ac.name AS created_by, d.created_at, d.updated_at,
+                   to_char(d.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at_exact,
+                   d.last_accessed${deletedCol}
             FROM documents d
             LEFT JOIN actors ac ON ac.id = d.created_by_actor_id
             WHERE d.namespace = $1${deletedFilter}
@@ -467,6 +471,13 @@ function paginateContent(content, offset, limit) {
 // what to delete from a listing taken moments earlier, and a concurrent write
 // landing in that window must not be destroyed. Callers that legitimately
 // delete whatever is there omit it and get the unconditional delete.
+//
+// Pass listNotes' `updated_at_exact`, NOT its `updated_at`. updated_at is
+// timestamptz(6) and real rows carry microseconds, but the pg driver hands
+// JavaScript a Date holding only milliseconds — comparing that would drop the
+// microseconds and let two distinct writes look like the same version.
+// updated_at_exact is the microsecond-precision text form, and comparing it
+// keeps the predicate exact and index-friendly (no function on the column).
 async function deleteNote(namespace, slug, expectedUpdatedAt) {
     // Soft delete the document and hard-delete its vector chunks.
     // The document row is kept (with deleted_at set) so restoreNote can
@@ -477,14 +488,7 @@ async function deleteNote(namespace, slug, expectedUpdatedAt) {
     let versionClause = '';
     if (conditional) {
         params.push(expectedUpdatedAt);
-        // Truncated to milliseconds on both sides. updated_at is timestamptz(6)
-        // but the pg driver hands callers a JS Date, which holds only
-        // milliseconds — so a plain `updated_at = $3` compares .259294 against
-        // .259 and never matches, silently turning every conditional delete
-        // into a conflict. The residual blind spot is a rewrite landing in the
-        // same millisecond as the one we read, which is not a window a
-        // caller can act inside anyway.
-        versionClause = " AND date_trunc('milliseconds', updated_at) = $3";
+        versionClause = ' AND updated_at = $3::timestamptz';
     }
 
     const result = await pool.query(`


### PR DESCRIPTION
After consolidating local memory files, the local directory is the intended state — but the sync pulls every retired file back down, so propagating the retirement meant a manual `delete_note` per slug. `--prune-remote` makes local authoritative for existence: a remote note under the agent's memory prefix with no local file is soft-deleted instead of pulled.

## Where the fix lives

The ticket pointed at `go/client/internal/memsync/notes.go`. That path is dormant — it is driven by `note_synchronization`, which has zero rows for every agent, so `NoteSync` returns immediately. The resurrection is in Phase 1, the server-driven `/agent/memory/sync`, whose `remote && !local` branch emits a `pull`.

That relocation forced the prune server-side. The sync response gives the client only `filename`, never the remote slug, and the server normalizes extensionless slugs onto `.md` filenames — `home`'s `instructions/memory/feedback_raw_byte_inspection_use_bash` is live in exactly that shape, so a client building `prefix + filename` would 404 on precisely the note the normalization exists for. Server-side also keeps the server owning namespace and prefix as it already deliberately does.

## Concurrency

`C:\dev` runs concurrent sessions against one memory directory, so this deletes into a moving target. Two independent guards:

- **Before the listing** — the client reports how long ago it scanned; the server subtracts that from its own clock and refuses to prune a note updated since. Sending elapsed time rather than a timestamp keeps the comparison inside one clock, so an offset in either direction cannot move the cutoff.
- **After the listing** — `deleteNote` takes an optional `expectedUpdatedAt` and makes the soft-delete conditional on it, closing the list→delete window. A conflict falls through to a pull; an already-gone note is accepted.

The version compare uses a new microsecond-precision `updated_at_exact` projection rather than the driver's `Date`, which holds only milliseconds. Verified on prod PG in a rolled-back transaction: an unchanged row deletes, a row rewritten one microsecond later survives.

Deletions are soft, so `restore_note` recovers a mistaken prune. Off by default, and an unflagged run sends byte-identical requests.

## Testing

193/193 node tests pass, `go build` + `go vet` clean. New tests cover both sides of the scan boundary, a zero scan age, the rejection cases, and the fail-closed paths. Two bugs were caught this way rather than in production: `new Date(null)` is epoch 0 rather than `NaN`, which read as older than any scan and would have pruned; and `omitempty` on a value-typed scan age would have dropped the ordinary 0 ms case and failed validation.

Two `code_review` rounds. Declined from round 1: making the Go signature variadic — `memsync` is under `internal/`, so no external importer is possible, and the one call site is updated.

Live end-to-end verification of the flag itself happens post-deploy.