### PR TITLE
LLM-583: close the open security alerts (6 Dependabot + ReDoS + timer overflow)

### DIFF
--- a/node/api/package-lock.json
+++ b/node/api/package-lock.json
@@ -141,12 +141,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -352,9 +352,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -372,9 +369,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -392,9 +386,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -412,9 +403,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -432,9 +420,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -452,9 +437,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1940,9 +1922,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "funding": [
                 {
                     "type": "github",
@@ -2116,9 +2098,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.25",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-            "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+            "version": "4.12.33",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+            "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -12,6 +12,32 @@ const { invokeAgent } = require('./virtual-agent');
 const { personContextSlug } = require('./people-slug');
 const { normalizeSlugPrefix, slugToDisplay } = require('./sim-conversation-distiller');
 
+// Upper bound on the operator-settable politeness delays between provider calls
+// (dream_interagent_delay, MEM-092; dream_interchunk_delay, MEM-118). An hour is
+// far past any real pause — the defaults are 2s and 1s.
+const MAX_DREAM_DELAY_MS = 3600000;
+
+// dreamDelayMs reads one of those config rows and clamps it.
+//
+// The clamp is not about a hostile operator, it's about a silent inversion:
+// Node stores a timer's delay in a signed 32-bit int, so a value past 2^31-1 ms
+// (~24.8 days) overflows, is clamped to 1ms, and only emits a
+// TimeoutOverflowWarning. A fat-fingered "pause a very long time" therefore
+// becomes "no pause at all" and the run hammers the provider — the opposite of
+// what was asked, with nothing in the logs to say so.
+//
+// The `|| fallback` is carried over verbatim rather than tightened, so parsing
+// behaviour is unchanged: blank and non-numeric values take the default, a
+// negative value survives to be skipped by the caller's `> 0` guard, and a
+// fractional one truncates. (One consequence of `||` worth knowing: an explicit
+// 0 also takes the default, so the config rows' documented "0 to disable" does
+// not actually disable. Pre-existing, unrelated to the timer overflow, and both
+// rows are at their defaults in production — filed separately rather than
+// changed here.)
+function dreamDelayMs(key, fallback) {
+    return Math.min(parseInt(config.get(key)) || fallback, MAX_DREAM_DELAY_MS);
+}
+
 // validatePersonSlug — defense for runPersonContextUpdate now that it's
 // exported. Pass the input back through the same slugify the dream cron
 // uses; if the result differs from the input, the input was not already
@@ -1365,7 +1391,7 @@ async function processDreamChunk(agent, agentNames, chunk, scope) {
 // never skip past unprocessed logs) and the next cron retries it. Returns the
 // per-chunk result array.
 async function runChunkLoop(agent, agentNames, chunks, scope, advanceCursor, lock) {
-    const interChunkDelay = parseInt(config.get('dream_interchunk_delay')) || 1000;
+    const interChunkDelay = dreamDelayMs('dream_interchunk_delay', 1000);
     const chunkResults = [];
 
     for (let i = 0; i < chunks.length; i++) {
@@ -1552,7 +1578,7 @@ async function dreamSharedRoster(agent, agentNames, actorResults, lock) {
         return 0;
     }
 
-    const interActorDelay = parseInt(config.get('dream_interagent_delay')) || 2000;
+    const interActorDelay = dreamDelayMs('dream_interagent_delay', 2000);
 
     for (let i = 0; i < roster.rows.length; i++) {
         const actorRow = roster.rows[i];
@@ -2021,7 +2047,7 @@ async function runDreamAgents(lock) {
         }
 
         // Delay between agents to avoid hammering the provider
-        const interDelay = parseInt(config.get('dream_interagent_delay')) || 2000;
+        const interDelay = dreamDelayMs('dream_interagent_delay', 2000);
         if (interDelay > 0) {
             await new Promise(resolve => setTimeout(resolve, interDelay));
         }
@@ -2111,4 +2137,4 @@ function startDreamScheduler() {
     logDream('scheduler', { message: 'Dream scheduler started', schedule });
 }
 
-module.exports = { runDream, prefilterLog, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport };
+module.exports = { runDream, prefilterLog, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, buildNotesLog, startDreamScheduler, runPersonContextUpdate, findDreamAgent, detectReasoningPreamble, soulNeedsRebuild, buildSoulUserMessage, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport, dreamDelayMs };

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -9,7 +9,8 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, prefilterLog, runPersonContextUpdate, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport } = require('./dream');
+const { buildNotesLog, soulNeedsRebuild, buildSoulUserMessage, extractSpeakers, buildPersonExcerptSections, buildPersonUserMessage, prefilterLog, runPersonContextUpdate, countFailedActors, peopleNotePath, validateRosterPrefix, resolveScopePrefix, planCronReport, dreamDelayMs } = require('./dream');
+const config = require('./config');
 
 test('single note gets a slug+date header above its content', () => {
     const rows = [{
@@ -671,4 +672,47 @@ test('validateRosterPrefix rejects a non-canonical prefix (must be stored canoni
     assert.equal(validateRosterPrefix('john-ellis'), null);       // missing slash
     assert.equal(validateRosterPrefix('constance-scott//'), null); // doubled slash
     assert.equal(validateRosterPrefix('  constance-scott/  '), null); // whitespace
+});
+
+// dreamDelayMs (LLM-583) — the operator-settable politeness delays between
+// provider calls. config.set writes the in-memory cache directly, so these need
+// no database.
+test('dreamDelayMs falls back when the config row is absent, blank or non-numeric', () => {
+    config.set('dream_test_delay', undefined);
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
+    config.set('dream_test_delay', '');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
+    config.set('dream_test_delay', 'soon');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
+});
+
+test('dreamDelayMs clamps a value past the 32-bit timer range (LLM-583)', () => {
+    // The bug this guards: setTimeout stores its delay in a signed 32-bit int, so
+    // 2^31 and above overflows, is clamped to 1ms and only emits a warning — the
+    // requested "wait a very long time" silently becomes no wait at all and the
+    // run hammers the provider. Clamping to an hour keeps a large value meaning
+    // "a long pause" rather than inverting it.
+    config.set('dream_test_delay', String(2 ** 31));
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 3600000);
+    config.set('dream_test_delay', '999999999999');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 3600000);
+    // Exactly at the ceiling is not clamped down.
+    config.set('dream_test_delay', '3600000');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 3600000);
+});
+
+test('dreamDelayMs leaves ordinary and negative values to the caller unchanged', () => {
+    config.set('dream_test_delay', '5000');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 5000);
+    // parseInt truncates rather than rounding — unchanged from before the clamp.
+    config.set('dream_test_delay', '1500.9');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 1500);
+    // A negative survives the clamp and is skipped by each caller's `> 0` guard.
+    config.set('dream_test_delay', '-5');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), -5);
+    // Documented, pre-existing `||` behaviour: an explicit 0 takes the default,
+    // so the config rows' "0 to disable" does not disable. Pinned here so a later
+    // change to that is deliberate rather than accidental.
+    config.set('dream_test_delay', '0');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
 });

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -710,9 +710,16 @@ test('dreamDelayMs leaves ordinary and negative values to the caller unchanged',
     // A negative survives the clamp and is skipped by each caller's `> 0` guard.
     config.set('dream_test_delay', '-5');
     assert.equal(dreamDelayMs('dream_test_delay', 2000), -5);
-    // Documented, pre-existing `||` behaviour: an explicit 0 takes the default,
-    // so the config rows' "0 to disable" does not disable. Pinned here so a later
-    // change to that is deliberate rather than accidental.
+});
+
+// KNOWN DEFECT, pinned deliberately — see LLM-584. This asserts behaviour that is
+// WRONG, not behaviour we want. Both config rows document "0 to disable"
+// (migrations MEM-092, MEM-118) but `parseInt(x) || fallback` treats the parsed 0
+// as falsy, so setting the row to 0 yields the DEFAULT delay instead of none.
+// LLM-583 carried the `||` over verbatim so a security fix would not also change
+// runtime behaviour; the pin exists so LLM-584's fix has to delete this test
+// rather than silently flip an assertion. Delete it when LLM-584 lands.
+test('dreamDelayMs: an explicit 0 wrongly takes the default (LLM-584, pinning a known defect)', () => {
     config.set('dream_test_delay', '0');
     assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
 });

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -414,6 +414,28 @@ function narrateEvent(event, actorName) {
 // value from being processed at all.
 const MAX_RAW_SLUG_PREFIX_LENGTH = 1024;
 
+// collapseTrailingSlashes reduces a run of trailing slashes to exactly one.
+//
+// This is a linear scan rather than `replace(/\/+$/, '')`. That pattern is
+// unanchored at the start, so on a run of slashes not followed by end-of-string
+// the engine retries at every offset and backtracks in O(n^2) (CodeQL
+// js/polynomial-redos). Measured on 200k slashes plus one character: 32,076ms
+// for the regex against 0.005ms for this loop, same output.
+//
+// Exported only so the linearity guard can reach it. MAX_RAW_SLUG_PREFIX_LENGTH
+// means normalizeSlugPrefix never hands this an adversarial input, so a test
+// going through normalizeSlugPrefix would short-circuit at the length check and
+// pass even with the quadratic regex restored — it has to call this directly to
+// prove anything. The property matters independently of the bound: raising that
+// ceiling must not silently reintroduce the backtracking.
+function collapseTrailingSlashes(value) {
+    let end = value.length;
+    while (end > 0 && value[end - 1] === '/') {
+        end--;
+    }
+    return value.slice(0, end) + '/';
+}
+
 // normalizeSlugPrefix validates and canonicalizes a shared-VA actor's memory
 // partition prefix (e.g. 'constance-scott/') before it's spliced into the note
 // slug. The engine derives it from the villager's display name (Slugify + '/'),
@@ -439,16 +461,7 @@ function normalizeSlugPrefix(raw) {
         return '';
     }
     // Collapse trailing slashes to exactly one, then require a safe kebab path.
-    // The collapse is a linear scan rather than `replace(/\/+$/, '')`: that
-    // pattern is unanchored at the start, so a long run of slashes makes the
-    // engine retry at every offset and backtrack in O(n^2) (CodeQL
-    // js/polynomial-redos). The length bound below cannot prevent that — it
-    // runs after the collapse, and this value arrives on a 5 MB request body.
-    let end = trimmed.length;
-    while (end > 0 && trimmed[end - 1] === '/') {
-        end--;
-    }
-    const withSlash = trimmed.slice(0, end) + '/';
+    const withSlash = collapseTrailingSlashes(trimmed);
     if (!/^[a-z0-9]+(-[a-z0-9]+)*\/$/.test(withSlash)) {
         return '';
     }
@@ -657,4 +670,4 @@ async function distillSimConversationDay(agentName, dayStr, events, opts = {}) {
 // distillSimConversationDay is the only production caller. slugToDisplay is
 // shared with dream.js, which needs the same slug -> "First Last" rendering to
 // recognize a dedicated NPC's own name in its distilled lines (LLM-523).
-module.exports = { distillSimConversationDay, narrateEvent, normalizeSlugPrefix, slugToDisplay };
+module.exports = { distillSimConversationDay, narrateEvent, normalizeSlugPrefix, slugToDisplay, collapseTrailingSlashes };

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -407,6 +407,13 @@ function narrateEvent(event, actorName) {
     }
 }
 
+// Ceiling on the RAW prefix before canonicalization. Deliberately loose against
+// the 100-char canonical cap: the raw value may carry surrounding whitespace and
+// a run of trailing slashes that collapse away, so a tight bound here would
+// reject values the canonical cap accepts. Its job is only to stop an absurd
+// value from being processed at all.
+const MAX_RAW_SLUG_PREFIX_LENGTH = 1024;
+
 // normalizeSlugPrefix validates and canonicalizes a shared-VA actor's memory
 // partition prefix (e.g. 'constance-scott/') before it's spliced into the note
 // slug. The engine derives it from the villager's display name (Slugify + '/'),
@@ -416,6 +423,15 @@ function narrateEvent(event, actorName) {
 // traversal ('../') into the saved note's slug. Exported for unit tests.
 function normalizeSlugPrefix(raw) {
     if (typeof raw !== 'string') {
+        return '';
+    }
+    // Reject an oversized value before doing any work on it. The canonical form
+    // is capped at 100 chars below, and the raw form can only legitimately add
+    // surrounding whitespace and extra trailing slashes on top of that — so
+    // anything past this ceiling was never going to be accepted. Bounding here
+    // rather than at the end keeps the trim/slice/test off a value that arrives
+    // on a 5 MB request body (express.json limit in server.js).
+    if (raw.length > MAX_RAW_SLUG_PREFIX_LENGTH) {
         return '';
     }
     const trimmed = raw.trim();

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -423,7 +423,16 @@ function normalizeSlugPrefix(raw) {
         return '';
     }
     // Collapse trailing slashes to exactly one, then require a safe kebab path.
-    const withSlash = trimmed.replace(/\/+$/, '') + '/';
+    // The collapse is a linear scan rather than `replace(/\/+$/, '')`: that
+    // pattern is unanchored at the start, so a long run of slashes makes the
+    // engine retry at every offset and backtrack in O(n^2) (CodeQL
+    // js/polynomial-redos). The length bound below cannot prevent that — it
+    // runs after the collapse, and this value arrives on a 5 MB request body.
+    let end = trimmed.length;
+    while (end > 0 && trimmed[end - 1] === '/') {
+        end--;
+    }
+    const withSlash = trimmed.slice(0, end) + '/';
     if (!/^[a-z0-9]+(-[a-z0-9]+)*\/$/.test(withSlash)) {
         return '';
     }

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -292,12 +292,26 @@ test('normalizeSlugPrefix returns promptly on a long run of slashes (LLM-583)', 
     // the body of POST /v1/sim/conversation-day under a 5 MB json limit, so a
     // quadratic scan here blocks the whole event loop.
     //
-    // 200k slashes plus a trailing non-slash is the worst case: linear finishes in
-    // well under a millisecond, quadratic takes minutes. The 1s bound is loose on
-    // purpose — it separates the two behaviours without being timing-sensitive.
+    // 200k slashes plus a trailing non-slash is the worst case. Measured on the
+    // old code: 32,076ms. Measured on the new code: 0.005ms. The 5s bound sits
+    // between them with 6x headroom against the quadratic case and six orders of
+    // magnitude against the linear one, so a slow or GC-stalled runner cannot
+    // flip it — only a return to backtracking can. Detecting backtracking at all
+    // requires a clock; this is the least timing-sensitive form of that.
     const hostile = '/'.repeat(200000) + 'a';
     const startedAt = process.hrtime.bigint();
     assert.equal(normalizeSlugPrefix(hostile), '');
     const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
-    assert.ok(elapsedMs < 1000, `normalizeSlugPrefix took ${elapsedMs.toFixed(1)}ms — the collapse is not linear`);
+    assert.ok(elapsedMs < 5000, `normalizeSlugPrefix took ${elapsedMs.toFixed(1)}ms — the collapse is not linear`);
+});
+
+test('normalizeSlugPrefix rejects an oversized raw value before normalizing (LLM-583)', () => {
+    // Defence in depth beside the linear collapse: the canonical cap is 100, so a
+    // raw value past 1024 was never going to be accepted and is refused before any
+    // trim/slice/regex touches it. The guard must not narrow what already passes —
+    // the raw form legitimately carries whitespace and collapsing trailing slashes.
+    assert.equal(normalizeSlugPrefix('/'.repeat(5 * 1024 * 1024)), '');
+    assert.equal(normalizeSlugPrefix('a'.repeat(1025)), '');
+    // Raw length over the canonical cap but under the raw ceiling still normalizes.
+    assert.equal(normalizeSlugPrefix('a'.repeat(99) + '/'.repeat(500)), 'a'.repeat(99) + '/');
 });

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -9,7 +9,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { narrateEvent, normalizeSlugPrefix } = require('./sim-conversation-distiller');
+const { narrateEvent, normalizeSlugPrefix, collapseTrailingSlashes } = require('./sim-conversation-distiller');
 
 const ACTOR = 'Ezekiel Crane';
 
@@ -284,13 +284,18 @@ test('normalizeSlugPrefix rejects traversal and any non-kebab shape', () => {
     assert.equal(normalizeSlugPrefix('two words/'), '');
 });
 
-test('normalizeSlugPrefix returns promptly on a long run of slashes (LLM-583)', () => {
-    // The trailing-slash collapse used to be `replace(/\/+$/, '')`. That pattern
-    // is unanchored at the start, so on slashes NOT followed by end-of-string the
-    // engine restarts at every offset and backtracks in O(n^2). The length bound
-    // runs after the collapse, so it never protected this. slugPrefix arrives on
-    // the body of POST /v1/sim/conversation-day under a 5 MB json limit, so a
-    // quadratic scan here blocks the whole event loop.
+test('collapseTrailingSlashes is linear on a long run of slashes (LLM-583)', () => {
+    // The collapse used to be `replace(/\/+$/, '')`. That pattern is unanchored at
+    // the start, so on slashes NOT followed by end-of-string the engine restarts
+    // at every offset and backtracks in O(n^2).
+    //
+    // This calls the helper directly rather than going through
+    // normalizeSlugPrefix. It has to: the raw-length guard added alongside this
+    // fix rejects anything past 1024 chars before the collapse is reached, so a
+    // 200k-char input routed through normalizeSlugPrefix would short-circuit and
+    // pass even with the quadratic regex restored. The linearity of the collapse
+    // is a property worth pinning on its own — raising that ceiling must not
+    // quietly reintroduce the backtracking.
     //
     // 200k slashes plus a trailing non-slash is the worst case. Measured on the
     // old code: 32,076ms. Measured on the new code: 0.005ms. The 5s bound sits
@@ -300,9 +305,25 @@ test('normalizeSlugPrefix returns promptly on a long run of slashes (LLM-583)', 
     // requires a clock; this is the least timing-sensitive form of that.
     const hostile = '/'.repeat(200000) + 'a';
     const startedAt = process.hrtime.bigint();
-    assert.equal(normalizeSlugPrefix(hostile), '');
+    assert.equal(collapseTrailingSlashes(hostile), hostile + '/');
     const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
-    assert.ok(elapsedMs < 5000, `normalizeSlugPrefix took ${elapsedMs.toFixed(1)}ms — the collapse is not linear`);
+    assert.ok(elapsedMs < 5000, `collapseTrailingSlashes took ${elapsedMs.toFixed(1)}ms — it is not linear`);
+});
+
+test('collapseTrailingSlashes matches the regex it replaced (LLM-583)', () => {
+    // Semantic equivalence with `value.replace(/\/+$/, '') + '/'`, which is what
+    // normalizeSlugPrefix used before. These are the shapes normalizeSlugPrefix
+    // feeds it — post-trim, so no surrounding whitespace.
+    assert.equal(collapseTrailingSlashes('constance-scott/'), 'constance-scott/');
+    assert.equal(collapseTrailingSlashes('constance-scott'), 'constance-scott/');
+    assert.equal(collapseTrailingSlashes('constance-scott////'), 'constance-scott/');
+    assert.equal(collapseTrailingSlashes('/'), '/');
+    assert.equal(collapseTrailingSlashes('////'), '/');
+    assert.equal(collapseTrailingSlashes(''), '/');
+    // Interior slashes are untouched — only a trailing run collapses. The kebab
+    // regex in normalizeSlugPrefix is what rejects these.
+    assert.equal(collapseTrailingSlashes('a/b'), 'a/b/');
+    assert.equal(collapseTrailingSlashes('a/b//'), 'a/b/');
 });
 
 test('normalizeSlugPrefix rejects an oversized raw value before normalizing (LLM-583)', () => {

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -283,3 +283,21 @@ test('normalizeSlugPrefix rejects traversal and any non-kebab shape', () => {
     assert.equal(normalizeSlugPrefix('a_b/'), '');
     assert.equal(normalizeSlugPrefix('two words/'), '');
 });
+
+test('normalizeSlugPrefix returns promptly on a long run of slashes (LLM-583)', () => {
+    // The trailing-slash collapse used to be `replace(/\/+$/, '')`. That pattern
+    // is unanchored at the start, so on slashes NOT followed by end-of-string the
+    // engine restarts at every offset and backtracks in O(n^2). The length bound
+    // runs after the collapse, so it never protected this. slugPrefix arrives on
+    // the body of POST /v1/sim/conversation-day under a 5 MB json limit, so a
+    // quadratic scan here blocks the whole event loop.
+    //
+    // 200k slashes plus a trailing non-slash is the worst case: linear finishes in
+    // well under a millisecond, quadratic takes minutes. The 1s bound is loose on
+    // purpose — it separates the two behaviours without being timing-sensitive.
+    const hostile = '/'.repeat(200000) + 'a';
+    const startedAt = process.hrtime.bigint();
+    assert.equal(normalizeSlugPrefix(hostile), '');
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+    assert.ok(elapsedMs < 1000, `normalizeSlugPrefix took ${elapsedMs.toFixed(1)}ms — the collapse is not linear`);
+});


### PR DESCRIPTION
Closes [LLM-583](https://jeffdafoe.atlassian.net/browse/LLM-583).

GitHub had 10 open security alerts on this repo — 6 Dependabot, 4 CodeQL. This closes 7 and converts the other 3 into a real fix rather than a dismissal.

## 1. Dependency bump (lockfile only)

`npm update hono @hono/node-server fast-uri` in `node/api`:

| Alert | Package | From | To | Severity |
|---|---|---|---|---|
| #52, #51 | `fast-uri` (via `ajv`) | 3.1.2 | 3.1.5 | high |
| #50, #49, #48 | `hono` | 4.12.25 | 4.12.33 | medium |
| #47 | `@hono/node-server` | 1.19.14 | 2.0.12 | medium |

All six are transitive under `@modelcontextprotocol/sdk` 1.30.0, whose declared ranges (`hono: ^4.11.4`, `@hono/node-server: ^1.19.9 || ^2.0.5`) already permit every patched version — so `package.json` is untouched and no `overrides` entry was needed. The SDK is the only dependent of `@hono/node-server` in the graph, so the 1.x → 2.x major has no other consumer.

**None of the six was reachable.** `routes/mcp.js` imports only the SDK's `server/index.js`, `server/streamableHttp.js` and `types.js`. Requiring exactly those pulls in 221 modules and **zero** from `hono` or `@hono` — verified at runtime, not just from the import list. The advisories cover `hono/jsx`, the `cx()` helper, the AWS API Gateway v1 adapter, and `serve-static` path traversal on Windows; production is Debian. Bumped because the patch is free.

## 2. Polynomial ReDoS in `normalizeSlugPrefix` (CodeQL #114)

`sim-conversation-distiller.js` collapsed trailing slashes with `replace(/\/+$/, '')`. That pattern is unanchored at the start, so on a run of slashes not followed by end-of-string the engine restarts at every offset and backtracks in O(n²). The existing 100-char cap never protected it — that check runs *after* the collapse.

`slugPrefix` arrives on the body of `POST /v1/sim/conversation-day` under `express.json({ limit: '5mb' })`. Node is single-threaded, so this blocks the whole process.

Measured on 200,000 slashes plus one trailing character:

```
regex collapse:  32075.8ms
linear collapse:     0.005ms
same result: true
```

At the 5 MB body limit that scales to hours. The route is gated by `requireSalemEngine`, so it needs the service credential — a real denial of service inside our own trust boundary rather than an externally reachable one.

Two fixes, belt and braces:

- The collapse is now `collapseTrailingSlashes`, a linear scan.
- `normalizeSlugPrefix` rejects a raw value past 1024 chars **before** any trim/slice/regex touches it. The bound is deliberately loose against the 100-char canonical cap, because the raw form legitimately carries whitespace and collapsing trailing slashes.

Semantics are unchanged throughout: `'a'.repeat(99) + '////'` still normalizes, `'a'.repeat(100) + '////'` still rejects.

## 3. `setTimeout` overflow on the dream delays (CodeQL #115, #117, #118)

I had these down as false positives — the delays come from `config` rows settable only from the admin dashboard. `code_review` pushed back, and checking the large-value behaviour found something better than the alert's own argument:

Node stores a timer's delay in a signed 32-bit int. A value past 2^31−1 ms (~24.8 days) overflows, is clamped to **1 ms**, and only emits a `TimeoutOverflowWarning`. So a fat-fingered "pause a long time" silently becomes **no pause at all** and the dream run hammers the provider — the opposite of the intent, with nothing in the logs to say so.

All three sites now go through `dreamDelayMs`, clamping to one hour. Parsing behaviour is carried over verbatim, so this ships inert: blank/non-numeric take the default, negatives survive to be skipped by each caller's `> 0` guard, fractions truncate. Both rows read their defaults in production (`dream_interagent_delay` 2000, `dream_interchunk_delay` 1000).

## Filed separately

[LLM-584](https://jeffdafoe.atlassian.net/browse/LLM-584) — `parseInt(x) || default` means an explicit `0` takes the default, so the "0 to disable" documented on both config rows does not disable. Pre-existing, dormant, unrelated to the overflow. Deliberately not folded into a security ticket; pinned by a test labelled as a known defect so LLM-584's fix has to delete it rather than quietly flip it.

## Review

Two `code_review` rounds. Round 2 caught a regression I had introduced in round 1: the new 1024-char bound meant the ReDoS test's 200k input short-circuited at the length guard and would have passed with the quadratic regex restored. That is why the collapse is exported and the linearity test calls it directly — any input large enough to separate linear from quadratic is, by construction, rejected before `normalizeSlugPrefix` reaches the collapse.

## Verification

- `npm ci` reproduces the lockfile with no further modification; installs run through Socket Firewall on a cold cache, no blocks.
- Full suite 200/200 (194 before this branch).

**Reviewer note on the lockfile diff:** it also drops six `libc` arrays from dev-only optional `@rollup/rollup-linux-*` entries. That is npm 11.8.0 re-serializing metadata a newer npm had written; versions and integrity hashes are unchanged, the packages are dev-only, and both CI and production are glibc. `npm ci` never writes the lockfile, so CI cannot churn it back. Left alone rather than hand-editing the lockfile into a state npm itself would not generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
