### PR TITLE
LLM-584: an explicit 0 in config means 0, not the default

### DIFF
--- a/node/api/src/services/cleanup.js
+++ b/node/api/src/services/cleanup.js
@@ -10,6 +10,7 @@
 
 const pool = require('../db');
 const config = require('./config');
+const { parseNonNegativeFinite } = config;
 const { log, logError } = require('./logger');
 
 function logCleanup(action, details) {
@@ -30,17 +31,23 @@ function buildDecayConditions(threshold) {
 
     // Kind-based half-lives
     const kindHalfLives = {
-        task: parseFloat(config.get('search_decay_halflife_task')) || 0,
-        learning: parseFloat(config.get('search_decay_halflife_learning')) || 0,
-        note: parseFloat(config.get('search_decay_halflife_note')) || 0,
-        conversation: parseFloat(config.get('search_decay_halflife_conversation')) || 0,
-        dream: parseFloat(config.get('search_decay_halflife_dream')) || 0,
+        task: parseNonNegativeFinite(config.get('search_decay_halflife_task')),
+        learning: parseNonNegativeFinite(config.get('search_decay_halflife_learning')),
+        note: parseNonNegativeFinite(config.get('search_decay_halflife_note')),
+        conversation: parseNonNegativeFinite(config.get('search_decay_halflife_conversation')),
+        dream: parseNonNegativeFinite(config.get('search_decay_halflife_dream')),
     };
 
-    // Cognitive type half-lives (override kind when set)
+    // Cognitive type half-lives (override kind when set).
+    //
+    // These two carry a non-zero fallback, so they must not be read through
+    // `|| 90`: both rows document "0 = no decay", and `||` would turn that 0
+    // back into 90/180 and let the `halfLife <= 0` skip below never fire. The
+    // note would keep decaying — and here that means the cron soft-deletes it —
+    // on a half-life the operator had switched off (LLM-584).
     const cognitiveHalfLives = {
-        episodic: parseFloat(config.get('search_decay_halflife_episodic')) || 90,
-        reflective: parseFloat(config.get('search_decay_halflife_reflective')) || 180,
+        episodic: parseNonNegativeFinite(config.get('search_decay_halflife_episodic'), 90),
+        reflective: parseNonNegativeFinite(config.get('search_decay_halflife_reflective'), 180),
     };
 
     // For each kind with a non-zero half-life, add a condition that matches
@@ -216,4 +223,4 @@ function startCleanupScheduler() {
     logCleanup('scheduler', { message: 'Cleanup scheduler started', schedule });
 }
 
-module.exports = { runDecayCleanup, purgeCallLogs, startCleanupScheduler };
+module.exports = { runDecayCleanup, purgeCallLogs, startCleanupScheduler, buildDecayConditions };

--- a/node/api/src/services/cleanup.js
+++ b/node/api/src/services/cleanup.js
@@ -17,6 +17,27 @@ function logCleanup(action, details) {
     log('cleanup', action, details);
 }
 
+// Read one decay half-life, resolving absent/blank/unparseable to the fallback
+// and an explicit 0 to 0 (see config.parseNonNegativeFinite).
+//
+// The extra negative check is specific to cleanup. parseNonNegativeFinite
+// resolves a negative to the fallback, which is right for search ranking in
+// memory.js — a nonsense value there costs nothing but a ranking weight. Here
+// it would be fail-open: this cron soft-deletes the note AND hard-deletes its
+// vector chunks, so a restored note comes back unsearchable. A typo like "-90"
+// must not turn "no cleanup for this category" into "delete at the default
+// rate". Present-but-invalid disables the rule instead.
+//
+// The consequence is that ranking and cleanup can disagree for a negative
+// value. That is deliberate, and is not the defect LLM-584 fixes: 0 is
+// documented and must mean the same thing everywhere, a negative is undocumented
+// garbage and the destructive path is entitled to be the conservative reader.
+function decayHalfLife(key, fallback = 0) {
+    const raw = config.get(key);
+    if (Number(raw) < 0) return 0;
+    return parseNonNegativeFinite(raw, fallback);
+}
+
 // Build SQL conditions that identify notes below the decay threshold.
 // Returns { conditions, params } where conditions is an array of
 // "kind = X AND decay < threshold" clauses, and params are the bound values.
@@ -31,11 +52,11 @@ function buildDecayConditions(threshold) {
 
     // Kind-based half-lives
     const kindHalfLives = {
-        task: parseNonNegativeFinite(config.get('search_decay_halflife_task')),
-        learning: parseNonNegativeFinite(config.get('search_decay_halflife_learning')),
-        note: parseNonNegativeFinite(config.get('search_decay_halflife_note')),
-        conversation: parseNonNegativeFinite(config.get('search_decay_halflife_conversation')),
-        dream: parseNonNegativeFinite(config.get('search_decay_halflife_dream')),
+        task: decayHalfLife('search_decay_halflife_task'),
+        learning: decayHalfLife('search_decay_halflife_learning'),
+        note: decayHalfLife('search_decay_halflife_note'),
+        conversation: decayHalfLife('search_decay_halflife_conversation'),
+        dream: decayHalfLife('search_decay_halflife_dream'),
     };
 
     // Cognitive type half-lives (override kind when set).
@@ -43,11 +64,11 @@ function buildDecayConditions(threshold) {
     // These two carry a non-zero fallback, so they must not be read through
     // `|| 90`: both rows document "0 = no decay", and `||` would turn that 0
     // back into 90/180 and let the `halfLife <= 0` skip below never fire. The
-    // note would keep decaying — and here that means the cron soft-deletes it —
-    // on a half-life the operator had switched off (LLM-584).
+    // note would keep decaying — and here that means the cron deletes it — on a
+    // half-life the operator had switched off (LLM-584).
     const cognitiveHalfLives = {
-        episodic: parseNonNegativeFinite(config.get('search_decay_halflife_episodic'), 90),
-        reflective: parseNonNegativeFinite(config.get('search_decay_halflife_reflective'), 180),
+        episodic: decayHalfLife('search_decay_halflife_episodic', 90),
+        reflective: decayHalfLife('search_decay_halflife_reflective', 180),
     };
 
     // For each kind with a non-zero half-life, add a condition that matches

--- a/node/api/src/services/cleanup.js
+++ b/node/api/src/services/cleanup.js
@@ -17,8 +17,10 @@ function logCleanup(action, details) {
     log('cleanup', action, details);
 }
 
-// Read one decay half-life, resolving absent/blank/unparseable to the fallback
-// and an explicit 0 to 0 (see config.parseNonNegativeFinite).
+// Read one decay half-life: absent, blank and unparseable resolve to the
+// fallback, an explicit 0 stays 0, and a negative disables the rule (see
+// config.parseNonNegativeFinite for the first two, and below for the third —
+// the negative is this function's one departure from the shared parser).
 //
 // The extra negative check is specific to cleanup. parseNonNegativeFinite
 // resolves a negative to the fallback, which is right for search ranking in

--- a/node/api/src/services/cleanup.test.js
+++ b/node/api/src/services/cleanup.test.js
@@ -1,0 +1,141 @@
+// Tests for buildDecayConditions — the half-life reader behind the nightly
+// decay cleanup. Run with: node --test (from node/api). Uses the built-in
+// node:test runner + node:assert, matching dream.test.js.
+//
+// These are pure-function tests: config.set writes the in-memory cache
+// directly, and buildDecayConditions only assembles SQL text, so no database
+// is involved.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildDecayConditions } = require('./cleanup');
+const config = require('./config');
+
+const HALF_LIFE_KEYS = [
+    'search_decay_halflife_task',
+    'search_decay_halflife_learning',
+    'search_decay_halflife_note',
+    'search_decay_halflife_conversation',
+    'search_decay_halflife_dream',
+    'search_decay_halflife_episodic',
+    'search_decay_halflife_reflective',
+];
+
+// Every test starts from "nothing decays" so each one only has to set the keys
+// it is actually about, and an unset key can never leak in from a prior test.
+function silenceAllHalfLives() {
+    for (const key of HALF_LIFE_KEYS) {
+        config.set(key, '0');
+    }
+}
+
+// The conditions are raw SQL strings; a type is present when some condition
+// mentions it. Kind conditions read `d.kind = 'note'`, cognitive ones read
+// `cognitive_type') = 'episodic'`.
+function mentions(conditions, needle) {
+    return conditions.some((c) => c.includes(needle));
+}
+
+test('a half-life of 0 produces no decay condition for that type', () => {
+    silenceAllHalfLives();
+    const { conditions } = buildDecayConditions(0.05);
+    assert.deepEqual(conditions, []);
+});
+
+test('an explicit 0 disables decay for a cognitive type that has a non-zero default (LLM-584)', () => {
+    // The defect this covers: episodic and reflective were read as
+    // `parseFloat(x) || 90` / `|| 180`, so the 0 their own config rows document
+    // as "0 = no decay" was falsy and became 90/180 again. The `halfLife <= 0`
+    // skip never fired, and runDecayCleanup soft-deletes what these conditions
+    // match — so the note kept decaying, and being deleted, on a half-life the
+    // operator had switched off.
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_episodic', '0');
+    config.set('search_decay_halflife_reflective', '0');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.deepEqual(conditions, []);
+    // Only the threshold is bound — no half-life was pushed.
+    assert.deepEqual(params, [0.05]);
+});
+
+test('silencing one cognitive type leaves the other intact', () => {
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_episodic', '0');
+    config.set('search_decay_halflife_reflective', '180');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.equal(conditions.length, 1);
+    assert.ok(mentions(conditions, "= 'reflective'"));
+    assert.ok(!mentions(conditions, "= 'episodic'"));
+    assert.deepEqual(params, [0.05, 180]);
+});
+
+test('a non-zero half-life still produces its condition, with the value bound', () => {
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_note', '45');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.equal(conditions.length, 1);
+    assert.ok(mentions(conditions, "d.kind = 'note'"));
+    assert.deepEqual(params, [0.05, 45]);
+});
+
+test('an absent, blank or unparseable half-life falls back rather than decaying', () => {
+    // Kind half-lives fall back to 0 (no decay); the two cognitive ones fall
+    // back to their documented defaults.
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_note', '');
+    config.set('search_decay_halflife_dream', 'soon');
+    config.set('search_decay_halflife_episodic', undefined);
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.equal(conditions.length, 1);
+    assert.ok(mentions(conditions, "= 'episodic'"));
+    assert.deepEqual(params, [0.05, 90]);
+});
+
+test('a negative half-life never reaches the SQL', () => {
+    // A negative half-life would invert the decay curve, so it must never be
+    // bound. It is invalid input rather than a request, so it takes the
+    // fallback — which means the outcome differs by key, and both are correct:
+    // a kind half-life falls back to 0 and decays nothing, while episodic and
+    // reflective fall back to their documented 90/180 and decay normally.
+    //
+    // That second case is a deliberate change of behaviour. The old `|| 180`
+    // kept the -1 (truthy) and let the `halfLife <= 0` skip swallow it, so a
+    // typo silently disabled cleanup for every reflective note while search
+    // ranking — already on parseNonNegativeFinite — went on applying 180. The
+    // two now agree, which is the point of the ticket.
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_note', '-45');
+    config.set('search_decay_halflife_reflective', '-1');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.equal(conditions.length, 1);
+    assert.ok(mentions(conditions, "= 'reflective'"));
+    assert.ok(!mentions(conditions, "d.kind = 'note'"));
+    assert.deepEqual(params, [0.05, 180]);
+});
+
+test('parameter placeholders stay aligned with the bound values', () => {
+    // The condition builder hands out $2, $3, ... as it walks the two maps.
+    // A drifting index would bind a half-life to the wrong condition and
+    // silently change which notes get deleted.
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_note', '45');
+    config.set('search_decay_halflife_dream', '30');
+    config.set('search_decay_halflife_episodic', '90');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.deepEqual(params, [0.05, 45, 30, 90]);
+    assert.ok(conditions.some((c) => c.includes("d.kind = 'note'") && c.includes('$2')));
+    assert.ok(conditions.some((c) => c.includes("d.kind = 'dream'") && c.includes('$3')));
+    assert.ok(conditions.some((c) => c.includes("= 'episodic'") && c.includes('$4')));
+});

--- a/node/api/src/services/cleanup.test.js
+++ b/node/api/src/services/cleanup.test.js
@@ -99,28 +99,41 @@ test('an absent, blank or unparseable half-life falls back rather than decaying'
     assert.deepEqual(params, [0.05, 90]);
 });
 
-test('a negative half-life never reaches the SQL', () => {
+test('a blank cognitive half-life falls back to its default, it does not disable decay', () => {
+    // Guards a trap in the parser: Number('') and Number('   ') are both 0, not
+    // NaN. Without an explicit blank check a blank row reads as an explicit
+    // zero, so on these two keys — the only ones with a non-zero fallback — a
+    // cleared value would silently mean "no decay" instead of 90/180. The
+    // preceding test cannot catch it: its blank key falls back to 0 anyway, so
+    // both readings give the same answer there.
+    silenceAllHalfLives();
+    config.set('search_decay_halflife_episodic', '');
+    config.set('search_decay_halflife_reflective', '   ');
+
+    const { conditions, params } = buildDecayConditions(0.05);
+
+    assert.equal(conditions.length, 2);
+    assert.ok(mentions(conditions, "= 'episodic'"));
+    assert.ok(mentions(conditions, "= 'reflective'"));
+    assert.deepEqual(params, [0.05, 90, 180]);
+});
+
+test('a negative half-life disables that rule, it never falls back to a deleting default', () => {
     // A negative half-life would invert the decay curve, so it must never be
-    // bound. It is invalid input rather than a request, so it takes the
-    // fallback — which means the outcome differs by key, and both are correct:
-    // a kind half-life falls back to 0 and decays nothing, while episodic and
-    // reflective fall back to their documented 90/180 and decay normally.
-    //
-    // That second case is a deliberate change of behaviour. The old `|| 180`
-    // kept the -1 (truthy) and let the `halfLife <= 0` skip swallow it, so a
-    // typo silently disabled cleanup for every reflective note while search
-    // ranking — already on parseNonNegativeFinite — went on applying 180. The
-    // two now agree, which is the point of the ticket.
+    // bound. It must also not resolve to the fallback: on episodic/reflective
+    // that fallback is 90/180, which would turn a typo into deletion at the
+    // default rate. This cron soft-deletes the note and hard-deletes its vector
+    // chunks, so that is not a recoverable mistake — invalid input disables the
+    // rule instead. See decayHalfLife's comment for why cleanup reads a
+    // negative differently from memory.js.
     silenceAllHalfLives();
     config.set('search_decay_halflife_note', '-45');
     config.set('search_decay_halflife_reflective', '-1');
 
     const { conditions, params } = buildDecayConditions(0.05);
 
-    assert.equal(conditions.length, 1);
-    assert.ok(mentions(conditions, "= 'reflective'"));
-    assert.ok(!mentions(conditions, "d.kind = 'note'"));
-    assert.deepEqual(params, [0.05, 180]);
+    assert.deepEqual(conditions, []);
+    assert.deepEqual(params, [0.05]);
 });
 
 test('parameter placeholders stay aligned with the bound values', () => {

--- a/node/api/src/services/config.js
+++ b/node/api/src/services/config.js
@@ -27,4 +27,17 @@ function set(key, value) {
     cache[key] = value;
 }
 
-module.exports = { init, get, set };
+// Parse a config value that must be a non-negative number, falling back when it
+// is absent, blank or unparseable.
+//
+// Use this instead of `parseFloat(value) || fallback` on any key whose
+// description gives 0 a meaning ("0 to disable", "0 = no decay"). `||` treats
+// the parsed 0 as absent and substitutes the fallback, so the documented
+// escape hatch silently does the opposite of what it says (LLM-584).
+function parseNonNegativeFinite(value, fallback = 0) {
+    const n = Number(value);
+    if (Number.isFinite(n) && n >= 0) return n;
+    return fallback;
+}
+
+module.exports = { init, get, set, parseNonNegativeFinite };

--- a/node/api/src/services/config.js
+++ b/node/api/src/services/config.js
@@ -34,7 +34,13 @@ function set(key, value) {
 // description gives 0 a meaning ("0 to disable", "0 = no decay"). `||` treats
 // the parsed 0 as absent and substitutes the fallback, so the documented
 // escape hatch silently does the opposite of what it says (LLM-584).
+// Blank is checked before conversion because Number('') and Number('   ') are
+// both 0, not NaN — so a blank row would otherwise read as an explicit zero and
+// silently mean "disable" on every key whose fallback is non-zero.
 function parseNonNegativeFinite(value, fallback = 0) {
+    if (value === null || value === undefined) return fallback;
+    if (typeof value === 'string' && value.trim() === '') return fallback;
+
     const n = Number(value);
     if (Number.isFinite(n) && n >= 0) return n;
     return fallback;

--- a/node/api/src/services/dream.js
+++ b/node/api/src/services/dream.js
@@ -26,16 +26,26 @@ const MAX_DREAM_DELAY_MS = 3600000;
 // becomes "no pause at all" and the run hammers the provider — the opposite of
 // what was asked, with nothing in the logs to say so.
 //
-// The `|| fallback` is carried over verbatim rather than tightened, so parsing
-// behaviour is unchanged: blank and non-numeric values take the default, a
-// negative value survives to be skipped by the caller's `> 0` guard, and a
-// fractional one truncates. (One consequence of `||` worth knowing: an explicit
-// 0 also takes the default, so the config rows' documented "0 to disable" does
-// not actually disable. Pre-existing, unrelated to the timer overflow, and both
-// rows are at their defaults in production — filed separately rather than
-// changed here.)
+// Parsing is integer-based and permissive: blank and non-numeric values take the
+// default, a fractional value truncates, and a negative one survives to be
+// skipped by the caller's `> 0` guard.
+//
+// Only a genuinely unparseable value falls back. An explicit 0 is kept, because
+// both config rows document "0 to disable" (migrations MEM-092, MEM-118) and the
+// earlier `parseInt(x) || fallback` treated that 0 as falsy — so setting a row to
+// 0 handed back the DEFAULT delay and the documented escape hatch never worked
+// (LLM-584). The callers' `> 0` guards already implement the disable path; only
+// the parse was swallowing the 0 before they could see it.
+//
+// This is the reason config.parseNonNegativeFinite is not used here: it parses
+// with Number rather than parseInt, which would keep fractions instead of
+// truncating them and would reject negatives instead of passing them through.
 function dreamDelayMs(key, fallback) {
-    return Math.min(parseInt(config.get(key)) || fallback, MAX_DREAM_DELAY_MS);
+    let configured = parseInt(config.get(key));
+    if (Number.isNaN(configured)) {
+        configured = fallback;
+    }
+    return Math.min(configured, MAX_DREAM_DELAY_MS);
 }
 
 // validatePersonSlug — defense for runPersonContextUpdate now that it's

--- a/node/api/src/services/dream.test.js
+++ b/node/api/src/services/dream.test.js
@@ -735,14 +735,15 @@ test('dreamDelayMs leaves ordinary and negative values to the caller unchanged',
     assert.equal(dreamDelayMs('dream_test_delay', 2000), -5);
 });
 
-// KNOWN DEFECT, pinned deliberately — see LLM-584. This asserts behaviour that is
-// WRONG, not behaviour we want. Both config rows document "0 to disable"
-// (migrations MEM-092, MEM-118) but `parseInt(x) || fallback` treats the parsed 0
-// as falsy, so setting the row to 0 yields the DEFAULT delay instead of none.
-// LLM-583 carried the `||` over verbatim so a security fix would not also change
-// runtime behaviour; the pin exists so LLM-584's fix has to delete this test
-// rather than silently flip an assertion. Delete it when LLM-584 lands.
-test('dreamDelayMs: an explicit 0 wrongly takes the default (LLM-584, pinning a known defect)', () => {
+// The defect this replaces: `parseInt(x) || fallback` treated the parsed 0 as
+// falsy, so a row set to 0 handed back the DEFAULT delay. Both rows document
+// "0 to disable" (migrations MEM-092, MEM-118), so the documented escape hatch
+// did the opposite of what it said. The callers' `> 0` guards were always right;
+// the parse never let a 0 reach them.
+test('dreamDelayMs: an explicit 0 disables the delay (LLM-584)', () => {
     config.set('dream_test_delay', '0');
-    assert.equal(dreamDelayMs('dream_test_delay', 2000), 2000);
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 0);
+    // "0" with surrounding whitespace is still an explicit zero, not a blank row.
+    config.set('dream_test_delay', ' 0 ');
+    assert.equal(dreamDelayMs('dream_test_delay', 2000), 0);
 });

--- a/node/api/src/services/memory.js
+++ b/node/api/src/services/memory.js
@@ -6,13 +6,8 @@ const { embed } = require('./embeddings');
 const { chunkByHeading, chunkConversation } = require('./chunker');
 const pgvector = require('pgvector');
 const config = require('./config');
+const { parseNonNegativeFinite } = config;
 const { handleError } = require('./error-handler');
-
-function parseNonNegativeFinite(value, fallback = 0) {
-    const n = Number(value);
-    if (Number.isFinite(n) && n >= 0) return n;
-    return fallback;
-}
 
 // Query preprocessing: strip filler words/phrases before embedding.
 // "can you tell me about how the auth middleware works" → "auth middleware works"


### PR DESCRIPTION
Two config reads used `parse*(config.get(key)) || fallback`, which treats a parsed 0 as absent. Both sets of rows document 0 as a meaningful setting in their own descriptions, so the documented escape hatch did the opposite of what it said.

The ticket was filed for the dream delays only. Its last line asked for a sweep of the same idiom; the sweep found a second instance, and Jeff approved widening this ticket rather than filing another.

## The dream delays — the originally filed defect

`dream_interagent_delay` and `dream_interchunk_delay` both document "0 to disable" (MEM-092, MEM-118). Setting either to 0 handed back the DEFAULT delay. The three call sites each guard with `if (delay > 0)`, so the disable path was always implemented correctly — only the parse swallowed the 0 before the guard could see it.

Fixed inline. `parseNonNegativeFinite` is deliberately not used here: it parses with `Number` rather than `parseInt`, so it would keep fractions instead of truncating them and reject negatives instead of passing them through to the caller's guard. Both are current behaviour this ticket should not change.

## The decay half-lives — found by the sweep, and the half that deletes data

`search_decay_halflife_episodic` and `search_decay_halflife_reflective` both document "0 = no decay" and were read as `|| 90` / `|| 180`, so the `halfLife <= 0` skip never fired.

`buildDecayConditions` feeds `runDecayCleanup`, which soft-deletes the note and hard-deletes its vector chunks. `memory.js` already read the same two keys through `parseNonNegativeFinite` and honoured an explicit 0, so search ranking and the cleanup cron disagreed about what the same key meant — while a comment in `cleanup.js` claimed it "mirrors the two-tier decay logic in memory.js".

## Also fixed: blank read as an explicit zero

`Number('')` and `Number('   ')` are 0, not NaN, so the shared parser resolved a blank value to 0 instead of the fallback. On the two keys with a non-zero fallback, a cleared row would have meant "no decay" rather than 90/180.

This was pre-existing in the helper rather than introduced by the move, so it also corrects search ranking in `memory.js`, which has read these keys through it all along.

## Deliberate decisions

**`parseNonNegativeFinite` moved from `memory.js` to `config.js`.** A config-value parser belongs with config, and it lets `cleanup.js` reuse it without requiring `memory.js` and its embeddings/pgvector/chunker graph. No circular import: `memory.js` does not require `cleanup.js`, and only `server.js` requires `cleanup.js`.

**The kind half-lives converted too**, though their `|| 0` was harmless — `0 || 0` is 0. Two idioms side by side in one function invite the bug back, and this makes the "mirrors memory.js" comment true.

**A negative disables the rule in cleanup rather than falling back.** This is cleanup's one departure from the shared parser, via a local `decayHalfLife`. Falling back would be fail-open on a path that hard-deletes vector chunks: a typo like "-90" would turn "no cleanup for this category" into "delete at the default rate", and the restored note would come back unsearchable. Ranking and cleanup can therefore disagree for a negative. That is deliberate — 0 is documented and must mean the same thing everywhere, which is this ticket's defect; a negative is undocumented garbage, and the deleting path is entitled to be the conservative reader.

Not taken: rejecting invalid values in a config-validation layer. It is the better long-term answer, but no such layer exists today and building one is a separate ticket. code_review agreed it should not hold this change.

## Risk

Nothing live changes on deploy. Both rows in each pair still hold their non-zero defaults in production (2000/1000 and 90/180), and no config row has a blank or NULL numeric value. All three fixes are dormant until an operator sets a 0, clears a row, or makes a typo.

## Sweep result

Every config row whose description gives 0 a special meaning was checked against its read site. Only the four above were broken. `dream_backload_count`, `dream_soul_min_chars` and `search_decay_halflife_dream` all fall back to a literal 0, where `0 || 0` is harmless — left alone.

## Tests

211 pass, 0 fail (`node --test` from `node/api`).

New `cleanup.test.js` covers `buildDecayConditions`, newly exported as a test seam: an explicit 0 disables per type, a blank cognitive value falls back to 90/180 rather than disabling, a negative never reaches SQL, and the `$n` placeholders stay aligned with their bound values. The `dream.test.js` test that pinned the defect deliberately is inverted.

Reviewed by code_review over two rounds; both blocking findings (the blank parse, and the negative fail-open) came from there and are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
