### PR TITLE
LLM-607: a one-way transfer is not a debt, in the dream ledger

### DIFF
--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -791,6 +791,23 @@ function computeDailyChunks(since, now) {
 // failure it guards against is not the model doubting the ledger but
 // misreading it — "(paid Josiah Thorne 1 coin for milk)" was consolidated into
 // a jug of milk given as a gift, inverting a purchase into a gratuity.
+//
+// The non-reciprocal clause is LLM-607, and it is the general form of that same
+// misreading. Every ledger line names one movement of coin or goods; nothing in
+// the block ever states that a movement came back, because a return is simply
+// another line. So a transfer with no answering line looks identical to a debt
+// outstanding, and the directive above tells the model to trust that appearance
+// completely. Moses James's character document acquired "Constable Marsh takes
+// my coin for a 'day's rate' but never delivers nails or any real help — the
+// ledger shows I pay him and get nothing", and the constable refunded eight
+// coins of collected town rate against it. The same document carried the same
+// shape about a gift of flour to a different neighbour, which is why the clause
+// is written generally rather than about the levy.
+//
+// The salem side stops the levy case at its source — a rate payment now narrates
+// as a due settled rather than carrying the payer's own words for it — but that
+// only covers transfers the engine classifies. Gifts, wages and one-sided
+// deliveries have no such marker, so the reading rule has to stand on its own.
 const LEDGER_PRECEDENCE_DIRECTIVE = [
     '## How to weigh these',
     '',
@@ -798,6 +815,7 @@ const LEDGER_PRECEDENCE_DIRECTIVE = [
     '',
     '- A payment, gift, or delivery counts ONLY if the ledger records it. Someone saying they paid you, or promising to make good on a debt, is not payment. Do not write an unbacked promise into the file as a settled matter.',
     '- Read the ledger direction exactly as written. "(paid Josiah Thorne 1 coin for milk)" means you spent a coin and received milk — a purchase you made, not a gift you were given.',
+    '- Not everything that moves one way is owed back. A due, a levy, a gift, a wage — these are settled when they change hands, and the ledger records no return because none was ever coming. Do not turn a one-way line into a debt, and do not write that someone "never delivered" or "gave nothing back" unless the ledger itself shows goods promised and not handed over.',
     '- Lines marked "overheard" were spoken while you were present but addressed to someone else. They tell you about this person\'s character and dealings; they are not your own transactions with them.',
 ].join('\n');
 

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -435,6 +435,29 @@ test('the user message renders ledger and speech as separate sections', () => {
     assert.ok(msg.includes('Where the two disagree, the ledger wins.'));
 });
 
+// LLM-607. Every ledger line names one movement, and a return is simply another
+// line — so a one-way transfer is indistinguishable from a debt outstanding, and
+// the directive tells the model to trust the ledger completely. Moses James's
+// character document acquired "the ledger shows I pay him and get nothing" about
+// nine settled levies, and the constable refunded eight coins against it.
+test('the directive says a one-way transfer is not automatically a debt', () => {
+    const msg = buildPersonUserMessage({
+        selfLabel: 'Moses James',
+        display: 'Constable Gideon Marsh',
+        today: '2026-08-06',
+        existingFile: '',
+        ledger: ['[Thursday 12:11 Moses James] (paid Constable Gideon Marsh 1 coin — the town rate, a due settled, with no goods owed in return)'],
+        said: '',
+    });
+    assert.ok(msg.includes('Not everything that moves one way is owed back.'));
+    // The clause has to name the write it is preventing, not just the reading —
+    // the grievance reached the character document as a phrasing, not as a sum.
+    assert.ok(msg.includes('never delivered'));
+    // It sits inside the ledger-precedence block, which is the authority the
+    // misreading was drawing on; a bullet elsewhere would not be weighed against it.
+    assert.ok(msg.indexOf('Where the two disagree, the ledger wins.') < msg.indexOf('Not everything that moves one way'));
+});
+
 test('an empty ledger says so explicitly rather than rendering blank', () => {
     const msg = buildPersonUserMessage({
         selfLabel: 'Constance Scott',

--- a/node/api/src/services/sim-conversation-distiller.js
+++ b/node/api/src/services/sim-conversation-distiller.js
@@ -249,6 +249,28 @@ function narrateEvent(event, actorName) {
         case 'pay':
         case 'paid': {
             const recipient = sanitizeLabel(p.recipient || p.recipient_name || 'someone');
+            // LLM-607: a payment that discharged the town rate is narrated as the
+            // due it was, and the payer's own words for it are DROPPED.
+            //
+            // This line goes into the ledger block of the consolidation prompt,
+            // under a directive telling the model the ledger is authoritative and
+            // complete. `payload.for` is model-authored — the villager's stated
+            // purpose — and for a levy it reads "Day's rate on the James Farm",
+            // which is a payment with a stated purpose and no delivery against it,
+            // i.e. indistinguishable from an order placed and never filled. Nine of
+            // those consolidated into Moses James's character document as a standing
+            // grievance ("takes my coin ... but never delivers"), and the constable
+            // refunded eight coins of collected rate on the strength of it.
+            //
+            // The engine settled the rate and knows what the coin was; the salem
+            // side stamps that on the durable payload as rate_settled. Its presence
+            // is the classification. Preferring it over the payer's account is the
+            // same rule the engine already applies to its own relationship facts.
+            const rateSettled = Number(p.rate_settled);
+            if (Number.isFinite(rateSettled) && rateSettled > 0) {
+                return '(paid ' + recipient + ' ' + formatCoins(p.amount)
+                    + ' — the town rate, a due settled, with no goods owed in return)';
+            }
             const forText = sanitizeLabel(p.for || p.for_text || '');
             const reason = forText ? ' for ' + forText : '';
             return '(paid ' + recipient + ' ' + formatCoins(p.amount) + reason + ')';

--- a/node/api/src/services/sim-conversation-distiller.test.js
+++ b/node/api/src/services/sim-conversation-distiller.test.js
@@ -41,6 +41,46 @@ test('paid pluralizes coins and tolerates a missing for-text', () => {
     );
 });
 
+// LLM-607. A rate payment is narrated as the due it was, and the payer's own
+// words for it are dropped. This line lands in the ledger block of the
+// consolidation prompt, under a directive saying the ledger is authoritative and
+// complete — so "for Day's rate on the James Farm" reads there as an order placed
+// and never filled. Nine of them became a standing grievance in Moses James's
+// character document, and the constable refunded eight coins of collected rate.
+test('a payment that settled the town rate narrates as a due, not a purchase', () => {
+    const payload = {
+        recipient: 'Constable Gideon Marsh',
+        amount: 1,
+        for: "Day's rate on the James Farm",
+        rate_settled: 1,
+    };
+    assert.equal(
+        narrateEvent({ kind: 'paid', payload }, ACTOR),
+        '(paid Constable Gideon Marsh 1 coin — the town rate, a due settled, with no goods owed in return)'
+    );
+    // The misleading half must be gone, not merely supplemented.
+    assert.ok(!narrateEvent({ kind: 'paid', payload }, ACTOR).includes("Day's rate"));
+});
+
+// Presence of rate_settled is the classification. Every purchase, and every row
+// written before the salem side started stamping the key, must narrate exactly as
+// it did before — a partial rollout must not reclassify ordinary trade.
+test('an ordinary purchase is unaffected by the rate-settlement branch', () => {
+    const cases = [
+        { recipient: 'Hannah', amount: 3, for: 'bread' },
+        { recipient: 'Hannah', amount: 3, for: 'bread', rate_settled: 0 },
+        { recipient: 'Hannah', amount: 3, for: 'bread', rate_settled: 'nonsense' },
+        { recipient: 'Hannah', amount: 3, for: 'bread', rate_settled: null },
+    ];
+    for (const payload of cases) {
+        assert.equal(
+            narrateEvent({ kind: 'paid', payload }, ACTOR),
+            '(paid Hannah 3 coins for bread)',
+            'rate_settled = ' + JSON.stringify(payload.rate_settled)
+        );
+    }
+});
+
 test('walked renders the destination, identical to v1 move_to', () => {
     const payload = { destination: 'the Tavern' };
     assert.equal(narrateEvent({ kind: 'walked', payload }, ACTOR), '(walked to the Tavern)');


### PR DESCRIPTION
[LLM-607](https://jeffdafoe.atlassian.net/browse/LLM-607) — the api half. Pairs with the salem PR, which stamps the `rate_settled` key this reads.

## The defect

The consolidation prompt's ledger block narrated a town-rate payment from the payer's own words:

```
(paid Constable Gideon Marsh 1 coin for Day's rate on the James Farm)
```

`payload.for` is model-authored, and a payment with a stated purpose and no delivery against it is indistinguishable from an order placed and never filled. The block sits under a directive telling the model the ledger is authoritative and complete, so the misreading arrived with full confidence.

Nine of those lines consolidated into Moses James's character document as *"Constable Marsh takes my coin for a 'day's rate' but never delivers ... the ledger shows I pay him and get nothing"*, which regenerated the dispute daily regardless of who was present. The constable refunded eight coins of collected rate against it.

LLM-572 fixed this for the engine's own relationship fact. It did not fix this path — and this is the path that writes the character document.

## The change

- `narrateEvent` renders a payment carrying `rate_settled` as the due it was, dropping the payer's words. Presence of the key is the classification, so every purchase and every row written before the stamp narrates byte-identically. Tested against `0`, `null`, and a non-numeric value.
- The ledger-precedence directive gains the general rule. Every ledger line names one movement and a return is simply another line, so any one-way transfer looks like a debt outstanding. Gifts and wages carry no engine marker, and the same character document held the same shape about a gift of flour to a different neighbour.

203 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)